### PR TITLE
Refactored findWhere and filterWhere to use wrapped nodes in predicate

### DIFF
--- a/docs/api/ShallowWrapper/filterWhere.md
+++ b/docs/api/ShallowWrapper/filterWhere.md
@@ -6,7 +6,7 @@ provided predicate function, return true.
 
 #### Arguments
 
-1. `predicate` (`ReactElement => Boolean`): A predicate function to match the nodes.
+1. `predicate` (`ShallowWrapper => Boolean`): A predicate function that is passed a wrapped node.
 
 
 
@@ -20,7 +20,7 @@ provided predicate function, return true.
 
 ```jsx
 const wrapper = shallow(<MyComponent />);
-const complexFoo = wrapper.find('.foo').filterWhere(n => typeof n.type !== 'string');
+const complexFoo = wrapper.find('.foo').filterWhere(n => typeof n.type() !== 'string');
 expect(complexComponents).to.have.length(4);
 ```
 

--- a/docs/api/ShallowWrapper/findWhere.md
+++ b/docs/api/ShallowWrapper/findWhere.md
@@ -5,7 +5,8 @@ Finds every node in the render tree that return true for the provided predicate 
 
 #### Arguments
 
-1. `predicate` (`ReactElement => Boolean`): A predicate function to match
+1. `predicate` (`ShallowWrapper => Boolean`): A predicate function called with the passed in wrapped
+nodes.
 
 
 
@@ -19,7 +20,7 @@ Finds every node in the render tree that return true for the provided predicate 
 
 ```jsx
 const wrapper = shallow(<MyComponent />);
-const complexComponents = wrapper.findWhere(n => typeof n.type !== 'string');
+const complexComponents = wrapper.findWhere(n => typeof n.type() !== 'string');
 expect(complexComponents).to.have.length(8);
 ```
 

--- a/src/ReactWrapper.js
+++ b/src/ReactWrapper.js
@@ -17,6 +17,30 @@ import {
 } from './react-compat';
 
 /**
+ * Finds all nodes in the current wrapper nodes' render trees that match the provided predicate
+ * function.
+ *
+ * @param {ReactWrapper} wrapper
+ * @param {Function} predicate
+ * @returns {ReactWrapper}
+ */
+function findWhereUnwrapped(wrapper, predicate) {
+  return wrapper.flatMap(n => treeFilter(n.node, predicate));
+}
+
+/**
+ * Returns a new wrapper instance with only the nodes of the current wrapper instance that match
+ * the provided predicate function.
+ *
+ * @param {ReactWrapper} wrapper
+ * @param {Function} predicate
+ * @returns {ReactWrapper}
+ */
+function filterWhereUnwrapped(wrapper, predicate) {
+  return wrapper.wrap(compact(wrapper.nodes.filter(predicate)));
+}
+
+/**
  * @class ReactWrapper
  */
 export default class ReactWrapper {
@@ -161,7 +185,7 @@ export default class ReactWrapper {
    * @returns {Boolean}
    */
   contains(node) {
-    return this.findWhere(other => instEqual(node, other)).length > 0;
+    return findWhereUnwrapped(this, other => instEqual(node, other)).length > 0;
   }
 
   /**
@@ -172,7 +196,7 @@ export default class ReactWrapper {
    */
   find(selector) {
     const predicate = buildInstPredicate(selector);
-    return this.findWhere(predicate);
+    return findWhereUnwrapped(this, predicate);
   }
 
   /**
@@ -196,7 +220,7 @@ export default class ReactWrapper {
    * @returns {ReactWrapper}
    */
   filterWhere(predicate) {
-    return this.wrap(compact(this.nodes.filter(predicate)));
+    return filterWhereUnwrapped(this, n => predicate(this.wrap(n)));
   }
 
   /**
@@ -208,7 +232,7 @@ export default class ReactWrapper {
    */
   filter(selector) {
     const predicate = buildInstPredicate(selector);
-    return this.filterWhere(predicate);
+    return filterWhereUnwrapped(this, predicate);
   }
 
   /**
@@ -220,7 +244,7 @@ export default class ReactWrapper {
    */
   not(selector) {
     const predicate = buildInstPredicate(selector);
-    return this.filterWhere(n => !predicate(n));
+    return filterWhereUnwrapped(this, n => !predicate(n));
   }
 
   /**
@@ -479,7 +503,7 @@ export default class ReactWrapper {
    * @returns {ReactWrapper}
    */
   findWhere(predicate) {
-    return this.flatMap(n => treeFilter(n.node, predicate));
+    return findWhereUnwrapped(this, n => predicate(this.wrap(n)));
   }
 
   /**

--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -24,6 +24,30 @@ import {
 } from './react-compat';
 
 /**
+ * Finds all nodes in the current wrapper nodes' render trees that match the provided predicate
+ * function.
+ *
+ * @param {ShallowWrapper} wrapper
+ * @param {Function} predicate
+ * @returns {ShallowWrapper}
+ */
+function findWhereUnwrapped(wrapper, predicate) {
+  return wrapper.flatMap(n => treeFilter(n.node, predicate));
+}
+
+/**
+ * Returns a new wrapper instance with only the nodes of the current wrapper instance that match
+ * the provided predicate function.
+ *
+ * @param {ShallowWrapper} wrapper
+ * @param {Function} predicate
+ * @returns {ShallowWrapper}
+ */
+function filterWhereUnwrapped(wrapper, predicate) {
+  return wrapper.wrap(compact(wrapper.nodes.filter(predicate)));
+}
+
+/**
  * @class ShallowWrapper
  */
 export default class ShallowWrapper {
@@ -152,7 +176,7 @@ export default class ShallowWrapper {
    * @returns {Boolean}
    */
   contains(node) {
-    return this.findWhere(other => nodeEqual(node, other)).length > 0;
+    return findWhereUnwrapped(this, other => nodeEqual(node, other)).length > 0;
   }
 
   /**
@@ -163,7 +187,7 @@ export default class ShallowWrapper {
    */
   find(selector) {
     const predicate = buildPredicate(selector);
-    return this.findWhere(predicate);
+    return findWhereUnwrapped(this, predicate);
   }
 
   /**
@@ -181,13 +205,14 @@ export default class ShallowWrapper {
 
   /**
    * Returns a new wrapper instance with only the nodes of the current wrapper instance that match
-   * the provided predicate function.
+   * the provided predicate function. The predicate should receive a wrapped node as its first
+   * argument.
    *
    * @param {Function} predicate
    * @returns {ShallowWrapper}
    */
   filterWhere(predicate) {
-    return this.wrap(compact(this.nodes.filter(predicate)));
+    return filterWhereUnwrapped(this, n => predicate(this.wrap(n)));
   }
 
   /**
@@ -199,7 +224,7 @@ export default class ShallowWrapper {
    */
   filter(selector) {
     const predicate = buildPredicate(selector);
-    return this.filterWhere(predicate);
+    return filterWhereUnwrapped(this, predicate);
   }
 
   /**
@@ -211,7 +236,7 @@ export default class ShallowWrapper {
    */
   not(selector) {
     const predicate = buildPredicate(selector);
-    return this.filterWhere(n => !predicate(n));
+    return filterWhereUnwrapped(this, n => !predicate(n));
   }
 
   /**
@@ -505,13 +530,14 @@ export default class ShallowWrapper {
 
   /**
    * Finds all nodes in the current wrapper nodes' render trees that match the provided predicate
-   * function.
+   * function. The predicate function will receive the nodes inside a ShallowWrapper as its
+   * first argument.
    *
    * @param {Function} predicate
    * @returns {ShallowWrapper}
    */
   findWhere(predicate) {
-    return this.flatMap(n => treeFilter(n.node, predicate));
+    return findWhereUnwrapped(this, n => predicate(this.wrap(n)));
   }
 
   /**

--- a/src/__tests__/ReactWrapper-spec.js
+++ b/src/__tests__/ReactWrapper-spec.js
@@ -146,6 +146,29 @@ describeWithDOM('mount', () => {
       expect(wrapper.findWhere(() => false).length).to.equal(0);
     });
 
+    it('should call the predicate with the wrapped node as the first argument', () => {
+      const wrapper = mount(
+        <div>
+          <div className="foo bar" />
+          <div className="foo baz" />
+          <div className="foo bux" />
+        </div>
+      );
+
+      const stub = sinon.stub();
+      stub.returns(true);
+      const spy = sinon.spy(stub);
+      wrapper.findWhere(spy);
+      expect(spy.callCount).to.equal(4);
+      expect(spy.args[0][0]).to.be.instanceOf(ReactWrapper);
+      expect(spy.args[1][0]).to.be.instanceOf(ReactWrapper);
+      expect(spy.args[2][0]).to.be.instanceOf(ReactWrapper);
+      expect(spy.args[3][0]).to.be.instanceOf(ReactWrapper);
+      expect(spy.args[1][0].hasClass('bar')).to.be.true;
+      expect(spy.args[2][0].hasClass('baz')).to.be.true;
+      expect(spy.args[3][0].hasClass('bux')).to.be.true;
+    });
+
   });
 
   describe('.setProps(newProps)', () => {
@@ -369,7 +392,7 @@ describeWithDOM('mount', () => {
       expect(baz.hasClass('baz')).to.be.true;
     });
 
-    it('should call the predicate with the node as the first argument', () => {
+    it('should call the predicate with the wrapper as the first argument', () => {
       const wrapper = mount(
         <div>
           <div className="foo bar" />
@@ -383,9 +406,12 @@ describeWithDOM('mount', () => {
       const spy = sinon.spy(stub);
       wrapper.find('.foo').filterWhere(spy);
       expect(spy.callCount).to.equal(3);
-      expect(spy.args[0][0]).to.equal(wrapper.find('.bar').node);
-      expect(spy.args[1][0]).to.equal(wrapper.find('.baz').node);
-      expect(spy.args[2][0]).to.equal(wrapper.find('.bux').node);
+      expect(spy.args[0][0]).to.be.instanceOf(ReactWrapper);
+      expect(spy.args[1][0]).to.be.instanceOf(ReactWrapper);
+      expect(spy.args[2][0]).to.be.instanceOf(ReactWrapper);
+      expect(spy.args[0][0].hasClass('bar')).to.be.true;
+      expect(spy.args[1][0].hasClass('baz')).to.be.true;
+      expect(spy.args[2][0].hasClass('bux')).to.be.true;
     });
   });
 

--- a/src/__tests__/ShallowWrapper-spec.js
+++ b/src/__tests__/ShallowWrapper-spec.js
@@ -142,6 +142,29 @@ describe('shallow', () => {
       expect(wrapper.findWhere(() => false).length).to.equal(0);
     });
 
+    it('should call the predicate with the wrapped node as the first argument', () => {
+      const wrapper = shallow(
+        <div>
+          <div className="foo bar" />
+          <div className="foo baz" />
+          <div className="foo bux" />
+        </div>
+      );
+
+      const stub = sinon.stub();
+      stub.returns(true);
+      const spy = sinon.spy(stub);
+      wrapper.findWhere(spy);
+      expect(spy.callCount).to.equal(4);
+      expect(spy.args[0][0]).to.be.instanceOf(ShallowWrapper);
+      expect(spy.args[1][0]).to.be.instanceOf(ShallowWrapper);
+      expect(spy.args[2][0]).to.be.instanceOf(ShallowWrapper);
+      expect(spy.args[3][0]).to.be.instanceOf(ShallowWrapper);
+      expect(spy.args[1][0].hasClass('bar')).to.be.true;
+      expect(spy.args[2][0].hasClass('baz')).to.be.true;
+      expect(spy.args[3][0].hasClass('bux')).to.be.true;
+    });
+
   });
 
   describe('.setProps(newProps)', () => {
@@ -348,7 +371,7 @@ describe('shallow', () => {
       expect(baz.hasClass('baz')).to.be.true;
     });
 
-    it('should call the predicate with the node as the first argument', () => {
+    it('should call the predicate with the wrapped node as the first argument', () => {
       const wrapper = shallow(
         <div>
           <div className="foo bar" />
@@ -362,9 +385,12 @@ describe('shallow', () => {
       const spy = sinon.spy(stub);
       wrapper.find('.foo').filterWhere(spy);
       expect(spy.callCount).to.equal(3);
-      expect(spy.args[0][0]).to.equal(wrapper.find('.bar').node);
-      expect(spy.args[1][0]).to.equal(wrapper.find('.baz').node);
-      expect(spy.args[2][0]).to.equal(wrapper.find('.bux').node);
+      expect(spy.args[0][0]).to.be.instanceOf(ShallowWrapper);
+      expect(spy.args[1][0]).to.be.instanceOf(ShallowWrapper);
+      expect(spy.args[2][0]).to.be.instanceOf(ShallowWrapper);
+      expect(spy.args[0][0].hasClass('bar')).to.be.true;
+      expect(spy.args[1][0].hasClass('baz')).to.be.true;
+      expect(spy.args[2][0].hasClass('bux')).to.be.true;
     });
   });
 


### PR DESCRIPTION
cc: @ljharb 

NOTE: this is a BREAKING change.

This changes the functionality of `.findWhere()` and `.filterWhere()` in both the ShallowWrapper and the ReactWrapper to expect a predicate function where the first argument is a wrapped node rather than a raw node. In practice this is much more useful.

Note that in the implementation, I am leaving the original `findWhere` on the prototype as `_findWhereUnwrapped` (and likewise for `filterWhere`) as other methods use these implementations internally, and to refactor them to use wrapped nodes rather than nodes seemed like it would be a big deoptimization.
