### PR TITLE
Fixed setState in React 0.13 in componentDidMount

### DIFF
--- a/src/__tests__/.eslintrc
+++ b/src/__tests__/.eslintrc
@@ -3,6 +3,7 @@
     "padded-blocks": 0,
     "no-unused-expressions": 0,
     "react/no-multi-comp": 0,
-    "react/prop-types": 0
+    "react/prop-types": 0,
+    "react/no-did-mount-set-state": 0,
   }
 }

--- a/src/__tests__/ReactWrapper-spec.js
+++ b/src/__tests__/ReactWrapper-spec.js
@@ -258,6 +258,25 @@ describeWithDOM('mount', () => {
       wrapper.setState({ id: 'bar' });
       expect(wrapper.find('.bar').length).to.equal(1);
     });
+
+    it('allows setState inside of componentDidMount', () => {
+      // NOTE: this test is a test to ensure that the following issue is
+      // fixed: https://github.com/airbnb/reagent/issues/27
+      class MySharona extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {mounted: false};
+        }
+        componentDidMount() {
+          this.setState({mounted: true});
+        }
+        render() {
+          return <div>{this.state.mounted ? 'a' : 'b'}</div>;
+        }
+      }
+      const wrapper = mount(<MySharona />);
+      expect(wrapper.find('div').text()).to.equal('a');
+    });
   });
 
   describe('.is(selector)', () => {

--- a/src/react-compat.js
+++ b/src/react-compat.js
@@ -11,6 +11,9 @@ if (REACT013) {
   TestUtils = require('react/addons').addons.TestUtils;
   createShallowRenderer = TestUtils.createRenderer;
   renderIntoDocument = TestUtils.renderIntoDocument;
+  // this fixes some issues in React 0.13 with setState and jsdom...
+  // see issue: https://github.com/airbnb/reagent/issues/27
+  require('react/lib/ExecutionEnvironment').canUseDOM = true;
 } else {
   renderToStaticMarkup = require('react-dom/server').renderToStaticMarkup;
   findDOMNode = require('react-dom').findDOMNode;


### PR DESCRIPTION
to: @iancmyers 
cc: @ljharb @goatslacker 

This PR fixes this issue: https://github.com/airbnb/reagent/issues/27

The issue is discussed in more detail here: http://stackoverflow.com/questions/26867535/calling-setstate-in-jsdom-based-tests-causing-cannot-render-markup-in-a-worker

The main problem is that react is required and statically sets a flag about whether or not things like `window` and `document` and `document.createElement`. Since at this point jsdom isn't necessarily loaded int the global, this means the flag is set to false. This manually sets the flag regardless of the presence of those things.
