### PR TITLE
Support for Stateless Components

### DIFF
--- a/src/ReactWrapper.js
+++ b/src/ReactWrapper.js
@@ -61,7 +61,7 @@ export default class ReactWrapper {
           />
       );
       this.root = this;
-      this.node = this.component.refs.component;
+      this.node = this.component.getWrappedComponent();
       this.nodes = [this.node];
       this.length = 1;
     } else {
@@ -108,7 +108,7 @@ export default class ReactWrapper {
    * @returns {ReactComponent}
    */
   instance() {
-    return this.component.refs.component;
+    return this.component.getInstance();
   }
 
   /**

--- a/src/ReactWrapperComponent.jsx
+++ b/src/ReactWrapperComponent.jsx
@@ -19,10 +19,30 @@ export default class ReactWrapperComponent extends React.Component {
     return new Promise(resolve => this.setState(newProps, resolve));
   }
 
+  getInstance() {
+    const component = this._reactInternalInstance._renderedComponent;
+    const inst = component.getPublicInstance();
+    if (inst === null) {
+      throw new Error(
+        `You cannot get an instance of a stateless component.`
+      );
+    }
+    return inst;
+  }
+
+  getWrappedComponent() {
+    const component = this._reactInternalInstance._renderedComponent;
+    const inst = component.getPublicInstance();
+    if (inst === null) {
+      return component;
+    }
+    return inst;
+  }
+
   render() {
     const { Component } = this.props;
     return (
-      <Component ref="component" {...this.state} />
+      <Component {...this.state} />
     );
   }
 }

--- a/src/__tests__/ReactWrapper-spec.js
+++ b/src/__tests__/ReactWrapper-spec.js
@@ -7,8 +7,25 @@ import {
   ReactWrapper,
   describeWithDOM,
 } from '../';
+import { describeIf } from './_helpers';
+import { REACT013 } from '../version';
 
 describeWithDOM('mount', () => {
+
+  describeIf(!REACT013, 'stateless components', () => {
+    it('works with stateless components', () => {
+      const Foo = ({ foo }) => (
+        <div>
+          <div className="bar">bar</div>
+          <div className="qoo">{foo}</div>
+        </div>
+      );
+      const wrapper = mount(<Foo foo="qux" />);
+      expect(wrapper.type()).to.equal(Foo);
+      expect(wrapper.find('.bar')).to.have.length(1);
+      expect(wrapper.find('.qoo').text()).to.equal('qux');
+    });
+  });
 
   describe('.contains(node)', () => {
 

--- a/src/__tests__/ShallowWrapper-spec.js
+++ b/src/__tests__/ShallowWrapper-spec.js
@@ -2,9 +2,25 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow, render, ShallowWrapper } from '../';
 import sinon from 'sinon';
-
+import { describeIf } from './_helpers';
+import { REACT013 } from '../version';
 
 describe('shallow', () => {
+
+  describeIf(!REACT013, 'stateless components', () => {
+    it('works with stateless components', () => {
+      const Foo = ({ foo }) => (
+        <div>
+          <div className="bar">bar</div>
+          <div className="qoo">{foo}</div>
+        </div>
+      );
+      const wrapper = shallow(<Foo foo="qux" />);
+      expect(wrapper.type()).to.equal('div');
+      expect(wrapper.find('.bar')).to.have.length(1);
+      expect(wrapper.find('.qoo').text()).to.equal('qux');
+    });
+  });
 
   describe('.contains(node)', () => {
 

--- a/src/__tests__/_helpers.js
+++ b/src/__tests__/_helpers.js
@@ -1,0 +1,11 @@
+/**
+ * Simple wrapper around mocha describe which allows a boolean to be passed in first which
+ * determines whether or not the test will be run
+ */
+export function describeIf(test, a, b) {
+  if (test) {
+    describe(a, b);
+  } else {
+    describe.skip(a, b);
+  }
+}


### PR DESCRIPTION
to: @ljharb @goatslacker 

Adds support for [stateless functional components](https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html#stateless-functional-components).

Brought up in https://github.com/airbnb/reagent/issues/45

Functional components cannot be a ref, and thus the "wrapper component" did not work with them.

Note that functional components are only available in react 0.14, so the tests for them are only run for react 0.14...