### PR TITLE
Fix reduceRight documentation

### DIFF
--- a/docs/api/ReactWrapper/reduceRight.md
+++ b/docs/api/ReactWrapper/reduceRight.md
@@ -41,7 +41,7 @@ class Foo extends React.Component {
 
 ```jsx
 const wrapper = mount(<Foo />);
-const total = wrapper.find(Bar).reduce((amount, n) => amount + n.prop('amount'));
+const total = wrapper.find(Bar).reduceRight((amount, n) => amount + n.prop('amount'));
 expect(total).to.equal(16);
 ```
 


### PR DESCRIPTION
Example contains `reduce` rather than `reduceRight`.