### PR TITLE
Fix typo on Shallow Rendering type() example

### DIFF
--- a/docs/api/ShallowWrapper/type.md
+++ b/docs/api/ShallowWrapper/type.md
@@ -16,7 +16,7 @@ Note: can only be called on a wrapper of a single node.
 
 ```jsx
 const wrapper = shallow(<div/>);
-expect(wrapper.ype()).to.equal('div');
+expect(wrapper.type()).to.equal('div');
 ```
 
 ```jsx


### PR DESCRIPTION
Just a small typo.