### PR TITLE
[bugfix] nodeHasId has issue with 0.14 in some cases

### DIFF
--- a/src/ShallowTraversal.js
+++ b/src/ShallowTraversal.js
@@ -63,8 +63,7 @@ export function parentsOfNode(node, root) {
 }
 
 export function nodeHasId(node, id) {
-  const maybeId = node && node._store && node._store.props && node._store.props.id;
-  return maybeId === id;
+  return propsOfNode(node).id === id;
 }
 
 export function nodeHasType(node, type) {

--- a/src/__tests__/ShallowWrapper-spec.js
+++ b/src/__tests__/ShallowWrapper-spec.js
@@ -87,6 +87,12 @@ describe('shallow', () => {
 
   describe('.find(selector)', () => {
 
+    it('should be able to match the root DOM element', () => {
+      const wrapper = shallow(<div id="ttt" className="ttt">hello</div>);
+      expect(wrapper.find('#ttt')).to.have.length(1);
+      expect(wrapper.find('.ttt')).to.have.length(1);
+    });
+
     it('should find an element based on a class name', () => {
       const wrapper = shallow(
         <div>


### PR DESCRIPTION
to: @ljharb @goatslacker 

The spec that was added in this PR would succeed in React 0.13 but fail in React 0.14 due to some changes in behavior from the two. This had been abstracted away for some selectors (like class name) through the correct `propsOfNode(node)` function, but the `nodeHasId` function was still prone to these issues. 

Thanks to @clouddra for pointing out.

Fixes https://github.com/airbnb/enzyme/issues/64