### PR TITLE
Support Property Selector

### DIFF
--- a/docs/api/ReactWrapper/find.md
+++ b/docs/api/ReactWrapper/find.md
@@ -28,6 +28,9 @@ expect(wrapper.find('div.some-class')).to.have.length(3);
 
 // CSS id selector
 expect(wrapper.find('#foo')).to.have.length(1);
+
+// property selector
+expect(wrapper.find('[htmlFor="checkbox"]')).to.have.length(1);
 ```
 
 Component Constructors:

--- a/docs/api/selector.md
+++ b/docs/api/selector.md
@@ -12,6 +12,24 @@ follows:
 - class syntax (`.foo`, `.foo-bar`, etc.)
 - tag syntax (`input`, `div`, `span`, etc.)
 - id syntax (`#foo`, `#foo-bar`, etc.)
+- prop syntax (`[htmlFor="foo"]`, `[bar]`, `[baz=1]`, etc.);
+
+**Note -- Prop selector**
+Strings, numeric literals and boolean property values are supported for prop syntax
+in combination of the expected string syntax. For example, the following
+is supported:
+
+```js
+const wrapper = mount(
+  <div>
+    <span foo={3} bar={false} title="baz" />
+  </div>
+)
+
+wrapper.find('[foo=3]')
+wrapper.find('[bar=false]')
+wrapper.find('[title="baz"]')
+```
 
 Further, enzyme supports combining any of those supported syntaxes together to uniquely identify a
 single node.  For instance:
@@ -19,6 +37,7 @@ single node.  For instance:
 ```css
 div.foo.bar
 input#input-name
+label[foo=true]
 ```
 
 Are all valid selectors in enzyme.  At this time, however, any contextual CSS selector syntax that

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -102,12 +102,12 @@ export function withSetStateAllowed(fn) {
 }
 
 export function splitSelector(selector) {
-  return selector.split(/(?=\.)/);
+  return selector.split(/(?=\.|\[.*\])/);
 }
 
 export function isSimpleSelector(selector) {
   // any of these characters pretty much guarantee it's a complex selector
-  return !/[~\s\[\]:>]/.test(selector);
+  return !/[~\s:>]/.test(selector);
 }
 
 export function selectorError(selector) {
@@ -116,8 +116,25 @@ export function selectorError(selector) {
   );
 }
 
-export const isCompoundSelector = /[a-z]\.[a-z]/i;
+export const isCompoundSelector = /([a-z]\.[a-z]|[a-z]\[.*\])/i;
 
+const isPropSelector = /^\[.*\]$/;
+
+export const SELECTOR = {
+  CLASS_TYPE: 0,
+  ID_TYPE: 1,
+  PROP_TYPE: 2,
+};
+
+export function selectorType(selector) {
+  if (selector[0] === '.') {
+    return SELECTOR.CLASS_TYPE;
+  } else if (selector[0] === '#') {
+    return SELECTOR.ID_TYPE;
+  } else if (isPropSelector.test(selector)) {
+    return SELECTOR.PROP_TYPE;
+  }
+}
 
 export function AND(fns) {
   return x => {
@@ -127,4 +144,27 @@ export function AND(fns) {
     }
     return true;
   };
+}
+
+export function coercePropValue(propValue) {
+  // can be undefined
+  if (propValue === undefined) {
+    return propValue;
+  }
+
+  // if propValue includes quotes, it should be
+  // treated as a string
+  if (propValue.search(/"/) !== -1) {
+    return propValue.replace(/"/g, '');
+  }
+
+  const numericPropValue = parseInt(propValue, 10);
+
+  // if parseInt is not NaN, then we've wanted a number
+  if (!isNaN(numericPropValue)) {
+    return numericPropValue;
+  }
+
+  // coerce to boolean
+  return propValue === 'true' ? true : false;
 }

--- a/src/__tests__/ReactWrapper-spec.js
+++ b/src/__tests__/ReactWrapper-spec.js
@@ -122,6 +122,100 @@ describeWithDOM('mount', () => {
       expect(wrapper.find(Foo).type()).to.equal(Foo);
     });
 
+    it('should find component based on a react prop', () => {
+      const wrapper = mount(
+        <div>
+          <span htmlFor="foo" />
+        </div>
+      );
+
+      expect(wrapper.find('[htmlFor="foo"]')).to.have.length(1);
+      expect(wrapper.find('[htmlFor]')).to.have.length(1);
+    });
+
+    it('should compound tag and prop selector', () => {
+      const wrapper = mount(
+        <div>
+          <span htmlFor="foo" />
+        </div>
+      );
+
+      expect(wrapper.find('span[htmlFor="foo"]')).to.have.length(1);
+      expect(wrapper.find('span[htmlFor]')).to.have.length(1);
+
+    });
+
+    it('should support data prop selectors', () => {
+      const wrapper = mount(
+        <div>
+          <span data-foo="bar" />
+        </div>
+      );
+
+      expect(wrapper.find('[data-foo="bar"]')).to.have.length(1);
+      expect(wrapper.find('[data-foo]')).to.have.length(1);
+    });
+
+    it('should find components with multiple matching props', () => {
+      const onChange = () => {};
+      const wrapper = mount(
+        <div>
+          <span htmlFor="foo" onChange={onChange} preserveAspectRatio="xMaxYMax" />
+        </div>
+      );
+
+      expect(wrapper.find('span[htmlFor="foo"][onChange]')).to.have.length(1);
+      expect(wrapper.find('span[htmlFor="foo"][preserveAspectRatio="xMaxYMax"]')).to.have.length(1);
+    });
+
+
+    it('should not find property when undefined', () => {
+      const wrapper = mount(
+        <div>
+          <span data-foo={undefined} />
+        </div>
+      );
+
+      expect(wrapper.find('[data-foo]')).to.have.length(0);
+    });
+
+    it('should support boolean and numeric values for matching props', () => {
+      const wrapper = mount(
+        <div>
+          <span value={1} />
+          <a value={false} />
+        </div>
+      );
+
+      expect(wrapper.find('span[value=1]')).to.have.length(1);
+      expect(wrapper.find('span[value=2]')).to.have.length(0);
+      expect(wrapper.find('a[value=false]')).to.have.length(1);
+      expect(wrapper.find('a[value=true]')).to.have.length(0);
+    });
+
+    it('should not find key or ref via property selector', () => {
+      class Foo extends React.Component {
+        render() {
+          const arrayOfComponents = [<div key="1" />, <div key="2" />];
+
+          return (
+            <div>
+              <div ref="foo" />
+              {arrayOfComponents}
+            </div>
+          );
+        }
+      }
+
+      const wrapper = mount(<Foo />);
+
+      expect(wrapper.find('div[ref="foo"]')).to.have.length(0);
+      expect(wrapper.find('div[key="1"]')).to.have.length(0);
+      expect(wrapper.find('[ref]')).to.have.length(0);
+      expect(wrapper.find('[key]')).to.have.length(0);
+    });
+
+
     it('should find multiple elements based on a class name', () => {
       const wrapper = mount(
         <div>

--- a/src/__tests__/ShallowTraversal-spec.js
+++ b/src/__tests__/ShallowTraversal-spec.js
@@ -6,6 +6,7 @@ import {
 } from '../Utils';
 import {
   hasClassName,
+  nodeHasProperty,
   treeForEach,
   treeFilter,
 } from '../ShallowTraversal';
@@ -23,6 +24,13 @@ describe('ShallowTraversal', () => {
       expect(fn('input.bar')).to.eql(['input', '.bar']);
       expect(fn('div.bar.baz')).to.eql(['div', '.bar', '.baz']);
       expect(fn('Foo.bar')).to.eql(['Foo', '.bar']);
+    });
+
+    it('splits tag names and attributes', () => {
+      expect(fn('input[type="text"]')).to.eql(['input', '[type="text"]']);
+      expect(
+        fn('div[title="title"][data-value="foo"]')
+      ).to.eql(['div', '[title="title"]', '[data-value="foo"]']);
     });
   });
 
@@ -45,6 +53,30 @@ describe('ShallowTraversal', () => {
     it('should also allow hyphens', () => {
       const node = (<div className="foo-bar"/>);
       expect(hasClassName(node, 'foo-bar')).to.equal(true);
+    });
+
+  });
+
+  describe('nodeHasProperty', () => {
+
+    it('should find properties', () => {
+      function noop() {}
+      const node = (<div onChange={noop} title="foo" />);
+
+      expect(nodeHasProperty(node, 'onChange')).to.equal(true);
+      expect(nodeHasProperty(node, 'title', 'foo')).to.equal(true);
+    });
+
+    it('should not match on html attributes', () => {
+      const node = (<div htmlFor="foo" />);
+
+      expect(nodeHasProperty(node, 'for', 'foo')).to.equal(false);
+    });
+
+    it('should not find undefined properties', () => {
+      const node = (<div title={undefined} />);
+
+      expect(nodeHasProperty(node, 'title')).to.equal(false);
     });
 
   });

--- a/src/__tests__/ShallowWrapper-spec.js
+++ b/src/__tests__/ShallowWrapper-spec.js
@@ -158,6 +158,81 @@ describe('shallow', () => {
       expect(wrapper.find('button').length).to.equal(1);
     });
 
+    it('should find component based on a react prop', () => {
+      const wrapper = shallow(
+        <div>
+          <span title="foo" />
+        </div>
+      );
+
+      expect(wrapper.find('[title="foo"]')).to.have.length(1);
+      expect(wrapper.find('[title]')).to.have.length(1);
+    });
+
+    it('should compound tag and prop selector', () => {
+      const wrapper = shallow(
+        <div>
+          <span preserveAspectRatio="xMaxYMax"/>
+        </div>
+      );
+
+      expect(wrapper.find('span[preserveAspectRatio="xMaxYMax"]')).to.have.length(1);
+      expect(wrapper.find('span[preserveAspectRatio]')).to.have.length(1);
+    });
+
+    it('should support data prop selectors', () => {
+      const wrapper = shallow(
+        <div>
+          <span data-foo="bar" />
+        </div>
+      );
+
+      expect(wrapper.find('[data-foo="bar"]')).to.have.length(1);
+      expect(wrapper.find('[data-foo]')).to.have.length(1);
+    });
+
+    it('should find components with multiple matching react props', () => {
+      function noop() {}
+      const wrapper = shallow(
+        <div>
+          <span htmlFor="foo" onChange={noop} preserveAspectRatio="xMaxYMax" />
+        </div>
+      );
+
+      expect(wrapper.find('span[htmlFor="foo"][onChange]')).to.have.length(1);
+      expect(wrapper.find('span[htmlFor="foo"][preserveAspectRatio="xMaxYMax"]')).to.have.length(1);
+      expect(wrapper.find('[htmlFor][preserveAspectRatio]')).to.have.length(1);
+    });
+
+    it('should support boolean and numeric values for matching props', () => {
+      const wrapper = shallow(
+        <div>
+          <span value={1} />
+          <a value={false} />
+        </div>
+      );
+
+      expect(wrapper.find('span[value=1]')).to.have.length(1);
+      expect(wrapper.find('span[value=2]')).to.have.length(0);
+      expect(wrapper.find('a[value=false]')).to.have.length(1);
+      expect(wrapper.find('a[value=true]')).to.have.length(0);
+    });
+
+    it('should not find key or ref via property selector', () => {
+      const arrayOfComponents = [<div key="1" />, <div key="2" />];
+      const wrapper = shallow(
+        <div>
+          <div ref="foo" />
+          {arrayOfComponents}
+        </div>
+      );
+
+      expect(wrapper.find('div[ref="foo"]')).to.have.length(0);
+      expect(wrapper.find('div[key="1"]')).to.have.length(0);
+      expect(wrapper.find('[ref]')).to.have.length(0);
+      expect(wrapper.find('[key]')).to.have.length(0);
+    });
+
     it('should find multiple elements based on a constructor', () => {
       const wrapper = shallow(
         <div>

--- a/src/__tests__/Utils-spec.js
+++ b/src/__tests__/Utils-spec.js
@@ -2,11 +2,14 @@ import React from 'react/addons';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import {
+  coercePropValue,
   onPrototype,
   getNode,
   nodeEqual,
   isSimpleSelector,
   propFromEvent,
+  SELECTOR,
+  selectorType,
 } from '../Utils';
 import {
   describeWithDOM,
@@ -160,7 +163,7 @@ describe('Utils', () => {
   });
 
 
-  describe('iuSimpleSelector', () => {
+  describe('isSimpleSelector', () => {
 
     describe('prohibited selectors', () => {
       function isComplex(selector) {
@@ -170,7 +173,6 @@ describe('Utils', () => {
       }
 
       isComplex('.foo .bar');
-      isComplex('input[name="foo"]');
       isComplex(':visible');
       isComplex('.foo>.bar');
       isComplex('.foo > .bar');
@@ -187,11 +189,56 @@ describe('Utils', () => {
 
       isSimple('.foo');
       isSimple('.foo-and-foo');
+      isSimple('input[foo="bar"]');
+      isSimple('input[foo="bar"][bar="baz"][baz="foo"]');
       isSimple('.FoOaNdFoO');
       isSimple('tag');
       isSimple('.foo.bar');
       isSimple('input.foo');
 
+    });
+
+  });
+
+  describe('selectorType', () => {
+
+    it('returns CLASS_TYPE for a prefixed .', () => {
+      const type = selectorType('.foo');
+
+      expect(type).to.be.equal(SELECTOR.CLASS_TYPE);
+    });
+
+    it('returns ID_TYPE for a prefixed #', () => {
+      const type = selectorType('#foo');
+
+      expect(type).to.be.equal(SELECTOR.ID_TYPE);
+    });
+
+    it('returns PROP_TYPE for []', () => {
+      function isProp(selector) {
+        expect(selectorType(selector)).to.be.equal(SELECTOR.PROP_TYPE);
+      }
+
+      isProp('[foo]');
+      isProp('[foo="bar"]');
+    });
+
+  });
+
+  describe('coercePropValue', () => {
+
+    it('returns undefined if passed undefined', () => {
+      expect(coercePropValue(undefined)).to.equal(undefined);
+    });
+
+    it('returns number if passed a stringified number', () => {
+      expect(coercePropValue('1')).to.be.equal(1);
+      expect(coercePropValue('0')).to.be.equal(0);
+    });
+
+    it('returns a boolean if passed a stringified bool', () => {
+      expect(coercePropValue('true')).to.equal(true);
+      expect(coercePropValue('false')).to.equal(false);
     });
 
   });


### PR DESCRIPTION
Per discussion in #4 and continued discussion here. This PR adds support for querying react properties, and not html attributes. The following syntax works:

* `component.find('input[type="text"][value="1"])`
* `component.find('label[htmlFor="button"]')`
* `component.find('div[data-wrapper]')`

