### PR TITLE
Added test for find by display name

### DIFF
--- a/src/__tests__/ShallowWrapper-spec.js
+++ b/src/__tests__/ShallowWrapper-spec.js
@@ -123,6 +123,19 @@ describe('shallow', () => {
       expect(wrapper.find(Foo).type()).to.equal(Foo);
     });
 
+    it('should find a component based on a display name', () => {
+      class Foo extends React.Component {
+        render() { return <div />; }
+      }
+      const wrapper = shallow(
+        <div>
+          <Foo className="foo" />
+        </div>
+      );
+      expect(wrapper.find('Foo').type()).to.equal(Foo);
+    });
+
+
     it('should find multiple elements based on a class name', () => {
       const wrapper = shallow(
         <div>


### PR DESCRIPTION
According to the docs, it should be possible to `find` an element based on its display name. I simply added a test to assure that.
