### PR TITLE
Add .ref(refName) to the documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -82,6 +82,7 @@
     * [someWhere(predicate)](/docs/api/ReactWrapper/someWhere.md)
     * [every(selector)](/docs/api/ReactWrapper/every.md)
     * [everyWhere(selector)](/docs/api/ReactWrapper/everyWhere.md)
+    * [ref(refName)](/docs/api/ReactWrapper/ref.md)
   * [Static Rendering](/docs/api/render.md)
   * [Selectors](/docs/api/selector.md)
 * [Change Log](/CHANGELOG.md)

--- a/docs/api/ReactWrapper/ref.md
+++ b/docs/api/ReactWrapper/ref.md
@@ -1,4 +1,4 @@
-# `.ref(refName) => Any`
+# `.ref(refName) => ReactWrapper`
 
 Returns a wrapper of the node that matches the provided reference name.
 

--- a/docs/api/ReactWrapper/ref.md
+++ b/docs/api/ReactWrapper/ref.md
@@ -16,16 +16,30 @@ NOTE: can only be called on a wrapper instance that is also the root instance.
 
 
 
-#### Example
-
+#### Examples
 
 ```jsx
-const wrapper = mount(<MyComponent foo={10} />);
-expect(wrapper.prop('foo')).to.equal(10);
+class Foo extends React.Component {
+  render() {
+    return (
+      <div>
+        <span ref="firstRef" amount={2}>First</span>
+        <span ref="secondRef" amount={4}>Second</span>
+        <span ref="thirdRef" amount={8}>Third</span>
+      </div>
+    );
+  }
+}
+```
+
+```jsx
+const wrapper = mount(<Foo />);
+expect(wrapper.ref('secondRef').prop('amount')).to.equal(4);
+expect(wrapper.ref('secondRef').text()).to.equal('Second');
 ```
 
 
 #### Related Methods
 
-- [`.props() => Object`](props.md)
-- [`.state([key]) => Any`](state.md)
+- [`.find(selector) => ReactWrapper`](find.md)
+- [`.findWhere(predicate) => ReactWrapper`](findWhere.md)

--- a/docs/api/ReactWrapper/ref.md
+++ b/docs/api/ReactWrapper/ref.md
@@ -1,0 +1,31 @@
+# `.ref(refName) => Any`
+
+Returns a wrapper of the node that matches the provided reference name.
+
+
+NOTE: can only be called on a wrapper instance that is also the root instance.
+
+#### Arguments
+
+1. `refName` (`String`): The ref attribute of the node
+
+
+#### Returns
+
+`ReactWrapper`: A wrapper of the node that matches the provided reference name.
+
+
+
+#### Example
+
+
+```jsx
+const wrapper = mount(<MyComponent foo={10} />);
+expect(wrapper.prop('foo')).to.equal(10);
+```
+
+
+#### Related Methods
+
+- [`.props() => Object`](props.md)
+- [`.state([key]) => Any`](state.md)

--- a/docs/api/mount.md
+++ b/docs/api/mount.md
@@ -156,3 +156,6 @@ Returns whether or not all of the nodes in the wrapper match the provided select
 
 #### [`everyWhere(selector) => Boolean`](/docs/api/ReactWrapper/everyWhere.md)
 Returns whether or not any of the nodes in the wrapper pass the provided predicate function.
+
+#### [`ref(refName) => ReactWrapper`](/docs/api/ReactWrapper/everyWhere.md)
+Returns a wrapper of the node that matches the provided reference name.

--- a/src/__tests__/ReactWrapper-spec.js
+++ b/src/__tests__/ReactWrapper-spec.js
@@ -1158,4 +1158,23 @@ describeWithDOM('mount', () => {
     });
   });
 
+  describe('.ref(refName)', () => {
+    it('gets a wrapper of the node matching the provided refName', () => {
+
+      class Foo extends React.Component {
+        render() {
+          return (
+            <div>
+              <span ref="firstRef" amount={2}>First</span>
+              <span ref="secondRef" amount={4}>Second</span>
+              <span ref="thirdRef" amount={8}>Third</span>
+            </div>
+          );
+        }
+      }
+      const wrapper = mount(<Foo />);
+      expect(wrapper.ref('secondRef').prop('amount')).to.equal(4);
+      expect(wrapper.ref('secondRef').text()).to.equal('Second');
+    });
+  });
 });


### PR DESCRIPTION
This PR fixes #86.

The method `.ref(refName)` already exists, but it was not documented in the API documentation.

 I created a new page for `.ref(refName)` and added a test for it in `src/__tests__/ReactWrapper-spec.js` just to assure that the provided examples in the documentation are working.