### PR TITLE
CHANGED: The jsdom dependency to allow a range of supported versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "react": "0.13.x || 0.14.x"
   },
   "optionalDependencies": {
-    "jsdom": "^6.1.0",
+    "jsdom": "^3.1.2 || ^5.6.1 || ^6.1.0 || ^7.2.2",
     "mocha-jsdom": "^1.0.0"
   }
 }


### PR DESCRIPTION
This allows versions of node <= 0.12.0 to use this project as jsdom 4.X > require node 4.X >

Issue: https://github.com/airbnb/enzyme/issues/94