### PR TITLE
Minor Doc Fixes for ShallowWrapper.{forEach, simulate}

### DIFF
--- a/docs/api/ShallowWrapper/forEach.md
+++ b/docs/api/ShallowWrapper/forEach.md
@@ -30,7 +30,7 @@ const wrapper = shallow(
 );
 
 wrapper.find('.foo').forEach(function (node) {
-  expect(s.hasClass('foo')).to.be true;
+  expect(node.hasClass('foo')).to.be.true;
 });
 ```
 

--- a/docs/api/ShallowWrapper/forEach.md
+++ b/docs/api/ShallowWrapper/forEach.md
@@ -30,7 +30,7 @@ const wrapper = shallow(
 );
 
 wrapper.find('.foo').forEach(function (node) {
-  expect(node.hasClass('foo')).to.be.true;
+  expect(node.hasClass('foo')).to.equal(true);
 });
 ```
 

--- a/docs/api/ShallowWrapper/simulate.md
+++ b/docs/api/ShallowWrapper/simulate.md
@@ -43,7 +43,7 @@ class Foo extends React.Component {
 const wrapper = shallow(<Foo />);
 
 expect(wrapper.find('.clicks-0').length).to.equal(1);
-wrapper.simulate('click');
+wrapper.find('a').simulate('click');
 expect(wrapper.find('.clicks-1').length).to.equal(1);
 ```
 


### PR DESCRIPTION
- Fix typos in ShallowWrapper/forEach docs example
- Fix ShallowWrapper/simulate docs example. Was simulating on wrong node (Fixes #88)