### PR TITLE
Enable no-unused-expressions ESLint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ describe('<MyComponent />', () => {
         <div className="unique" />
       </MyComponent>
     );
-    expect(wrapper.contains(<div className="unique" />)).to.be.true;
+    expect(wrapper.contains(<div className="unique" />)).to.equal(true);
   });
 
   it('simulates click events', () => {
@@ -74,7 +74,7 @@ describe('<MyComponent />', () => {
       <Foo onButtonClick={onButtonClick} />
     );
     wrapper.find('button').simulate('click');
-    expect(onButtonClick.calledOnce).to.be.true;
+    expect(onButtonClick.calledOnce).to.equal(true);
   });
 
 });
@@ -98,7 +98,7 @@ describeWithDOM('<Foo />', () => {
   it('calls componentDidMount', () => {
     spyLifecycle(Foo);
     const wrapper = mount(<Foo />);
-    expect(Foo.prototype.componentDidMount.calledOnce).to.be.true;
+    expect(Foo.prototype.componentDidMount.calledOnce).to.equal(true);
   });
 
   it('allows us to set props', () => {
@@ -114,7 +114,7 @@ describeWithDOM('<Foo />', () => {
       <Foo onButtonClick={onButtonClick} />
     );
     wrapper.find('button').simulate('click');
-    expect(onButtonClick.calledOnce).to.be.true;
+    expect(onButtonClick.calledOnce).to.equal(true);
   });
 
 });

--- a/docs/api/ReactWrapper/contains.md
+++ b/docs/api/ReactWrapper/contains.md
@@ -23,7 +23,7 @@ like the one passed in.
 
 ```jsx
 const wrapper = mount(<MyComponent />);
-expect(wrapper.contains(<div className="foo bar" />)).to.be.true;
+expect(wrapper.contains(<div className="foo bar" />)).to.equal(true);
 ```
 
 

--- a/docs/api/ReactWrapper/every.md
+++ b/docs/api/ReactWrapper/every.md
@@ -25,9 +25,9 @@ const wrapper = mount(
     <div className="foo hoo" />
   </div>
 );
-expect(wrapper.find('.foo').every('.foo')).to.be.true;
-expect(wrapper.find('.foo').every('.qoo')).to.be.false;
-expect(wrapper.find('.foo').every('.bar')).to.be.false;
+expect(wrapper.find('.foo').every('.foo')).to.equal(true);
+expect(wrapper.find('.foo').every('.qoo')).to.equal(false);
+expect(wrapper.find('.foo').every('.bar')).to.equal(false);
 ```
 
 #### Related Methods

--- a/docs/api/ReactWrapper/everyWhere.md
+++ b/docs/api/ReactWrapper/everyWhere.md
@@ -25,9 +25,9 @@ const wrapper = mount(
     <div className="foo hoo" />
   </div>
 );
-expect(wrapper.find('.foo').everyWhere(n => n.hasClass('foo'))).to.be.true;
-expect(wrapper.find('.foo').everyWhere(n => n.hasClass('qoo'))).to.be.false;
-expect(wrapper.find('.foo').everyWhere(n => n.hasClass('bar'))).to.be.false;
+expect(wrapper.find('.foo').everyWhere(n => n.hasClass('foo'))).to.equal(true);
+expect(wrapper.find('.foo').everyWhere(n => n.hasClass('qoo'))).to.equal(false);
+expect(wrapper.find('.foo').everyWhere(n => n.hasClass('bar'))).to.equal(false);
 ```
 
 

--- a/docs/api/ReactWrapper/forEach.md
+++ b/docs/api/ReactWrapper/forEach.md
@@ -30,7 +30,7 @@ const wrapper = mount(
 );
 
 wrapper.find('.foo').forEach(function (node) {
-  expect(s.hasClass('foo')).to.be true;
+  expect(s.hasClass('foo')).to.equal(true);
 });
 ```
 

--- a/docs/api/ReactWrapper/hasClass.md
+++ b/docs/api/ReactWrapper/hasClass.md
@@ -20,7 +20,7 @@ Returns whether or not the current node has a `className` prop including the pas
 
 ```jsx
 const wrapper = mount(<MyComponent />);
-expect(wrapper.find('.my-button').hasClass('disabled')).to.be.true;
+expect(wrapper.find('.my-button').hasClass('disabled')).to.equal(true);
 ```
 
 ### Common Gotchas

--- a/docs/api/ReactWrapper/is.md
+++ b/docs/api/ReactWrapper/is.md
@@ -20,6 +20,6 @@ Returns whether or not the current node matches a provided selector.
 
 ```jsx
 const wrapper = mount(<div className="some-class other-class" />);
-expect(wrapper.is('.some-class')).to.be.true;
+expect(wrapper.is('.some-class')).to.equal(true);
 ```
 

--- a/docs/api/ReactWrapper/parent.md
+++ b/docs/api/ReactWrapper/parent.md
@@ -13,7 +13,7 @@ Returns a wrapper with the direct parent of the node in the current wrapper.
 
 ```jsx
 const wrapper = mount(<ToDoList />);
-expect(wrapper.find('ul').parent().is('div')).to.be.true;;
+expect(wrapper.find('ul').parent().is('div')).to.equal(true);
 ```
 
 #### Related Methods

--- a/docs/api/ReactWrapper/setProps.md
+++ b/docs/api/ReactWrapper/setProps.md
@@ -46,9 +46,9 @@ expect(wrapper.find('.bar')).to.have.length(1);
 const spy = sinon.spy(MyComponent.prototype, 'componentWillReceiveProps');
 
 const wrapper = mount(<MyComponent foo="bar" />);
-expect(spy.calledOnce).to.be.false;
+expect(spy.calledOnce).to.equal(false);
 wrapper.setProps({ foo: 'foo' });
-expect(spy.calledOnce).to.be.true;
+expect(spy.calledOnce).to.equal(true);
 ```
 
 

--- a/docs/api/ReactWrapper/some.md
+++ b/docs/api/ReactWrapper/some.md
@@ -25,9 +25,9 @@ const wrapper = mount(
     <div className="foo hoo" />
   </div>
 );
-expect(wrapper.find('.foo').some('.qoo')).to.be.true;
-expect(wrapper.find('.foo').some('.foo')).to.be.true;
-expect(wrapper.find('.foo').some('.bar')).to.be.false;
+expect(wrapper.find('.foo').some('.qoo')).to.equal(true);
+expect(wrapper.find('.foo').some('.foo')).to.equal(true);
+expect(wrapper.find('.foo').some('.bar')).to.equal(false);
 ```
 
 #### Related Methods

--- a/docs/api/ReactWrapper/someWhere.md
+++ b/docs/api/ReactWrapper/someWhere.md
@@ -25,9 +25,9 @@ const wrapper = mount(
     <div className="foo hoo" />
   </div>
 );
-expect(wrapper.find('.foo').someWhere(n => n.hasClass('qoo'))).to.be.true;
-expect(wrapper.find('.foo').someWhere(n => n.hasClass('foo'))).to.be.true;
-expect(wrapper.find('.foo').someWhere(n => n.hasClass('bar'))).to.be.false;
+expect(wrapper.find('.foo').someWhere(n => n.hasClass('qoo'))).to.equal(true);
+expect(wrapper.find('.foo').someWhere(n => n.hasClass('foo'))).to.equal(true);
+expect(wrapper.find('.foo').someWhere(n => n.hasClass('bar'))).to.equal(false);
 ```
 
 

--- a/docs/api/ShallowWrapper/contains.md
+++ b/docs/api/ShallowWrapper/contains.md
@@ -23,7 +23,7 @@ like the one passed in.
 
 ```jsx
 const wrapper = shallow(<MyComponent />);
-expect(wrapper.contains(<div className="foo bar" />)).to.be.true;
+expect(wrapper.contains(<div className="foo bar" />)).to.equal(true);
 ```
 
 

--- a/docs/api/ShallowWrapper/every.md
+++ b/docs/api/ShallowWrapper/every.md
@@ -25,9 +25,9 @@ const wrapper = shallow(
     <div className="foo hoo" />
   </div>
 );
-expect(wrapper.find('.foo').every('.foo')).to.be.true;
-expect(wrapper.find('.foo').every('.qoo')).to.be.false;
-expect(wrapper.find('.foo').every('.bar')).to.be.false;
+expect(wrapper.find('.foo').every('.foo')).to.equal(true);
+expect(wrapper.find('.foo').every('.qoo')).to.equal(false);
+expect(wrapper.find('.foo').every('.bar')).to.equal(false);
 ```
 
 #### Related Methods

--- a/docs/api/ShallowWrapper/everyWhere.md
+++ b/docs/api/ShallowWrapper/everyWhere.md
@@ -25,9 +25,9 @@ const wrapper = shallow(
     <div className="foo hoo" />
   </div>
 );
-expect(wrapper.find('.foo').everyWhere(n => n.hasClass('foo'))).to.be.true;
-expect(wrapper.find('.foo').everyWhere(n => n.hasClass('qoo'))).to.be.false;
-expect(wrapper.find('.foo').everyWhere(n => n.hasClass('bar'))).to.be.false;
+expect(wrapper.find('.foo').everyWhere(n => n.hasClass('foo'))).to.equal(true);
+expect(wrapper.find('.foo').everyWhere(n => n.hasClass('qoo'))).to.equal(false);
+expect(wrapper.find('.foo').everyWhere(n => n.hasClass('bar'))).to.equal(false);
 ```
 
 

--- a/docs/api/ShallowWrapper/hasClass.md
+++ b/docs/api/ShallowWrapper/hasClass.md
@@ -20,7 +20,7 @@ Returns whether or not the current node has a `className` prop including the pas
 
 ```jsx
 const wrapper = shallow(<MyComponent />);
-expect(wrapper.find('.my-button').hasClass('disabled')).to.be.true;
+expect(wrapper.find('.my-button').hasClass('disabled')).to.equal(true);
 ```
 
 ### Common Gotchas

--- a/docs/api/ShallowWrapper/is.md
+++ b/docs/api/ShallowWrapper/is.md
@@ -20,6 +20,6 @@ Returns whether or not the current node matches a provided selector.
 
 ```jsx
 const wrapper = shallow(<div className="some-class other-class" />);
-expect(wrapper.is('.some-class')).to.be.true;
+expect(wrapper.is('.some-class')).to.equal(true);
 ```
 

--- a/docs/api/ShallowWrapper/parent.md
+++ b/docs/api/ShallowWrapper/parent.md
@@ -2,18 +2,15 @@
 
 Returns a wrapper with the direct parent of the node in the current wrapper.
 
-
 #### Returns
 
 `ShallowWrapper`: A new wrapper that wraps the resulting nodes.
-
-
 
 #### Examples
 
 ```jsx
 const wrapper = shallow(<ToDoList />);
-expect(wrapper.find('ul').parent().is('div')).to.be.true;;
+expect(wrapper.find('ul').parent().is('div')).to.equal(true);
 ```
 
 #### Related Methods

--- a/docs/api/ShallowWrapper/setProps.md
+++ b/docs/api/ShallowWrapper/setProps.md
@@ -46,9 +46,9 @@ expect(wrapper.find('.bar')).to.have.length(1);
 const spy = sinon.spy(MyComponent.prototype, 'componentWillReceiveProps');
 
 const wrapper = shallow(<MyComponent foo="bar" />);
-expect(spy.calledOnce).to.be.false;
+expect(spy.calledOnce).to.equal(false);
 wrapper.setProps({ foo: 'foo' });
-expect(spy.calledOnce).to.be.true;
+expect(spy.calledOnce).to.equal(true);
 ```
 
 

--- a/docs/api/ShallowWrapper/some.md
+++ b/docs/api/ShallowWrapper/some.md
@@ -25,9 +25,9 @@ const wrapper = shallow(
     <div className="foo hoo" />
   </div>
 );
-expect(wrapper.find('.foo').some('.qoo')).to.be.true;
-expect(wrapper.find('.foo').some('.foo')).to.be.true;
-expect(wrapper.find('.foo').some('.bar')).to.be.false;
+expect(wrapper.find('.foo').some('.qoo')).to.equal(true);
+expect(wrapper.find('.foo').some('.foo')).to.equal(true);
+expect(wrapper.find('.foo').some('.bar')).to.equal(false);
 ```
 
 #### Related Methods

--- a/docs/api/ShallowWrapper/someWhere.md
+++ b/docs/api/ShallowWrapper/someWhere.md
@@ -25,9 +25,9 @@ const wrapper = shallow(
     <div className="foo hoo" />
   </div>
 );
-expect(wrapper.find('.foo').someWhere(n => n.hasClass('qoo'))).to.be.true;
-expect(wrapper.find('.foo').someWhere(n => n.hasClass('foo'))).to.be.true;
-expect(wrapper.find('.foo').someWhere(n => n.hasClass('bar'))).to.be.false;
+expect(wrapper.find('.foo').someWhere(n => n.hasClass('qoo'))).to.equal(true);
+expect(wrapper.find('.foo').someWhere(n => n.hasClass('foo'))).to.equal(true);
+expect(wrapper.find('.foo').someWhere(n => n.hasClass('bar'))).to.equal(false);
 ```
 
 

--- a/docs/api/mount.md
+++ b/docs/api/mount.md
@@ -15,7 +15,7 @@ describe('<Foo />', () => {
   it('calls componentDidMount', () => {
     spy(Foo.prototype, 'componentDidMount');
     const wrapper = mount(<Foo />);
-    expect(Foo.prototype.componentDidMount.calledOnce).to.be.true;
+    expect(Foo.prototype.componentDidMount.calledOnce).to.equal(true);
   });
 
   it('allows us to set props', () => {
@@ -31,7 +31,7 @@ describe('<Foo />', () => {
       <Foo onButtonClick={onButtonClick} />
     );
     wrapper.find('button').simulate('click');
-    expect(onButtonClick.calledOnce).to.be.true;
+    expect(onButtonClick.calledOnce).to.equal(true);
   });
 
 });

--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -24,7 +24,7 @@ describe('<MyComponent />', () => {
         <div className="unique" />
       </MyComponent>
     );
-    expect(wrapper.contains(<div className="unique" />)).to.be.true;
+    expect(wrapper.contains(<div className="unique" />)).to.equal(true);
   });
 
   it('simulates click events', () => {
@@ -33,7 +33,7 @@ describe('<MyComponent />', () => {
       <Foo onButtonClick={onButtonClick} />
     );
     wrapper.find('button').simulate('click');
-    expect(onButtonClick.calledOnce).to.be.true;
+    expect(onButtonClick.calledOnce).to.equal(true);
   });
 
 });

--- a/src/ReactWrapper.js
+++ b/src/ReactWrapper.js
@@ -203,7 +203,7 @@ export default class ReactWrapper {
    * Example:
    * ```
    * const wrapper = mount(<MyComponent />);
-   * expect(wrapper.contains(<div className="foo bar" />)).to.be.true;
+   * expect(wrapper.contains(<div className="foo bar" />)).to.equal(true);
    * ```
    *
    * @param {ReactElement} node

--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -195,7 +195,7 @@ export default class ShallowWrapper {
    * Example:
    * ```
    * const wrapper = shallow(<MyComponent />);
-   * expect(wrapper.contains(<div className="foo bar" />)).to.be.true;
+   * expect(wrapper.contains(<div className="foo bar" />)).to.equal(true);
    * ```
    *
    * @param {ReactElement} node

--- a/src/__tests__/.eslintrc
+++ b/src/__tests__/.eslintrc
@@ -1,7 +1,6 @@
 {
   "rules": {
     "padded-blocks": 0,
-    "no-unused-expressions": 0,
     "react/no-multi-comp": 0,
     "react/prop-types": 0,
     "react/no-did-mount-set-state": 0,

--- a/src/__tests__/ReactWrapper-spec.js
+++ b/src/__tests__/ReactWrapper-spec.js
@@ -28,7 +28,7 @@ describeWithDOM('mount', () => {
       expect(wrapper.text()).to.equal('foo');
     });
 
-    it('throws if context is passed in but contextTypes is missing', () => {
+    it('should not throw if context is passed in but contextTypes is missing', () => {
       const SimpleComponent = React.createClass({
         render() {
           return <div>{this.context.name}</div>;
@@ -36,7 +36,7 @@ describeWithDOM('mount', () => {
       });
 
       const context = { name: 'foo' };
-      expect(() => mount(<SimpleComponent />, { context })).to.throw;
+      expect(() => mount(<SimpleComponent />, { context })).to.not.throw(Error);
     });
   });
 
@@ -61,8 +61,8 @@ describeWithDOM('mount', () => {
       const a = <div className="foo" />;
       const b = <div className="foo" />;
       const c = <div className="bar" />;
-      expect(mount(a).contains(b)).to.be.true;
-      expect(mount(a).contains(c)).to.be.false;
+      expect(mount(a).contains(b)).to.equal(true);
+      expect(mount(a).contains(c)).to.equal(false);
     });
 
     it('should allow matches on a nested node', () => {
@@ -72,7 +72,7 @@ describeWithDOM('mount', () => {
         </div>
       );
       const b = <div className="foo" />;
-      expect(wrapper.contains(b)).to.be.true;
+      expect(wrapper.contains(b)).to.equal(true);
     });
 
     it('should match composite components', () => {
@@ -85,7 +85,7 @@ describeWithDOM('mount', () => {
         </div>
       );
       const b = <Foo />;
-      expect(wrapper.contains(b)).to.be.true;
+      expect(wrapper.contains(b)).to.equal(true);
     });
 
   });
@@ -164,7 +164,7 @@ describeWithDOM('mount', () => {
           <button />
         </div>
       );
-      expect(() => wrapper.find('.foo .foo')).to.throw;
+      expect(() => wrapper.find('.foo .foo')).to.throw(Error);
     });
 
   });
@@ -209,9 +209,9 @@ describeWithDOM('mount', () => {
       expect(spy.args[1][0]).to.be.instanceOf(ReactWrapper);
       expect(spy.args[2][0]).to.be.instanceOf(ReactWrapper);
       expect(spy.args[3][0]).to.be.instanceOf(ReactWrapper);
-      expect(spy.args[1][0].hasClass('bar')).to.be.true;
-      expect(spy.args[2][0].hasClass('baz')).to.be.true;
-      expect(spy.args[3][0].hasClass('bux')).to.be.true;
+      expect(spy.args[1][0].hasClass('bar')).to.equal(true);
+      expect(spy.args[2][0].hasClass('baz')).to.equal(true);
+      expect(spy.args[3][0].hasClass('bux')).to.equal(true);
     });
 
   });
@@ -253,10 +253,10 @@ describeWithDOM('mount', () => {
       }
       const nextProps = { id: 'bar', foo: 'bla'};
       const wrapper = mount(<Foo id="foo" />);
-      expect(spy.calledOnce).to.be.false;
+      expect(spy.calledOnce).to.equal(false);
       wrapper.setProps(nextProps);
-      expect(spy.calledOnce).to.be.true;
-      expect(spy.calledWith(nextProps)).to.be.true;
+      expect(spy.calledOnce).to.equal(true);
+      expect(spy.calledWith(nextProps)).to.equal(true);
     });
 
   });
@@ -283,7 +283,7 @@ describeWithDOM('mount', () => {
 
     it('should throw if it is called when shallow didnt include context', () => {
       const wrapper = mount(<SimpleComponent />);
-      expect(() => wrapper.setContext({ name: 'bar' })).to.throw;
+      expect(() => wrapper.setContext({ name: 'bar' })).to.throw(Error);
     });
   });
 
@@ -328,7 +328,7 @@ describeWithDOM('mount', () => {
       const wrapper = mount(<Foo />);
 
       wrapper.simulate('click', { someSpecialData: 'foo'});
-      expect(spy.calledOnce).to.be.true;
+      expect(spy.calledOnce).to.equal(true);
       expect(spy.args[0][0].someSpecialData).to.equal('foo');
     });
 
@@ -376,17 +376,17 @@ describeWithDOM('mount', () => {
   describe('.is(selector)', () => {
     it('should return true when selector matches current element', () => {
       const wrapper = mount(<div className="foo bar baz" />);
-      expect(wrapper.is('.foo')).to.be.true;
+      expect(wrapper.is('.foo')).to.equal(true);
     });
 
     it('should allow for compound selectors', () => {
       const wrapper = mount(<div className="foo bar baz" />);
-      expect(wrapper.is('.foo.bar')).to.be.true;
+      expect(wrapper.is('.foo.bar')).to.equal(true);
     });
 
     it('should return false when selector does not match', () => {
       const wrapper = mount(<div className="bar baz" />);
-      expect(wrapper.is('.foo')).to.be.false;
+      expect(wrapper.is('.foo')).to.equal(false);
     });
   });
 
@@ -460,7 +460,7 @@ describeWithDOM('mount', () => {
 
       const baz = wrapper.find('.foo').filterWhere(stub);
       expect(baz.length).to.equal(1);
-      expect(baz.hasClass('baz')).to.be.true;
+      expect(baz.hasClass('baz')).to.equal(true);
     });
 
     it('should call the predicate with the wrapper as the first argument', () => {
@@ -480,9 +480,9 @@ describeWithDOM('mount', () => {
       expect(spy.args[0][0]).to.be.instanceOf(ReactWrapper);
       expect(spy.args[1][0]).to.be.instanceOf(ReactWrapper);
       expect(spy.args[2][0]).to.be.instanceOf(ReactWrapper);
-      expect(spy.args[0][0].hasClass('bar')).to.be.true;
-      expect(spy.args[1][0].hasClass('baz')).to.be.true;
-      expect(spy.args[2][0].hasClass('bux')).to.be.true;
+      expect(spy.args[0][0].hasClass('bar')).to.equal(true);
+      expect(spy.args[1][0].hasClass('baz')).to.equal(true);
+      expect(spy.args[2][0].hasClass('bux')).to.equal(true);
     });
   });
 
@@ -626,9 +626,9 @@ describeWithDOM('mount', () => {
         </div>
       );
       expect(wrapper.children().length).to.equal(3);
-      expect(wrapper.children().at(0).hasClass('foo')).to.be.true;
-      expect(wrapper.children().at(1).hasClass('bar')).to.be.true;
-      expect(wrapper.children().at(2).hasClass('baz')).to.be.true;
+      expect(wrapper.children().at(0).hasClass('foo')).to.equal(true);
+      expect(wrapper.children().at(1).hasClass('bar')).to.equal(true);
+      expect(wrapper.children().at(2).hasClass('baz')).to.equal(true);
     });
 
     it('should not return any of the children of children', () => {
@@ -641,8 +641,8 @@ describeWithDOM('mount', () => {
         </div>
       );
       expect(wrapper.children().length).to.equal(2);
-      expect(wrapper.children().at(0).hasClass('foo')).to.be.true;
-      expect(wrapper.children().at(1).hasClass('baz')).to.be.true;
+      expect(wrapper.children().at(0).hasClass('foo')).to.equal(true);
+      expect(wrapper.children().at(1).hasClass('baz')).to.equal(true);
     });
 
     it('should handle mixed children with and without arrays', () => {
@@ -663,9 +663,9 @@ describeWithDOM('mount', () => {
         ]} />
       );
       expect(wrapper.children().length).to.equal(3);
-      expect(wrapper.children().at(0).hasClass('foo')).to.be.true;
-      expect(wrapper.children().at(1).hasClass('bar')).to.be.true;
-      expect(wrapper.children().at(2).hasClass('baz')).to.be.true;
+      expect(wrapper.children().at(0).hasClass('foo')).to.equal(true);
+      expect(wrapper.children().at(1).hasClass('bar')).to.equal(true);
+      expect(wrapper.children().at(2).hasClass('baz')).to.equal(true);
     });
 
     it('should optionally allow a selector to filter by', () => {
@@ -678,8 +678,8 @@ describeWithDOM('mount', () => {
       );
       const children = wrapper.children('.bip');
       expect(children.length).to.equal(2);
-      expect(children.at(0).hasClass('bar')).to.be.true;
-      expect(children.at(1).hasClass('baz')).to.be.true;
+      expect(children.at(0).hasClass('bar')).to.equal(true);
+      expect(children.at(1).hasClass('baz')).to.equal(true);
     });
   });
 
@@ -698,9 +698,9 @@ describeWithDOM('mount', () => {
       const parents = wrapper.find('.baz').parents();
 
       expect(parents.length).to.equal(3);
-      expect(parents.at(0).hasClass('bar')).to.be.true;
-      expect(parents.at(1).hasClass('foo')).to.be.true;
-      expect(parents.at(2).hasClass('bax')).to.be.true;
+      expect(parents.at(0).hasClass('bar')).to.equal(true);
+      expect(parents.at(1).hasClass('foo')).to.equal(true);
+      expect(parents.at(2).hasClass('bax')).to.equal(true);
 
     });
 
@@ -718,8 +718,8 @@ describeWithDOM('mount', () => {
       const parents = wrapper.find('.bar').parents();
 
       expect(parents.length).to.equal(2);
-      expect(parents.at(0).hasClass('foo')).to.be.true;
-      expect(parents.at(1).hasClass('bax')).to.be.true;
+      expect(parents.at(0).hasClass('foo')).to.equal(true);
+      expect(parents.at(1).hasClass('bax')).to.equal(true);
     });
 
     it('should optionally allow a selector', () => {
@@ -736,8 +736,8 @@ describeWithDOM('mount', () => {
       const parents = wrapper.find('.baz').parents('.foo');
 
       expect(parents.length).to.equal(2);
-      expect(parents.at(0).hasClass('foo')).to.be.true;
-      expect(parents.at(1).hasClass('bax')).to.be.true;
+      expect(parents.at(0).hasClass('foo')).to.equal(true);
+      expect(parents.at(1).hasClass('bax')).to.equal(true);
     });
   });
 
@@ -753,7 +753,7 @@ describeWithDOM('mount', () => {
         </div>
       );
 
-      expect(wrapper.find('.baz').parent().hasClass('bar')).to.be.true;
+      expect(wrapper.find('.baz').parent().hasClass('bar')).to.equal(true);
     });
 
     it('should work for multiple nodes', () => {
@@ -773,9 +773,9 @@ describeWithDOM('mount', () => {
 
       const parents = wrapper.find('.baz').parent();
       expect(parents).to.have.length(3);
-      expect(parents.at(0).hasClass('foo')).to.be.true;
-      expect(parents.at(1).hasClass('bar')).to.be.true;
-      expect(parents.at(2).hasClass('bax')).to.be.true;
+      expect(parents.at(0).hasClass('foo')).to.equal(true);
+      expect(parents.at(1).hasClass('bar')).to.equal(true);
+      expect(parents.at(2).hasClass('bax')).to.equal(true);
     });
   });
 
@@ -792,7 +792,7 @@ describeWithDOM('mount', () => {
       );
 
       const closestFoo = wrapper.find('.bar').closest('.foo');
-      expect(closestFoo.hasClass('baz')).to.be.true;
+      expect(closestFoo.hasClass('baz')).to.equal(true);
       expect(closestFoo.length).to.equal(1);
     });
 
@@ -807,7 +807,7 @@ describeWithDOM('mount', () => {
         </div>
       );
 
-      expect(wrapper.find('.baz').parent().hasClass('bar')).to.be.true;
+      expect(wrapper.find('.baz').parent().hasClass('bar')).to.equal(true);
     });
 
     it('should return itself if matching', () => {
@@ -821,7 +821,7 @@ describeWithDOM('mount', () => {
         </div>
       );
 
-      expect(wrapper.find('.bux').closest('.baz').hasClass('bux')).to.be.true;
+      expect(wrapper.find('.bux').closest('.baz').hasClass('bux')).to.equal(true);
     });
   });
 
@@ -831,12 +831,12 @@ describeWithDOM('mount', () => {
         <div className="foo bar baz some-long-string FoOo" />
       );
 
-      expect(wrapper.hasClass('foo')).to.be.true;
-      expect(wrapper.hasClass('bar')).to.be.true;
-      expect(wrapper.hasClass('baz')).to.be.true;
-      expect(wrapper.hasClass('some-long-string')).to.be.true;
-      expect(wrapper.hasClass('FoOo')).to.be.true;
-      expect(wrapper.hasClass('doesnt-exist')).to.be.false;
+      expect(wrapper.hasClass('foo')).to.equal(true);
+      expect(wrapper.hasClass('bar')).to.equal(true);
+      expect(wrapper.hasClass('baz')).to.equal(true);
+      expect(wrapper.hasClass('some-long-string')).to.equal(true);
+      expect(wrapper.hasClass('FoOo')).to.equal(true);
+      expect(wrapper.hasClass('doesnt-exist')).to.equal(false);
     });
   });
 
@@ -855,11 +855,11 @@ describeWithDOM('mount', () => {
 
       expect(spy.callCount).to.equal(3);
       expect(spy.args[0][0]).to.be.instanceOf(ReactWrapper);
-      expect(spy.args[0][0].hasClass('bax')).to.be.true;
+      expect(spy.args[0][0].hasClass('bax')).to.equal(true);
       expect(spy.args[1][0]).to.be.instanceOf(ReactWrapper);
-      expect(spy.args[1][0].hasClass('bar')).to.be.true;
+      expect(spy.args[1][0].hasClass('bar')).to.equal(true);
       expect(spy.args[2][0]).to.be.instanceOf(ReactWrapper);
-      expect(spy.args[2][0].hasClass('baz')).to.be.true;
+      expect(spy.args[2][0].hasClass('baz')).to.equal(true);
     });
   });
 
@@ -878,11 +878,11 @@ describeWithDOM('mount', () => {
 
       expect(spy.callCount).to.equal(3);
       expect(spy.args[0][0]).to.be.instanceOf(ReactWrapper);
-      expect(spy.args[0][0].hasClass('bax')).to.be.true;
+      expect(spy.args[0][0].hasClass('bax')).to.equal(true);
       expect(spy.args[1][0]).to.be.instanceOf(ReactWrapper);
-      expect(spy.args[1][0].hasClass('bar')).to.be.true;
+      expect(spy.args[1][0].hasClass('bar')).to.equal(true);
       expect(spy.args[2][0]).to.be.instanceOf(ReactWrapper);
-      expect(spy.args[2][0].hasClass('baz')).to.be.true;
+      expect(spy.args[2][0].hasClass('baz')).to.equal(true);
     });
 
     it('should return an array with the mapped values', () => {
@@ -918,11 +918,11 @@ describeWithDOM('mount', () => {
 
       expect(spy.callCount).to.equal(3);
       expect(spy.args[0][1]).to.be.instanceOf(ReactWrapper);
-      expect(spy.args[0][1].hasClass('bax')).to.be.true;
+      expect(spy.args[0][1].hasClass('bax')).to.equal(true);
       expect(spy.args[1][1]).to.be.instanceOf(ReactWrapper);
-      expect(spy.args[1][1].hasClass('bar')).to.be.true;
+      expect(spy.args[1][1].hasClass('bar')).to.equal(true);
       expect(spy.args[2][1]).to.be.instanceOf(ReactWrapper);
-      expect(spy.args[2][1].hasClass('baz')).to.be.true;
+      expect(spy.args[2][1].hasClass('baz')).to.equal(true);
     });
 
     it('should accumulate a value', () => {
@@ -964,11 +964,11 @@ describeWithDOM('mount', () => {
 
       expect(spy.callCount).to.equal(3);
       expect(spy.args[0][1]).to.be.instanceOf(ReactWrapper);
-      expect(spy.args[0][1].hasClass('baz')).to.be.true;
+      expect(spy.args[0][1].hasClass('baz')).to.equal(true);
       expect(spy.args[1][1]).to.be.instanceOf(ReactWrapper);
-      expect(spy.args[1][1].hasClass('bar')).to.be.true;
+      expect(spy.args[1][1].hasClass('bar')).to.equal(true);
       expect(spy.args[2][1]).to.be.instanceOf(ReactWrapper);
-      expect(spy.args[2][1].hasClass('bax')).to.be.true;
+      expect(spy.args[2][1].hasClass('bax')).to.equal(true);
     });
 
     it('should accumulate a value', () => {
@@ -1004,9 +1004,9 @@ describeWithDOM('mount', () => {
           <div className="foo hoo" />
         </div>
       );
-      expect(wrapper.find('.foo').some('.qoo')).to.be.true;
-      expect(wrapper.find('.foo').some('.foo')).to.be.true;
-      expect(wrapper.find('.foo').some('.bar')).to.be.false;
+      expect(wrapper.find('.foo').some('.qoo')).to.equal(true);
+      expect(wrapper.find('.foo').some('.foo')).to.equal(true);
+      expect(wrapper.find('.foo').some('.bar')).to.equal(false);
     });
   });
 
@@ -1019,9 +1019,9 @@ describeWithDOM('mount', () => {
           <div className="foo hoo" />
         </div>
       );
-      expect(wrapper.find('.foo').someWhere(n => n.hasClass('qoo'))).to.be.true;
-      expect(wrapper.find('.foo').someWhere(n => n.hasClass('foo'))).to.be.true;
-      expect(wrapper.find('.foo').someWhere(n => n.hasClass('bar'))).to.be.false;
+      expect(wrapper.find('.foo').someWhere(n => n.hasClass('qoo'))).to.equal(true);
+      expect(wrapper.find('.foo').someWhere(n => n.hasClass('foo'))).to.equal(true);
+      expect(wrapper.find('.foo').someWhere(n => n.hasClass('bar'))).to.equal(false);
     });
   });
 
@@ -1034,9 +1034,9 @@ describeWithDOM('mount', () => {
           <div className="foo hoo" />
         </div>
       );
-      expect(wrapper.find('.foo').every('.foo')).to.be.true;
-      expect(wrapper.find('.foo').every('.qoo')).to.be.false;
-      expect(wrapper.find('.foo').every('.bar')).to.be.false;
+      expect(wrapper.find('.foo').every('.foo')).to.equal(true);
+      expect(wrapper.find('.foo').every('.qoo')).to.equal(false);
+      expect(wrapper.find('.foo').every('.bar')).to.equal(false);
     });
   });
 
@@ -1049,9 +1049,9 @@ describeWithDOM('mount', () => {
           <div className="foo hoo" />
         </div>
       );
-      expect(wrapper.find('.foo').everyWhere(n => n.hasClass('foo'))).to.be.true;
-      expect(wrapper.find('.foo').everyWhere(n => n.hasClass('qoo'))).to.be.false;
-      expect(wrapper.find('.foo').everyWhere(n => n.hasClass('bar'))).to.be.false;
+      expect(wrapper.find('.foo').everyWhere(n => n.hasClass('foo'))).to.equal(true);
+      expect(wrapper.find('.foo').everyWhere(n => n.hasClass('qoo'))).to.equal(false);
+      expect(wrapper.find('.foo').everyWhere(n => n.hasClass('bar'))).to.equal(false);
     });
   });
 
@@ -1077,12 +1077,12 @@ describeWithDOM('mount', () => {
       const nodes = wrapper.find('.foo').flatMap(w => w.children().nodes);
 
       expect(nodes.length).to.equal(6);
-      expect(nodes.at(0).hasClass('bar')).to.be.true;
-      expect(nodes.at(1).hasClass('bar')).to.be.true;
-      expect(nodes.at(2).hasClass('baz')).to.be.true;
-      expect(nodes.at(3).hasClass('baz')).to.be.true;
-      expect(nodes.at(4).hasClass('bax')).to.be.true;
-      expect(nodes.at(5).hasClass('bax')).to.be.true;
+      expect(nodes.at(0).hasClass('bar')).to.equal(true);
+      expect(nodes.at(1).hasClass('bar')).to.equal(true);
+      expect(nodes.at(2).hasClass('baz')).to.equal(true);
+      expect(nodes.at(3).hasClass('baz')).to.equal(true);
+      expect(nodes.at(4).hasClass('bax')).to.equal(true);
+      expect(nodes.at(5).hasClass('bax')).to.equal(true);
     });
   });
 
@@ -1096,7 +1096,7 @@ describeWithDOM('mount', () => {
           <div className="bar" />
         </div>
       );
-      expect(wrapper.find('.bar').first().hasClass('baz')).to.be.true;
+      expect(wrapper.find('.bar').first().hasClass('baz')).to.equal(true);
     });
   });
 
@@ -1110,7 +1110,7 @@ describeWithDOM('mount', () => {
           <div className="bar baz" />
         </div>
       );
-      expect(wrapper.find('.bar').last().hasClass('baz')).to.be.true;
+      expect(wrapper.find('.bar').last().hasClass('baz')).to.equal(true);
     });
   });
 
@@ -1119,8 +1119,8 @@ describeWithDOM('mount', () => {
       const wrapper = mount(
         <div className="foo" />
       );
-      expect(wrapper.find('.bar').isEmpty()).to.be.true;
-      expect(wrapper.find('.foo').isEmpty()).to.be.false;
+      expect(wrapper.find('.bar').isEmpty()).to.equal(true);
+      expect(wrapper.find('.foo').isEmpty()).to.equal(false);
     });
   });
 
@@ -1134,10 +1134,10 @@ describeWithDOM('mount', () => {
           <div className="bar baz" />
         </div>
       );
-      expect(wrapper.find('.bar').at(0).hasClass('foo')).to.be.true;
-      expect(wrapper.find('.bar').at(1).hasClass('bax')).to.be.true;
-      expect(wrapper.find('.bar').at(2).hasClass('bux')).to.be.true;
-      expect(wrapper.find('.bar').at(3).hasClass('baz')).to.be.true;
+      expect(wrapper.find('.bar').at(0).hasClass('foo')).to.equal(true);
+      expect(wrapper.find('.bar').at(1).hasClass('bax')).to.equal(true);
+      expect(wrapper.find('.bar').at(2).hasClass('bux')).to.equal(true);
+      expect(wrapper.find('.bar').at(3).hasClass('baz')).to.equal(true);
     });
   });
 

--- a/src/__tests__/ShallowTraversal-spec.js
+++ b/src/__tests__/ShallowTraversal-spec.js
@@ -30,21 +30,21 @@ describe('ShallowTraversal', () => {
 
     it('should work for standalone classNames', () => {
       const node = (<div className="foo"/>);
-      expect(hasClassName(node, 'foo')).to.be.true;
-      expect(hasClassName(node, 'bar')).to.be.false;
+      expect(hasClassName(node, 'foo')).to.equal(true);
+      expect(hasClassName(node, 'bar')).to.equal(false);
     });
 
     it('should work for multiple classNames', () => {
       const node = (<div className="foo bar baz"/>);
-      expect(hasClassName(node, 'foo')).to.be.true;
-      expect(hasClassName(node, 'bar')).to.be.true;
-      expect(hasClassName(node, 'baz')).to.be.true;
-      expect(hasClassName(node, 'bax')).to.be.false;
+      expect(hasClassName(node, 'foo')).to.equal(true);
+      expect(hasClassName(node, 'bar')).to.equal(true);
+      expect(hasClassName(node, 'baz')).to.equal(true);
+      expect(hasClassName(node, 'bax')).to.equal(false);
     });
 
     it('should also allow hyphens', () => {
       const node = (<div className="foo-bar"/>);
-      expect(hasClassName(node, 'foo-bar')).to.be.true;
+      expect(hasClassName(node, 'foo-bar')).to.equal(true);
     });
 
   });
@@ -55,7 +55,7 @@ describe('ShallowTraversal', () => {
       const spy = sinon.spy();
       const node = (<div />);
       treeForEach(node, spy);
-      expect(spy.calledOnce).to.be.true;
+      expect(spy.calledOnce).to.equal(true);
     });
 
     it('should handle a single child', () => {

--- a/src/__tests__/ShallowWrapper-spec.js
+++ b/src/__tests__/ShallowWrapper-spec.js
@@ -23,7 +23,7 @@ describe('shallow', () => {
       expect(wrapper.text()).to.equal('foo');
     });
 
-    it('throws if context is passed in but contextTypes is missing', () => {
+    it('should not throw if context is passed in but contextTypes is missing', () => {
       const SimpleComponent = React.createClass({
         render() {
           return <div>{this.context.name}</div>;
@@ -31,7 +31,7 @@ describe('shallow', () => {
       });
 
       const context = { name: 'foo' };
-      expect(() => shallow(<SimpleComponent />, { context })).to.throw;
+      expect(() => shallow(<SimpleComponent />, { context })).to.not.throw(Error);
     });
   });
 
@@ -56,8 +56,8 @@ describe('shallow', () => {
       const a = <div className="foo" />;
       const b = <div className="foo" />;
       const c = <div className="bar" />;
-      expect(shallow(a).contains(b)).to.be.true;
-      expect(shallow(a).contains(c)).to.be.false;
+      expect(shallow(a).contains(b)).to.equal(true);
+      expect(shallow(a).contains(c)).to.equal(false);
     });
 
     it('should allow matches on a nested node', () => {
@@ -67,7 +67,7 @@ describe('shallow', () => {
         </div>
       );
       const b = <div className="foo" />;
-      expect(wrapper.contains(b)).to.be.true;
+      expect(wrapper.contains(b)).to.equal(true);
     });
 
     it('should match composite components', () => {
@@ -80,7 +80,7 @@ describe('shallow', () => {
         </div>
       );
       const b = <Foo />;
-      expect(wrapper.contains(b)).to.be.true;
+      expect(wrapper.contains(b)).to.equal(true);
     });
 
   });
@@ -178,7 +178,7 @@ describe('shallow', () => {
           <button />
         </div>
       );
-      expect(() => wrapper.find('.foo .foo')).to.throw;
+      expect(() => wrapper.find('.foo .foo')).to.throw(Error);
     });
 
   });
@@ -223,9 +223,9 @@ describe('shallow', () => {
       expect(spy.args[1][0]).to.be.instanceOf(ShallowWrapper);
       expect(spy.args[2][0]).to.be.instanceOf(ShallowWrapper);
       expect(spy.args[3][0]).to.be.instanceOf(ShallowWrapper);
-      expect(spy.args[1][0].hasClass('bar')).to.be.true;
-      expect(spy.args[2][0].hasClass('baz')).to.be.true;
-      expect(spy.args[3][0].hasClass('bux')).to.be.true;
+      expect(spy.args[1][0].hasClass('bar')).to.equal(true);
+      expect(spy.args[2][0].hasClass('baz')).to.equal(true);
+      expect(spy.args[3][0].hasClass('bux')).to.equal(true);
     });
 
   });
@@ -267,10 +267,10 @@ describe('shallow', () => {
       }
       const nextProps = { id: 'bar', foo: 'bla' };
       const wrapper = shallow(<Foo id="foo" />);
-      expect(spy.calledOnce).to.be.false;
+      expect(spy.calledOnce).to.equal(false);
       wrapper.setProps(nextProps);
-      expect(spy.calledOnce).to.be.true;
-      expect(spy.calledWith(nextProps)).to.be.true;
+      expect(spy.calledOnce).to.equal(true);
+      expect(spy.calledWith(nextProps)).to.equal(true);
     });
 
   });
@@ -297,7 +297,7 @@ describe('shallow', () => {
 
     it('should throw if it is called when shallow didnt include context', () => {
       const wrapper = shallow(<SimpleComponent />);
-      expect(() => wrapper.setContext({ name: 'bar' })).to.throw;
+      expect(() => wrapper.setContext({ name: 'bar' })).to.throw(Error);
     });
   });
 
@@ -373,17 +373,17 @@ describe('shallow', () => {
   describe('.is(selector)', () => {
     it('should return true when selector matches current element', () => {
       const wrapper = shallow(<div className="foo bar baz" />);
-      expect(wrapper.is('.foo')).to.be.true;
+      expect(wrapper.is('.foo')).to.equal(true);
     });
 
     it('should allow for compound selectors', () => {
       const wrapper = shallow(<div className="foo bar baz" />);
-      expect(wrapper.is('.foo.bar')).to.be.true;
+      expect(wrapper.is('.foo.bar')).to.equal(true);
     });
 
     it('should return false when selector does not match', () => {
       const wrapper = shallow(<div className="bar baz" />);
-      expect(wrapper.is('.foo')).to.be.false;
+      expect(wrapper.is('.foo')).to.equal(false);
     });
   });
 
@@ -457,7 +457,7 @@ describe('shallow', () => {
 
       const baz = wrapper.find('.foo').filterWhere(stub);
       expect(baz.length).to.equal(1);
-      expect(baz.hasClass('baz')).to.be.true;
+      expect(baz.hasClass('baz')).to.equal(true);
     });
 
     it('should call the predicate with the wrapped node as the first argument', () => {
@@ -477,9 +477,9 @@ describe('shallow', () => {
       expect(spy.args[0][0]).to.be.instanceOf(ShallowWrapper);
       expect(spy.args[1][0]).to.be.instanceOf(ShallowWrapper);
       expect(spy.args[2][0]).to.be.instanceOf(ShallowWrapper);
-      expect(spy.args[0][0].hasClass('bar')).to.be.true;
-      expect(spy.args[1][0].hasClass('baz')).to.be.true;
-      expect(spy.args[2][0].hasClass('bux')).to.be.true;
+      expect(spy.args[0][0].hasClass('bar')).to.equal(true);
+      expect(spy.args[1][0].hasClass('baz')).to.equal(true);
+      expect(spy.args[2][0].hasClass('bux')).to.equal(true);
     });
   });
 
@@ -623,9 +623,9 @@ describe('shallow', () => {
         </div>
       );
       expect(wrapper.children().length).to.equal(3);
-      expect(wrapper.children().at(0).hasClass('foo')).to.be.true;
-      expect(wrapper.children().at(1).hasClass('bar')).to.be.true;
-      expect(wrapper.children().at(2).hasClass('baz')).to.be.true;
+      expect(wrapper.children().at(0).hasClass('foo')).to.equal(true);
+      expect(wrapper.children().at(1).hasClass('bar')).to.equal(true);
+      expect(wrapper.children().at(2).hasClass('baz')).to.equal(true);
     });
 
     it('should not return any of the children of children', () => {
@@ -638,8 +638,8 @@ describe('shallow', () => {
         </div>
       );
       expect(wrapper.children().length).to.equal(2);
-      expect(wrapper.children().at(0).hasClass('foo')).to.be.true;
-      expect(wrapper.children().at(1).hasClass('baz')).to.be.true;
+      expect(wrapper.children().at(0).hasClass('foo')).to.equal(true);
+      expect(wrapper.children().at(1).hasClass('baz')).to.equal(true);
     });
 
     it('should handle mixed children with and without arrays', () => {
@@ -660,9 +660,9 @@ describe('shallow', () => {
         ]} />
       );
       expect(wrapper.children().length).to.equal(3);
-      expect(wrapper.children().at(0).hasClass('foo')).to.be.true;
-      expect(wrapper.children().at(1).hasClass('bar')).to.be.true;
-      expect(wrapper.children().at(2).hasClass('baz')).to.be.true;
+      expect(wrapper.children().at(0).hasClass('foo')).to.equal(true);
+      expect(wrapper.children().at(1).hasClass('bar')).to.equal(true);
+      expect(wrapper.children().at(2).hasClass('baz')).to.equal(true);
     });
 
     it('should optionally allow a selector to filter by', () => {
@@ -675,8 +675,8 @@ describe('shallow', () => {
       );
       const children = wrapper.children('.bip');
       expect(children.length).to.equal(2);
-      expect(children.at(0).hasClass('bar')).to.be.true;
-      expect(children.at(1).hasClass('baz')).to.be.true;
+      expect(children.at(0).hasClass('bar')).to.equal(true);
+      expect(children.at(1).hasClass('baz')).to.equal(true);
     });
   });
 
@@ -695,9 +695,9 @@ describe('shallow', () => {
       const parents = wrapper.find('.baz').parents();
 
       expect(parents.length).to.equal(3);
-      expect(parents.at(0).hasClass('bar')).to.be.true;
-      expect(parents.at(1).hasClass('foo')).to.be.true;
-      expect(parents.at(2).hasClass('bax')).to.be.true;
+      expect(parents.at(0).hasClass('bar')).to.equal(true);
+      expect(parents.at(1).hasClass('foo')).to.equal(true);
+      expect(parents.at(2).hasClass('bax')).to.equal(true);
 
     });
 
@@ -715,8 +715,8 @@ describe('shallow', () => {
       const parents = wrapper.find('.bar').parents();
 
       expect(parents.length).to.equal(2);
-      expect(parents.at(0).hasClass('foo')).to.be.true;
-      expect(parents.at(1).hasClass('bax')).to.be.true;
+      expect(parents.at(0).hasClass('foo')).to.equal(true);
+      expect(parents.at(1).hasClass('bax')).to.equal(true);
     });
 
     it('should optionally allow a selector', () => {
@@ -733,8 +733,8 @@ describe('shallow', () => {
       const parents = wrapper.find('.baz').parents('.foo');
 
       expect(parents.length).to.equal(2);
-      expect(parents.at(0).hasClass('foo')).to.be.true;
-      expect(parents.at(1).hasClass('bax')).to.be.true;
+      expect(parents.at(0).hasClass('foo')).to.equal(true);
+      expect(parents.at(1).hasClass('bax')).to.equal(true);
     });
   });
 
@@ -750,7 +750,7 @@ describe('shallow', () => {
         </div>
       );
 
-      expect(wrapper.find('.baz').parent().hasClass('bar')).to.be.true;
+      expect(wrapper.find('.baz').parent().hasClass('bar')).to.equal(true);
     });
 
     it('should work for multiple nodes', () => {
@@ -770,9 +770,9 @@ describe('shallow', () => {
 
       const parents = wrapper.find('.baz').parent();
       expect(parents).to.have.length(3);
-      expect(parents.at(0).hasClass('foo')).to.be.true;
-      expect(parents.at(1).hasClass('bar')).to.be.true;
-      expect(parents.at(2).hasClass('bax')).to.be.true;
+      expect(parents.at(0).hasClass('foo')).to.equal(true);
+      expect(parents.at(1).hasClass('bar')).to.equal(true);
+      expect(parents.at(2).hasClass('bax')).to.equal(true);
     });
   });
 
@@ -789,7 +789,7 @@ describe('shallow', () => {
       );
 
       const closestFoo = wrapper.find('.bar').closest('.foo');
-      expect(closestFoo.hasClass('baz')).to.be.true;
+      expect(closestFoo.hasClass('baz')).to.equal(true);
       expect(closestFoo.length).to.equal(1);
     });
 
@@ -804,7 +804,7 @@ describe('shallow', () => {
         </div>
       );
 
-      expect(wrapper.find('.baz').parent().hasClass('bar')).to.be.true;
+      expect(wrapper.find('.baz').parent().hasClass('bar')).to.equal(true);
     });
 
     it('should return itself if matching', () => {
@@ -818,7 +818,7 @@ describe('shallow', () => {
         </div>
       );
 
-      expect(wrapper.find('.bux').closest('.baz').hasClass('bux')).to.be.true;
+      expect(wrapper.find('.bux').closest('.baz').hasClass('bux')).to.equal(true);
     });
   });
 
@@ -828,12 +828,12 @@ describe('shallow', () => {
         <div className="foo bar baz some-long-string FoOo" />
       );
 
-      expect(wrapper.hasClass('foo')).to.be.true;
-      expect(wrapper.hasClass('bar')).to.be.true;
-      expect(wrapper.hasClass('baz')).to.be.true;
-      expect(wrapper.hasClass('some-long-string')).to.be.true;
-      expect(wrapper.hasClass('FoOo')).to.be.true;
-      expect(wrapper.hasClass('doesnt-exist')).to.be.false;
+      expect(wrapper.hasClass('foo')).to.equal(true);
+      expect(wrapper.hasClass('bar')).to.equal(true);
+      expect(wrapper.hasClass('baz')).to.equal(true);
+      expect(wrapper.hasClass('some-long-string')).to.equal(true);
+      expect(wrapper.hasClass('FoOo')).to.equal(true);
+      expect(wrapper.hasClass('doesnt-exist')).to.equal(false);
     });
   });
 
@@ -852,11 +852,11 @@ describe('shallow', () => {
 
       expect(spy.callCount).to.equal(3);
       expect(spy.args[0][0]).to.be.instanceOf(ShallowWrapper);
-      expect(spy.args[0][0].hasClass('bax')).to.be.true;
+      expect(spy.args[0][0].hasClass('bax')).to.equal(true);
       expect(spy.args[1][0]).to.be.instanceOf(ShallowWrapper);
-      expect(spy.args[1][0].hasClass('bar')).to.be.true;
+      expect(spy.args[1][0].hasClass('bar')).to.equal(true);
       expect(spy.args[2][0]).to.be.instanceOf(ShallowWrapper);
-      expect(spy.args[2][0].hasClass('baz')).to.be.true;
+      expect(spy.args[2][0].hasClass('baz')).to.equal(true);
     });
   });
 
@@ -875,11 +875,11 @@ describe('shallow', () => {
 
       expect(spy.callCount).to.equal(3);
       expect(spy.args[0][0]).to.be.instanceOf(ShallowWrapper);
-      expect(spy.args[0][0].hasClass('bax')).to.be.true;
+      expect(spy.args[0][0].hasClass('bax')).to.equal(true);
       expect(spy.args[1][0]).to.be.instanceOf(ShallowWrapper);
-      expect(spy.args[1][0].hasClass('bar')).to.be.true;
+      expect(spy.args[1][0].hasClass('bar')).to.equal(true);
       expect(spy.args[2][0]).to.be.instanceOf(ShallowWrapper);
-      expect(spy.args[2][0].hasClass('baz')).to.be.true;
+      expect(spy.args[2][0].hasClass('baz')).to.equal(true);
     });
 
     it('should return an array with the mapped values', () => {
@@ -915,11 +915,11 @@ describe('shallow', () => {
 
       expect(spy.callCount).to.equal(3);
       expect(spy.args[0][1]).to.be.instanceOf(ShallowWrapper);
-      expect(spy.args[0][1].hasClass('bax')).to.be.true;
+      expect(spy.args[0][1].hasClass('bax')).to.equal(true);
       expect(spy.args[1][1]).to.be.instanceOf(ShallowWrapper);
-      expect(spy.args[1][1].hasClass('bar')).to.be.true;
+      expect(spy.args[1][1].hasClass('bar')).to.equal(true);
       expect(spy.args[2][1]).to.be.instanceOf(ShallowWrapper);
-      expect(spy.args[2][1].hasClass('baz')).to.be.true;
+      expect(spy.args[2][1].hasClass('baz')).to.equal(true);
     });
 
     it('should accumulate a value', () => {
@@ -961,11 +961,11 @@ describe('shallow', () => {
 
       expect(spy.callCount).to.equal(3);
       expect(spy.args[0][1]).to.be.instanceOf(ShallowWrapper);
-      expect(spy.args[0][1].hasClass('baz')).to.be.true;
+      expect(spy.args[0][1].hasClass('baz')).to.equal(true);
       expect(spy.args[1][1]).to.be.instanceOf(ShallowWrapper);
-      expect(spy.args[1][1].hasClass('bar')).to.be.true;
+      expect(spy.args[1][1].hasClass('bar')).to.equal(true);
       expect(spy.args[2][1]).to.be.instanceOf(ShallowWrapper);
-      expect(spy.args[2][1].hasClass('bax')).to.be.true;
+      expect(spy.args[2][1].hasClass('bax')).to.equal(true);
     });
 
     it('should accumulate a value', () => {
@@ -1001,9 +1001,9 @@ describe('shallow', () => {
           <div className="foo hoo" />
         </div>
       );
-      expect(wrapper.find('.foo').some('.qoo')).to.be.true;
-      expect(wrapper.find('.foo').some('.foo')).to.be.true;
-      expect(wrapper.find('.foo').some('.bar')).to.be.false;
+      expect(wrapper.find('.foo').some('.qoo')).to.equal(true);
+      expect(wrapper.find('.foo').some('.foo')).to.equal(true);
+      expect(wrapper.find('.foo').some('.bar')).to.equal(false);
     });
   });
 
@@ -1016,9 +1016,9 @@ describe('shallow', () => {
           <div className="foo hoo" />
         </div>
       );
-      expect(wrapper.find('.foo').someWhere(n => n.hasClass('qoo'))).to.be.true;
-      expect(wrapper.find('.foo').someWhere(n => n.hasClass('foo'))).to.be.true;
-      expect(wrapper.find('.foo').someWhere(n => n.hasClass('bar'))).to.be.false;
+      expect(wrapper.find('.foo').someWhere(n => n.hasClass('qoo'))).to.equal(true);
+      expect(wrapper.find('.foo').someWhere(n => n.hasClass('foo'))).to.equal(true);
+      expect(wrapper.find('.foo').someWhere(n => n.hasClass('bar'))).to.equal(false);
     });
   });
 
@@ -1031,9 +1031,9 @@ describe('shallow', () => {
           <div className="foo hoo" />
         </div>
       );
-      expect(wrapper.find('.foo').every('.foo')).to.be.true;
-      expect(wrapper.find('.foo').every('.qoo')).to.be.false;
-      expect(wrapper.find('.foo').every('.bar')).to.be.false;
+      expect(wrapper.find('.foo').every('.foo')).to.equal(true);
+      expect(wrapper.find('.foo').every('.qoo')).to.equal(false);
+      expect(wrapper.find('.foo').every('.bar')).to.equal(false);
     });
   });
 
@@ -1046,9 +1046,9 @@ describe('shallow', () => {
           <div className="foo hoo" />
         </div>
       );
-      expect(wrapper.find('.foo').everyWhere(n => n.hasClass('foo'))).to.be.true;
-      expect(wrapper.find('.foo').everyWhere(n => n.hasClass('qoo'))).to.be.false;
-      expect(wrapper.find('.foo').everyWhere(n => n.hasClass('bar'))).to.be.false;
+      expect(wrapper.find('.foo').everyWhere(n => n.hasClass('foo'))).to.equal(true);
+      expect(wrapper.find('.foo').everyWhere(n => n.hasClass('qoo'))).to.equal(false);
+      expect(wrapper.find('.foo').everyWhere(n => n.hasClass('bar'))).to.equal(false);
     });
   });
 
@@ -1074,12 +1074,12 @@ describe('shallow', () => {
       const nodes = wrapper.find('.foo').flatMap(w => w.children().nodes);
 
       expect(nodes.length).to.equal(6);
-      expect(nodes.at(0).hasClass('bar')).to.be.true;
-      expect(nodes.at(1).hasClass('bar')).to.be.true;
-      expect(nodes.at(2).hasClass('baz')).to.be.true;
-      expect(nodes.at(3).hasClass('baz')).to.be.true;
-      expect(nodes.at(4).hasClass('bax')).to.be.true;
-      expect(nodes.at(5).hasClass('bax')).to.be.true;
+      expect(nodes.at(0).hasClass('bar')).to.equal(true);
+      expect(nodes.at(1).hasClass('bar')).to.equal(true);
+      expect(nodes.at(2).hasClass('baz')).to.equal(true);
+      expect(nodes.at(3).hasClass('baz')).to.equal(true);
+      expect(nodes.at(4).hasClass('bax')).to.equal(true);
+      expect(nodes.at(5).hasClass('bax')).to.equal(true);
     });
   });
 
@@ -1122,7 +1122,7 @@ describe('shallow', () => {
           <div className="bar" />
         </div>
       );
-      expect(wrapper.find('.bar').first().hasClass('baz')).to.be.true;
+      expect(wrapper.find('.bar').first().hasClass('baz')).to.equal(true);
     });
   });
 
@@ -1136,7 +1136,7 @@ describe('shallow', () => {
           <div className="bar baz" />
         </div>
       );
-      expect(wrapper.find('.bar').last().hasClass('baz')).to.be.true;
+      expect(wrapper.find('.bar').last().hasClass('baz')).to.equal(true);
     });
   });
 
@@ -1145,8 +1145,8 @@ describe('shallow', () => {
       const wrapper = shallow(
         <div className="foo" />
       );
-      expect(wrapper.find('.bar').isEmpty()).to.be.true;
-      expect(wrapper.find('.foo').isEmpty()).to.be.false;
+      expect(wrapper.find('.bar').isEmpty()).to.equal(true);
+      expect(wrapper.find('.foo').isEmpty()).to.equal(false);
     });
   });
 
@@ -1160,10 +1160,10 @@ describe('shallow', () => {
           <div className="bar baz" />
         </div>
       );
-      expect(wrapper.find('.bar').at(0).hasClass('foo')).to.be.true;
-      expect(wrapper.find('.bar').at(1).hasClass('bax')).to.be.true;
-      expect(wrapper.find('.bar').at(2).hasClass('bux')).to.be.true;
-      expect(wrapper.find('.bar').at(3).hasClass('baz')).to.be.true;
+      expect(wrapper.find('.bar').at(0).hasClass('foo')).to.equal(true);
+      expect(wrapper.find('.bar').at(1).hasClass('bax')).to.equal(true);
+      expect(wrapper.find('.bar').at(2).hasClass('bux')).to.equal(true);
+      expect(wrapper.find('.bar').at(3).hasClass('baz')).to.equal(true);
     });
   });
 

--- a/src/__tests__/Utils-spec.js
+++ b/src/__tests__/Utils-spec.js
@@ -62,7 +62,7 @@ describe('Utils', () => {
       expect(nodeEqual(
         <div />,
         <div />
-      )).to.be.true;
+      )).to.equal(true);
 
     });
 
@@ -71,7 +71,7 @@ describe('Utils', () => {
       expect(nodeEqual(
         <div />,
         <nav />
-      )).to.be.false;
+      )).to.equal(false);
 
     });
 
@@ -80,17 +80,17 @@ describe('Utils', () => {
       expect(nodeEqual(
         <div className="foo" />,
         <div className="foo" />
-      )).to.be.true;
+      )).to.equal(true);
 
       expect(nodeEqual(
         <div id="foo" className="bar" />,
         <div id="foo" className="bar" />
-      )).to.be.true;
+      )).to.equal(true);
 
       expect(nodeEqual(
         <div id="foo" className="baz" />,
         <div id="foo" className="bar" />
-      )).to.be.false;
+      )).to.equal(false);
 
     });
 
@@ -101,7 +101,7 @@ describe('Utils', () => {
           <div />
         </div>,
         <div />
-      )).to.be.false;
+      )).to.equal(false);
 
       expect(nodeEqual(
         <div>
@@ -110,7 +110,7 @@ describe('Utils', () => {
         <div>
           <div />
         </div>
-      )).to.be.true;
+      )).to.equal(true);
 
       expect(nodeEqual(
         <div>
@@ -119,7 +119,7 @@ describe('Utils', () => {
         <div>
           <div className="foo" />
         </div>
-      )).to.be.true;
+      )).to.equal(true);
 
       expect(nodeEqual(
         <div>
@@ -128,7 +128,7 @@ describe('Utils', () => {
         <div>
           <div />
         </div>
-      )).to.be.false;
+      )).to.equal(false);
 
     });
 
@@ -137,12 +137,12 @@ describe('Utils', () => {
       expect(nodeEqual(
         <div foo={{ a: 1, b: 2 }} />,
         <div foo={{ a: 1, b: 2 }} />
-      )).to.be.true;
+      )).to.equal(true);
 
       expect(nodeEqual(
         <div foo={{ a: 2, b: 2 }} />,
         <div foo={{ a: 1, b: 2 }} />
-      )).to.be.false;
+      )).to.equal(false);
 
     });
 
@@ -165,7 +165,7 @@ describe('Utils', () => {
     describe('prohibited selectors', () => {
       function isComplex(selector) {
         it(selector, () => {
-          expect(isSimpleSelector(selector)).to.be.false;
+          expect(isSimpleSelector(selector)).to.equal(false);
         });
       }
 
@@ -181,7 +181,7 @@ describe('Utils', () => {
     describe('allowed selectors', () => {
       function isSimple(selector) {
         it(selector, () => {
-          expect(isSimpleSelector(selector)).to.be.true;
+          expect(isSimpleSelector(selector)).to.equal(true);
         });
       }
 


### PR DESCRIPTION
This enables the `no-unused-expressions` ESLint rule and fixes the corresponding violations. In fixing the errors I stumbled upon two tests that were broken. After discussing with @lelandrichardson, I've inverted the test case as the current behavior is the desired behavior.

Fixes #97