### PR TITLE
Fix `ShallowWrapper.setProps` not passing old context.

### DIFF
--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -133,7 +133,7 @@ export default class ShallowWrapper {
     this.single(() => {
       withSetStateAllowed(() => {
         this.unrendered = React.cloneElement(this.unrendered, props);
-        this.renderer.render(this.unrendered);
+        this.renderer.render(this.unrendered, this.options.context);
         this.update();
       });
     });

--- a/src/__tests__/ShallowWrapper-spec.js
+++ b/src/__tests__/ShallowWrapper-spec.js
@@ -380,10 +380,10 @@ describe('shallow', () => {
 
       const context = { x: 'yolo' };
       const wrapper = shallow(<Foo x={5} />, { context });
-      expect(wrapper.first('div').text(), 'value of context.x should be printed').to.equal('yolo');
+      expect(wrapper.first('div').text()).to.equal('yolo');
 
       wrapper.setProps({ x: 5 }); // Just force a re-render
-      expect(wrapper.first('div').text(), 'context should still be the same').to.equal('yolo');
+      expect(wrapper.first('div').text()).to.equal('yolo');
     });
   });
 

--- a/src/__tests__/ShallowWrapper-spec.js
+++ b/src/__tests__/ShallowWrapper-spec.js
@@ -367,7 +367,7 @@ describe('shallow', () => {
       expect(wrapper.props().d).to.equal('e');
     });
 
-    it('should pass in old context', ( ) => {
+    it('should pass in old context', () => {
       class Foo extends React.Component {
         render() {
           return (

--- a/src/__tests__/ShallowWrapper-spec.js
+++ b/src/__tests__/ShallowWrapper-spec.js
@@ -367,6 +367,24 @@ describe('shallow', () => {
       expect(wrapper.props().d).to.equal('e');
     });
 
+    it('should pass in old context', ( ) => {
+      class Foo extends React.Component {
+        render() {
+          return (
+            <div>{this.context.x}</div>
+          );
+        }
+      }
+
+      Foo.contextTypes = { x: React.PropTypes.string };
+
+      const context = { x: 'yolo' };
+      const wrapper = shallow(<Foo x={5} />, { context });
+      expect(wrapper.first('div').text(), 'value of context.x should be printed').to.equal('yolo');
+
+      wrapper.setProps({ x: 5 }); // Just force a re-render
+      expect(wrapper.first('div').text(), 'context should still be the same').to.equal('yolo');
+    });
   });
 
   describe('.setContext(newContext)', () => {


### PR DESCRIPTION
Resolves https://github.com/airbnb/enzyme/issues/119.