### PR TITLE
Property selector: Throw when using non-literal

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -168,8 +168,17 @@ export function coercePropValue(propValue) {
     return numericPropValue;
   }
 
-  // coerce to boolean
-  return propValue === 'true' ? true : false;
+  if (/true|false/.test(propValue)) {
+    return propValue === 'true' ? true : false;
+  }
+
+  // if none of these match a literal, the api has been used incorrectly
+  // and should throw an error
+  throw new TypeError(
+    'Enzyme::Selector expects a literal value on the right side of the property expression.' +
+    'This error is likely caused by not wrapping a string in quotes.' +
+    'i.e., [foo=bar] should be [foo="bar"].'
+  );
 }
 
 export function mapNativeEventNames(event) {

--- a/src/__tests__/ReactWrapper-spec.js
+++ b/src/__tests__/ReactWrapper-spec.js
@@ -215,6 +215,11 @@ describeWithDOM('mount', () => {
       expect(wrapper.find('[key]')).to.have.length(0);
     });
 
+    it('should throw an error when using property selector with an invalid literal', () => {
+      const wrapper = mount(<div />);
+      expect(() => wrapper.find('[foo=bar]')).to.throw(Error);
+    });
+
 
     it('should find multiple elements based on a class name', () => {
       const wrapper = mount(

--- a/src/__tests__/ShallowTraversal-spec.js
+++ b/src/__tests__/ShallowTraversal-spec.js
@@ -64,13 +64,13 @@ describe('ShallowTraversal', () => {
       const node = (<div onChange={noop} title="foo" />);
 
       expect(nodeHasProperty(node, 'onChange')).to.equal(true);
-      expect(nodeHasProperty(node, 'title', 'foo')).to.equal(true);
+      expect(nodeHasProperty(node, 'title', '"foo"')).to.equal(true);
     });
 
     it('should not match on html attributes', () => {
       const node = (<div htmlFor="foo" />);
 
-      expect(nodeHasProperty(node, 'for', 'foo')).to.equal(false);
+      expect(nodeHasProperty(node, 'for', '"foo"')).to.equal(false);
     });
 
     it('should not find undefined properties', () => {

--- a/src/__tests__/ShallowWrapper-spec.js
+++ b/src/__tests__/ShallowWrapper-spec.js
@@ -233,6 +233,11 @@ describe('shallow', () => {
       expect(wrapper.find('[key]')).to.have.length(0);
     });
 
+    it('should throw an error when using the property selector without a literal', () => {
+      const wrapper = shallow(<div />);
+      expect(() => wrapper.find('[foo=bar]')).to.throw(Error);
+    });
+
     it('should find multiple elements based on a constructor', () => {
       const wrapper = shallow(
         <div>


### PR DESCRIPTION
Fixes #127 by throwing an error when a non-literal value is supplied to the property selector.