### PR TITLE
Possible error in example.

### DIFF
--- a/docs/api/ReactWrapper/setProps.md
+++ b/docs/api/ReactWrapper/setProps.md
@@ -28,7 +28,7 @@ NOTE: can only be called on a wrapper instance that is also the root instance.
 class Foo extends React.Component {
   render() {
     return (
-      <div className={this.state.name}/>
+      <div className={this.props.name}/>
     );
   }
 }


### PR DESCRIPTION
I think in this example the className attribute should contain the name prop rather than the state name.