### PR TITLE
Fix shallowwrapper not calling events with lowercase names

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -86,7 +86,8 @@ export function nodeEqual(a, b) {
 // 'click' => 'onClick'
 // 'mouseEnter' => 'onMouseEnter'
 export function propFromEvent(event) {
-  return `on${event[0].toUpperCase()}${event.substring(1)}`;
+  const nativeEvent = mapNativeEventNames(event);
+  return `on${nativeEvent[0].toUpperCase()}${nativeEvent.substring(1)}`;
 }
 
 export function withSetStateAllowed(fn) {

--- a/src/__tests__/ShallowWrapper-spec.js
+++ b/src/__tests__/ShallowWrapper-spec.js
@@ -577,6 +577,42 @@ describe('shallow', () => {
       expect(spy.args[0][1]).to.equal(b);
     });
 
+    describe('Normalizing JS event names', () => {
+      it('should convert lowercase events to React camelcase', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          render() {
+            return (
+              <a onDoubleClick={spy}>foo</a>
+            );
+          }
+        }
+
+        const wrapper = shallow(<Foo />);
+
+        wrapper.simulate('doubleclick');
+        expect(spy.calledOnce).to.equal(true);
+      });
+
+      describeIf(!REACT013, 'normalizing mouseenter', () => {
+        it('should convert lowercase events to React camelcase', () => {
+          const spy = sinon.spy();
+          class Foo extends React.Component {
+            render() {
+              return (
+                <a onMouseEnter={spy}>foo</a>
+              );
+            }
+          }
+
+          const wrapper = shallow(<Foo />);
+
+          wrapper.simulate('mouseenter');
+          expect(spy.calledOnce).to.equal(true);
+        });
+      });
+    });
+
   });
 
   describe('.setState(newState)', () => {


### PR DESCRIPTION
When using the ShallowHelper you could not use lowercase event names such as `keydown`. This is because the propsFromEvent function is expecting the camelcased version.
To fix run the event through mapToNativeEventNames.