### PR TITLE
Mention chai-enzyme in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ compatible with all major test runners and assertion libraries out there. The do
 examples for enzyme use [mocha](https://mochajs.org/) and [chai](http://chaijs.com/), but you
 should be able to extrapolate to your framework of choice.
 
+If you are interesting in using enzyme with custom Chai.js assertions and convenience functions for
+testing your React components, you can consider using [chai-enzyme](https://github.com/producthunt/chai-enzyme).
 
 
 ### [Installation](/docs/installation/README.md)


### PR DESCRIPTION
Mentions [chai-enzyme](https://github.com/producthunt/chai-enzyme) in the readme.

If you think the wording is wrong, feel free to suggest any other text and I'll be happy to change (or move to a different place).

We could even go stronger in wording if we want to push users more towards the usage of the library:

> For convenience functions implementated as Chai.js custom assertions install [chai-enzyme](https://github.com/producthunt/chai-enzyme).
