### PR TITLE
fix #145 `contains` does not fail on string input

### DIFF
--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -202,13 +202,7 @@ export default class ShallowWrapper {
    * @returns {Boolean}
    */
   contains(node) {
-    let nodeToCompare = node;
-
-    if (typeof nodeToCompare === 'number') {
-      nodeToCompare = '' + nodeToCompare;
-    }
-
-    return findWhereUnwrapped(this, other => nodeEqual(nodeToCompare, other)).length > 0;
+    return findWhereUnwrapped(this, other => nodeEqual(node, other)).length > 0;
   }
 
   /**

--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -202,7 +202,13 @@ export default class ShallowWrapper {
    * @returns {Boolean}
    */
   contains(node) {
-    return findWhereUnwrapped(this, other => nodeEqual(node, other)).length > 0;
+    let nodeToCompare = node;
+
+    if (typeof nodeToCompare === 'number') {
+      nodeToCompare = '' + nodeToCompare;
+    }
+
+    return findWhereUnwrapped(this, other => nodeEqual(nodeToCompare, other)).length > 0;
   }
 
   /**

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -64,6 +64,7 @@ export function nodeEqual(a, b) {
   if (a === b) return true;
   if (!a || !b) return false;
   if (a.type !== b.type) return false;
+
   const left = propsOfNode(a);
   const leftKeys = Object.keys(left);
   const right = propsOfNode(b);
@@ -80,7 +81,12 @@ export function nodeEqual(a, b) {
       return false;
     }
   }
-  return leftKeys.length === Object.keys(right).length;
+
+  if (typeof a !== 'string') {
+    return leftKeys.length === Object.keys(right).length;
+  }
+
+  return false;
 }
 
 // 'click' => 'onClick'

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -82,7 +82,7 @@ export function nodeEqual(a, b) {
     }
   }
 
-  if (typeof a !== 'string') {
+  if (typeof a !== 'string' && typeof a !== 'number') {
     return leftKeys.length === Object.keys(right).length;
   }
 

--- a/src/__tests__/ShallowWrapper-spec.js
+++ b/src/__tests__/ShallowWrapper-spec.js
@@ -83,6 +83,20 @@ describe('shallow', () => {
       expect(wrapper.contains(b)).to.equal(true);
     });
 
+    it('should work with strings', () => {
+      const wrapper = shallow(<div>foo</div>);
+
+      expect(wrapper.contains('foo')).to.equal(true);
+      expect(wrapper.contains('bar')).to.equal(false);
+    });
+
+    it('should work with numbers', () => {
+      const wrapper = shallow(<div>1</div>);
+
+      expect(wrapper.contains(1)).to.equal(true);
+      expect(wrapper.contains(2)).to.equal(false);
+    });
+
   });
 
   describe('.equals(node)', () => {

--- a/src/__tests__/ShallowWrapper-spec.js
+++ b/src/__tests__/ShallowWrapper-spec.js
@@ -98,6 +98,23 @@ describe('shallow', () => {
       expect(wrapper.contains('1')).to.equal(false);
     });
 
+    it('should work with nested strings & numbers', () => {
+      const wrapper = shallow(
+        <div>
+          <div>
+            <div>{5}</div>
+          </div>
+          <div>foo</div>
+        </div>
+      );
+
+      expect(wrapper.contains('foo')).to.equal(true);
+      expect(wrapper.contains(<div>foo</div>)).to.equal(true);
+
+      expect(wrapper.contains(5)).to.equal(true);
+      expect(wrapper.contains(<div>{5}</div>)).to.equal(true);
+    });
+
   });
 
   describe('.equals(node)', () => {

--- a/src/__tests__/ShallowWrapper-spec.js
+++ b/src/__tests__/ShallowWrapper-spec.js
@@ -91,10 +91,11 @@ describe('shallow', () => {
     });
 
     it('should work with numbers', () => {
-      const wrapper = shallow(<div>1</div>);
+      const wrapper = shallow(<div>{1}</div>);
 
       expect(wrapper.contains(1)).to.equal(true);
       expect(wrapper.contains(2)).to.equal(false);
+      expect(wrapper.contains('1')).to.equal(false);
     });
 
   });


### PR DESCRIPTION
Also I added a check for number:

```
    it('should work with numbers', () => {
      const wrapper = shallow(<div>1</div>);

      expect(wrapper.contains(1)).to.equal(true);
      expect(wrapper.contains(2)).to.equal(false);
    });
```