### PR TITLE
Make correct output for number children in debug

### DIFF
--- a/src/Debug.js
+++ b/src/Debug.js
@@ -43,8 +43,8 @@ function propsString(node) {
 }
 
 export function debugNode(node, indentLength = 2) {
+  if (typeof node === 'string' || typeof node === 'number') return escape(node);
   if (!node) return '';
-  if (typeof node === 'string') return escape(node);
 
   const children = compact(childrenOfNode(node).map(n => debugNode(n, indentLength)));
   const type = typeName(node);

--- a/src/__tests__/Debug-spec.js
+++ b/src/__tests__/Debug-spec.js
@@ -112,6 +112,22 @@ describe('debug', () => {
       );
     });
 
+    it('should render number children properly', () => {
+      expect(debugNode(
+        <div>
+          {-1}
+          {0}
+          {1}
+        </div>
+      )).to.equal(
+`<div>
+  -1
+  0
+  1
+</div>`
+      );
+    });
+
     it('renders html entities properly', () => {
       expect(debugNode(
         <div>&gt;</div>
@@ -124,7 +140,12 @@ describe('debug', () => {
 
     it('should not render falsy children ', () => {
       expect(debugNode(
-        <div id="foo">{false}</div>
+        <div id="foo">
+          {false}
+          {null}
+          {undefined}
+          {''}
+        </div>
       )).to.equal(
 `<div id="foo" />`
       );


### PR DESCRIPTION
Now we have strange `<undefined />` tag instead of child of number type. This PR should fix it.