### PR TITLE
Make correct output for component name in debug

### DIFF
--- a/src/Debug.js
+++ b/src/Debug.js
@@ -8,7 +8,7 @@ import { without, escape, compact } from 'underscore';
 
 export function typeName(node) {
   return typeof node.type === 'function'
-    ? (node.type.displayName || 'Component')
+    ? (node.type.displayName || node.type.name || 'Component')
     : node.type;
 }
 

--- a/src/__tests__/Debug-spec.js
+++ b/src/__tests__/Debug-spec.js
@@ -5,6 +5,8 @@ import {
   indent,
   debugNode,
 } from '../Debug';
+import { itIf } from './_helpers';
+import { REACT013 } from '../version';
 
 describe('debug', () => {
 
@@ -80,7 +82,40 @@ describe('debug', () => {
       class Foo extends React.Component {
         render() { return <div />; }
       }
-      Foo.displayName = 'Foo'; // TODO(lmr): why do i have to do this...?
+      Foo.displayName = 'Bar';
+
+      expect(debugNode(
+        <div>
+          <Foo />
+        </div>
+      )).to.equal(
+`<div>
+  <Bar />
+</div>`
+      );
+
+    });
+
+    it('should render composite components as tags w/ name', () => {
+      class Foo extends React.Component {
+        render() { return <div />; }
+      }
+
+      expect(debugNode(
+        <div>
+          <Foo />
+        </div>
+      )).to.equal(
+`<div>
+  <Foo />
+</div>`
+      );
+
+    });
+
+    itIf(!REACT013, 'should render stateless components as tags w/ name', () => {
+
+      const Foo = () => <div />;
 
       expect(debugNode(
         <div>

--- a/src/__tests__/_helpers.js
+++ b/src/__tests__/_helpers.js
@@ -9,3 +9,15 @@ export function describeIf(test, a, b) {
     describe.skip(a, b);
   }
 }
+
+/**
+ * Simple wrapper around mocha it which allows a boolean to be passed in first which
+ * determines whether or not the test will be run
+ */
+export function itIf(test, a, b) {
+  if (test) {
+    it(a, b);
+  } else {
+    it.skip(a, b);
+  }
+}


### PR DESCRIPTION
Composite components without `displayName` property are output as `<Component />` now. Debug can rely of `name` property of component if it is a class or a function and output it as component name.