### PR TITLE
attachTo option for mount/ReactWrapper

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -91,6 +91,7 @@
     * [every(selector)](/docs/api/ReactWrapper/every.md)
     * [everyWhere(selector)](/docs/api/ReactWrapper/everyWhere.md)
     * [ref(refName)](/docs/api/ReactWrapper/ref.md)
+    * [detach()](/docs/api/ReactWrapper/detach.md)
   * [Static Rendering](/docs/api/render.md)
   * [Selectors](/docs/api/selector.md)
 * [Change Log](/CHANGELOG.md)

--- a/docs/api/ReactWrapper/detach.md
+++ b/docs/api/ReactWrapper/detach.md
@@ -1,0 +1,65 @@
+# `.detach() => void`
+
+Detaches the react tree from the DOM. Runs `ReactDOM.unmountComponentAtNode()` under the hood.
+
+This method will most commonly be used as a "cleanup" method if you decide to use the
+`attachTo` option in `mount(node, options)`.
+
+The method is intentionally not "fluent" (in that it doesn't return `this`) because you should
+not be doing anything with this wrapper after this method is called.
+
+Using the `attachTo` is not generally recommended unless it is absolutely necessary to test 
+something.  It is your responsibility to clean up after yourself at the end of the test if you do
+decide to use it, though.
+
+
+#### Examples
+
+
+With the `attachTo` option, you can mount components to attached DOM elements:
+```jsx
+// render a component directly into document.body
+const wrapper = mount(<Bar />, { attachTo: document.body });
+
+// we can see that the component is rendered into the document
+expect(wrapper.find('.in-bar')).to.have.length(1);
+expect(document.body.childNodes).to.have.length(1);
+
+// detach it to clean up after yourself
+wrapper.detach();
+
+// now we can see that 
+expect(document.body.childNodes).to.have.length(0);
+```
+
+Similarly, if you want to create some one-off elements for your test to mount into:
+```jsx
+// create a div in the document to mount into
+const div = global.document.createElement('div');
+global.document.body.appendChild(div);
+
+// div is empty. body has the div attached.
+expect(document.body.childNodes).to.have.length(1);
+expect(div.childNodes).to.have.length(0);
+
+// mount a component passing div into the `attachTo` option
+const wrapper = mount(<Foo />, { attachTo: div });
+
+// we can see now the component is rendered into the document
+expect(wrapper.find('.in-foo')).to.have.length(1);
+expect(document.body.childNodes).to.have.length(1);
+expect(div.childNodes).to.have.length(1);
+
+// call detach to clean up
+wrapper.detach();
+
+// div is now empty, but still attached to the document
+expect(document.body.childNodes).to.have.length(1);
+expect(div.childNodes).to.have.length(0);
+
+// remove div if you want
+global.document.body.removeChild(div);
+
+expect(document.body.childNodes).to.have.length(0);
+expect(div.childNodes).to.have.length(0);
+```

--- a/docs/api/mount.md
+++ b/docs/api/mount.md
@@ -44,6 +44,7 @@ describe('<Foo />', () => {
 1. `node` (`ReactElement`): The node to render
 2. `options` (`Object` [optional]):
 - `options.context`: (`Object` [optional]): Context to be passed into the component
+- `options.attachTo`: (`DOMElement` [optional]): DOM Element to attach the component to.
 
 #### Returns
 
@@ -177,3 +178,6 @@ Returns whether or not any of the nodes in the wrapper pass the provided predica
 
 #### [`ref(refName) => ReactWrapper`](/docs/api/ReactWrapper/ref.md)
 Returns a wrapper of the node that matches the provided reference name.
+
+#### [`.detach() => void`](ReactWrapper/detach.md)
+Unmount the component from the DOM node it's attached to.

--- a/src/ReactWrapper.js
+++ b/src/ReactWrapper.js
@@ -12,9 +12,10 @@ import {
   getNode,
 } from './MountedTraversal';
 import {
-  renderIntoDocument,
+  renderWithOptions,
   Simulate,
   findDOMNode,
+  unmountComponentAtNode,
 } from './react-compat';
 import {
   mapNativeEventNames,
@@ -63,13 +64,13 @@ export default class ReactWrapper {
 
     if (!root) {
       const ReactWrapperComponent = createWrapperComponent(nodes, options);
-      this.component = renderIntoDocument(
+      this.component = renderWithOptions(
         <ReactWrapperComponent
           Component={nodes.type}
           props={nodes.props}
           context={options.context}
-        />
-      );
+        />,
+      options);
       this.root = this;
       this.node = this.component.getWrappedComponent();
       this.nodes = [this.node];
@@ -710,5 +711,27 @@ export default class ReactWrapper {
    */
   debug() {
     return debugInsts(this.nodes);
+  }
+
+  /**
+   * Detaches the react tree from the DOM. Runs `ReactDOM.unmountComponentAtNode()` under the hood.
+   *
+   * This method will most commonly be used as a "cleanup" method if you decide to use the
+   * `attachTo` option in `mount(node, options)`.
+   *
+   * The method is intentionally not "fluent" (in that it doesn't return `this`) because you should
+   * not be doing anything with this wrapper after this method is called.
+   */
+  detach() {
+    if (this.root !== this) {
+      throw new Error('ReactWrapper::detach() can only be called on the root');
+    }
+    if (!this.options.attachTo) {
+      throw new Error(
+        'ReactWrapper::detach() can only be called on when the `attachTo` option was passed into ' +
+        '`mount()`.'
+      );
+    }
+    unmountComponentAtNode(this.options.attachTo);
   }
 }

--- a/src/__tests__/ReactWrapper-spec.js
+++ b/src/__tests__/ReactWrapper-spec.js
@@ -1546,4 +1546,94 @@ describeWithDOM('mount', () => {
     });
   });
 
+  describe('attachTo option', () => {
+    it('should attach and stuff', () => {
+      class Foo extends React.Component {
+        render() {
+          return (<div className="in-foo" />);
+        }
+      }
+      const div = global.document.createElement('div');
+      global.document.body.appendChild(div);
+
+      expect(document.body.childNodes).to.have.length(1);
+      expect(div.childNodes).to.have.length(0);
+
+      const wrapper = mount(<Foo />, { attachTo: div });
+
+      expect(wrapper.find('.in-foo')).to.have.length(1);
+      expect(document.body.childNodes).to.have.length(1);
+      expect(div.childNodes).to.have.length(1);
+
+      wrapper.detach();
+
+      expect(document.body.childNodes).to.have.length(1);
+      expect(div.childNodes).to.have.length(0);
+
+      global.document.body.removeChild(div);
+
+      expect(document.body.childNodes).to.have.length(0);
+      expect(div.childNodes).to.have.length(0);
+    });
+
+    it('should allow for multiple attaches/detaches on same node', () => {
+      class Foo extends React.Component {
+        render() {
+          return (<div className="in-foo" />);
+        }
+      }
+      class Bar extends React.Component {
+        render() {
+          return (<section className="in-bar" />);
+        }
+      }
+      let wrapper;
+      const div = global.document.createElement('div');
+      global.document.body.appendChild(div);
+
+      expect(document.body.childNodes).to.have.length(1);
+      expect(div.childNodes).to.have.length(0);
+
+      wrapper = mount(<Foo />, { attachTo: div });
+
+      expect(wrapper.find('.in-foo')).to.have.length(1);
+      expect(document.body.childNodes).to.have.length(1);
+      expect(div.childNodes).to.have.length(1);
+
+      wrapper.detach();
+
+      wrapper = mount(<Bar />, { attachTo: div });
+
+      expect(wrapper.find('.in-bar')).to.have.length(1);
+      expect(document.body.childNodes).to.have.length(1);
+      expect(div.childNodes).to.have.length(1);
+
+      wrapper.detach();
+
+      expect(document.body.childNodes).to.have.length(1);
+      expect(div.childNodes).to.have.length(0);
+
+      global.document.body.removeChild(div);
+
+      expect(document.body.childNodes).to.have.length(0);
+      expect(div.childNodes).to.have.length(0);
+    });
+
+    it('will attach to the body successfully', () => {
+      class Bar extends React.Component {
+        render() {
+          return (<section className="in-bar" />);
+        }
+      }
+      const wrapper = mount(<Bar />, { attachTo: document.body });
+
+      expect(wrapper.find('.in-bar')).to.have.length(1);
+      expect(document.body.childNodes).to.have.length(1);
+
+      wrapper.detach();
+
+      expect(document.body.childNodes).to.have.length(0);
+    });
+  });
+
 });

--- a/src/react-compat.js
+++ b/src/react-compat.js
@@ -9,6 +9,8 @@ let findDOMNode;
 let React;
 let ReactContext;
 let childrenToArray;
+let renderWithOptions;
+let unmountComponentAtNode;
 
 React = require('react');
 
@@ -16,6 +18,7 @@ if (REACT013) {
   renderToStaticMarkup = React.renderToStaticMarkup;
   /* eslint-disable react/no-deprecated */
   findDOMNode = React.findDOMNode;
+  unmountComponentAtNode = React.unmountComponentAtNode;
   /* eslint-enable react/no-deprecated */
   TestUtils = require('react/addons').addons.TestUtils;
   ReactContext = require('react/lib/ReactContext');
@@ -50,9 +53,18 @@ if (REACT013) {
     }
     return results;
   };
+
+  renderWithOptions = (node, options) => {
+    if (options.attachTo) {
+      return React.render(node, options.attachTo);
+    }
+    return TestUtils.renderIntoDocument(node);
+  };
 } else {
+  const ReactDOM = require('react-dom');
   renderToStaticMarkup = require('react-dom/server').renderToStaticMarkup;
-  findDOMNode = require('react-dom').findDOMNode;
+  findDOMNode = ReactDOM.findDOMNode;
+  unmountComponentAtNode = ReactDOM.unmountComponentAtNode;
   // We require the testutils, but they don't come with 0.14 out of the box, so we
   // require them here through this node module. The bummer is that we are not able
   // to list this as a dependency in package.json and have 0.13 work properly.
@@ -92,6 +104,13 @@ if (REACT013) {
   };
   renderIntoDocument = TestUtils.renderIntoDocument;
   childrenToArray = React.Children.toArray;
+
+  renderWithOptions = (node, options) => {
+    if (options.attachTo) {
+      return ReactDOM.render(node, options.attachTo);
+    }
+    return TestUtils.renderIntoDocument(node);
+  };
 }
 
 const {
@@ -121,4 +140,6 @@ export {
   findDOMNode,
   findAllInRenderedTree,
   childrenToArray,
+  renderWithOptions,
+  unmountComponentAtNode,
 };


### PR DESCRIPTION
to: @ljharb @goatslacker 
cc: @lencioni

Adds an optional API to render the components to a DOM element attached to the DOM. This will allow the user to test a couple of things they can't currently test such as focus state, computed style, etc.