### PR TITLE
Prevent null or false nodes from being passed into tree traversal

### DIFF
--- a/src/ShallowTraversal.js
+++ b/src/ShallowTraversal.js
@@ -28,7 +28,9 @@ export function hasClassName(node, className) {
 }
 
 export function treeForEach(tree, fn) {
-  fn(tree);
+  if (tree !== null && tree !== false) {
+    fn(tree);
+  }
   childrenOfNode(tree).forEach(node => treeForEach(node, fn));
 }
 

--- a/src/__tests__/ReactWrapper-spec.js
+++ b/src/__tests__/ReactWrapper-spec.js
@@ -444,6 +444,22 @@ describeWithDOM('mount', () => {
         expect(foundNotSpan).to.have.length(0);
       });
     });
+
+    it('should not pass in null or false nodes', () => {
+      const wrapper = mount(
+        <div>
+          <div className="foo bar" />
+          {null}
+          {false}
+        </div>
+      );
+      const stub = sinon.stub();
+      stub.returns(true);
+      const spy = sinon.spy(stub);
+      wrapper.findWhere(spy);
+      expect(spy.callCount).to.equal(2);
+    });
+
   });
 
   describe('.setProps(newProps)', () => {

--- a/src/__tests__/ShallowWrapper-spec.js
+++ b/src/__tests__/ShallowWrapper-spec.js
@@ -531,6 +531,22 @@ describe('shallow', () => {
         expect(foundNotSpan).to.have.length(0);
       });
     });
+
+    it('should not pass in null or false nodes', () => {
+      const wrapper = shallow(
+        <div>
+          <div className="foo bar" />
+          {null}
+          {false}
+        </div>
+      );
+      const stub = sinon.stub();
+      stub.returns(true);
+      const spy = sinon.spy(stub);
+      wrapper.findWhere(spy);
+      expect(spy.callCount).to.equal(2);
+    });
+
   });
 
   describe('.setProps(newProps)', () => {


### PR DESCRIPTION
cc: @ljharb 

Fixes #166 