### PR TITLE
Update Jest docs

### DIFF
--- a/docs/guides/jest.md
+++ b/docs/guides/jest.md
@@ -22,7 +22,9 @@ several modules to be unmocked in your `package.json`:
     "object.assign",
     "define-properties",
     "function-bind",
-    "object-keys"
+    "object-keys",
+    "object.values",
+    "es-abstract"
   ]
 }
 ```


### PR DESCRIPTION
This commit adds 2 modules that should not be mocked by default in jest.

closes: https://github.com/airbnb/enzyme/issues/179