### PR TITLE
Fix cannot find module 'underscore'

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -1,5 +1,5 @@
 /* eslint no-use-before-define:0 */
-import { isEqual } from 'underscore';
+import isEqual from 'lodash/isEqual';
 import {
   isDOMComponent,
   findDOMNode,


### PR DESCRIPTION
I think enzyme already switched from `underscore` to `lodash`.

```
➜  npm test

> enzyme@2.0.0 test /Users/koba04/github/enzyme
> npm run lint && npm run test:only


> enzyme@2.0.0 lint /Users/koba04/github/enzyme
> eslint src/**


> enzyme@2.0.0 test:only /Users/koba04/github/enzyme
> mocha --require withDom.js --compilers js:babel-core/register --recursive test/*.js

module.js:340
    throw err;
    ^

Error: Cannot find module 'underscore'
```