### PR TITLE
Fix props() and debug() for SFCs

### DIFF
--- a/src/Debug.js
+++ b/src/Debug.js
@@ -89,11 +89,11 @@ export function debugInst(inst, indentLength = 2) {
   const publicInst = inst.getPublicInstance();
 
   if (typeof publicInst === 'string' || typeof publicInst === 'number') return escape(publicInst);
-  if (!publicInst) return '';
+  if (!publicInst && !inst._renderedComponent) return '';
 
   // do stuff with publicInst
   const currentElement = inst._currentElement;
-  const type = typeName(currentElement);
+  const type = typeName(currentElement) || inst._renderedComponent._tag;
   const props = propsString(currentElement);
   const children = [];
   if (isDOMComponent(publicInst)) {

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -17,6 +17,9 @@ export function propsOfNode(node) {
   if (node && node._reactInternalComponent && node._reactInternalComponent._currentElement) {
     return (node._reactInternalComponent._currentElement.props) || {};
   }
+  if (node && node._currentElement) {
+    return (node._currentElement.props) || {};
+  }
   return (node && node.props) || {};
 }
 

--- a/test/ReactWrapper-spec.js
+++ b/test/ReactWrapper-spec.js
@@ -466,7 +466,7 @@ describeWithDOM('mount', () => {
         expect(foundNotSpan).to.have.length(0);
       });
 
-      it('should return props object when debug() is called', () => {
+      it('should return props object when props() is called', () => {
         const SFC = function SFC({ selector }) {
           return (
             <div data-foo={selector}>Test SFC</div>
@@ -476,6 +476,18 @@ describeWithDOM('mount', () => {
         const selector = 'blah';
         const wrapper = mount(<SFC data-foo={selector} />);
         expect(wrapper.props()).to.deep.equal({ 'data-foo' : selector });
+      });
+
+      it.only('should return shallow rendered string when debug() is called', () => {
+        const SFC = function SFC({ data }) {
+          return (
+            <div data-foo={data}>Test SFC</div>
+          );
+        };
+
+        const content = 'blah';
+        const wrapper = mount(<SFC data={content} />);
+        expect(wrapper.debug()).to.equal('<SFC data="' + content + '">\n  <div data-foo="' + content + '">\n    Test SFC\n  </div>\n</SFC>');
       });
     });
 

--- a/test/ReactWrapper-spec.js
+++ b/test/ReactWrapper-spec.js
@@ -465,6 +465,18 @@ describeWithDOM('mount', () => {
         ));
         expect(foundNotSpan).to.have.length(0);
       });
+
+      it('should return props object when debug() is called', () => {
+        const SFC = function SFC({ selector }) {
+          return (
+            <div data-foo={selector}>Test SFC</div>
+          );
+        };
+
+        const selector = 'blah';
+        const wrapper = mount(<SFC data-foo={selector} />);
+        expect(wrapper.props()).to.deep.equal({ 'data-foo' : selector });
+      });
     });
 
     it('should not pass in null or false nodes', () => {

--- a/test/ReactWrapper-spec.js
+++ b/test/ReactWrapper-spec.js
@@ -475,7 +475,7 @@ describeWithDOM('mount', () => {
 
         const content = 'blah';
         const wrapper = mount(<SFC data={content} />);
-        expect(wrapper.props()).to.deep.equal({ 'data' : content });
+        expect(wrapper.props()).to.deep.equal({ data: content });
       });
 
       it('should return shallow rendered string when debug() is called', () => {

--- a/test/ReactWrapper-spec.js
+++ b/test/ReactWrapper-spec.js
@@ -467,18 +467,18 @@ describeWithDOM('mount', () => {
       });
 
       it('should return props object when props() is called', () => {
-        const SFC = function SFC({ selector }) {
+        const SFC = function SFC({ data }) {
           return (
-            <div data-foo={selector}>Test SFC</div>
+            <div data-foo={data}>Test SFC</div>
           );
         };
 
-        const selector = 'blah';
-        const wrapper = mount(<SFC data-foo={selector} />);
-        expect(wrapper.props()).to.deep.equal({ 'data-foo' : selector });
+        const content = 'blah';
+        const wrapper = mount(<SFC data={content} />);
+        expect(wrapper.props()).to.deep.equal({ 'data' : content });
       });
 
-      it.only('should return shallow rendered string when debug() is called', () => {
+      it('should return shallow rendered string when debug() is called', () => {
         const SFC = function SFC({ data }) {
           return (
             <div data-foo={data}>Test SFC</div>


### PR DESCRIPTION
Mounted wrappers for Stateless Function Components now return expected values for props() and debug(), where before they returned empty values. (addresses #134)