### PR TITLE
Add “In the Wild” section

### DIFF
--- a/INTHEWILD.md
+++ b/INTHEWILD.md
@@ -1,0 +1,9 @@
+Please use [pull requests](https://github.com/airbnb/enzyme/pull/new/master) to add your organization and/or project to this document!
+
+Organizations
+----------
+ - [Airbnb](https://github.com/airbnb)
+
+Projects
+----------
+ - [Rheostat](https://github.com/airbnb/rheostat)

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ describe('<Foo />', () => {
     wrapper.find('button').simulate('click');
     expect(onButtonClick.calledOnce).to.equal(true);
   });
-  
+
   it('calls componentDidMount', () => {
     sinon.spy(Foo.prototype, 'componentDidMount');
     const wrapper = mount(<Foo />);
@@ -173,7 +173,9 @@ Read the full [API Documentation](/docs/api/render.md)
 
 See the [Contributors Guide](/CONTRIBUTING.md)
 
+### In the wild
 
+Organizations and projects using `enzyme` can list themselves [here](INTHEWILD.md).
 
 ### License
 


### PR DESCRIPTION
The idea is that companies and/or projects can list themselves here, just like https://github.com/airbnb/javascript#in-the-wild,  https://github.com/airbnb/aerosolve/pull/103, and https://github.com/airbnb/airpal/pull/164.

It's in a separate file so that PRs to it don't have to touch the main README.