### PR TITLE
Fix typos in shallow/ShallowWrapper docs

### DIFF
--- a/docs/api/ShallowWrapper/filterWhere.md
+++ b/docs/api/ShallowWrapper/filterWhere.md
@@ -21,7 +21,7 @@ provided predicate function, return true.
 ```jsx
 const wrapper = shallow(<MyComponent />);
 const complexFoo = wrapper.find('.foo').filterWhere(n => typeof n.type() !== 'string');
-expect(complexComponents).to.have.length(4);
+expect(complexFoo).to.have.length(4);
 ```
 
 

--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -40,7 +40,7 @@ describe('<MyComponent />', () => {
 
 ```
 
-## `shallow(node[, options]) => ReactWrapper`
+## `shallow(node[, options]) => ShallowWrapper`
 
 #### Arguments
 


### PR DESCRIPTION
* The object returned from `shallow` is a `ShallowWrapper`, not `ReactWrapper`
* `complexFoo` is defined in an example in `filterWhere.md`, but `complexComponents` is asserted