### PR TITLE
Update jest.md for Jest 0.9

### DIFF
--- a/docs/guides/jest.md
+++ b/docs/guides/jest.md
@@ -1,7 +1,7 @@
 # Using Jest with Enzyme
 
 If you are using Jest with enzyme and using Jest's "automocking" feature, you will need to mark
-several modules to be unmocked in your `package.json`:
+react and enzyme to be unmocked in your `package.json`:
 
 ```js
 /* package.json */
@@ -10,20 +10,7 @@ several modules to be unmocked in your `package.json`:
   "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
   "unmockedModulePathPatterns": [
     "react",
-    "react-dom",
-    "react-addons-test-utils",
-    "fbjs",
-    "enzyme",
-    "cheerio",
-    "htmlparser2",
-    "lodash",
-    "domhandler",
-    "object.assign",
-    "define-properties",
-    "function-bind",
-    "object-keys",
-    "object.values",
-    "es-abstract"
+    "enzyme"
   ]
 }
 ```

--- a/docs/guides/jest.md
+++ b/docs/guides/jest.md
@@ -1,6 +1,6 @@
 # Using Jest with Enzyme
 
-If you are using Jest with enzyme and using Jest's "automocking" feature, you will need to mark
+If you are using Jest 0.9+ with enzyme and using Jest's "automocking" feature, you will need to mark
 react and enzyme to be unmocked in your `package.json`:
 
 ```js
@@ -14,6 +14,8 @@ react and enzyme to be unmocked in your `package.json`:
   ]
 }
 ```
+
+If you are using a previous version of Jest together with npm3, you may need to unmock [more modules](https://github.com/airbnb/enzyme/blob/78febd90fe2fb184771b8b0356b0fcffbdad386e/docs/guides/jest.md).
 
 ## Example Projects
 


### PR DESCRIPTION
We finally fixed the npm3 module resolution and we do transitive unmocking of dependencies now.

"react-dom" and "react-addons-test-utils" should be unmocked too, however they aren' part of either react or enzyme so I guess we can remove them from this list too.