### PR TITLE
Fixes version of React in Browserify guide

### DIFF
--- a/docs/guides/browserify.md
+++ b/docs/guides/browserify.md
@@ -33,9 +33,9 @@ b.external('react/lib/ExecutionEnvironment');
 ```
 
 
-## React 0.13 Compatibility
+## React 0.14 Compatibility
 
-If you are using React 0.13, the instructions above will be the same but with a different list of 
+If you are using React 0.14, the instructions above will be the same but with a different list of 
 externals:
 
 ```


### PR DESCRIPTION
The 'Using Enzyme with Browserify' guide specifies that you should make browserify ignore a different set of files if using React 0.13, but these are the files that should be ignored if using 0.14 onwards.