### PR TITLE
Prevent falsy nodes from being counted as children

### DIFF
--- a/src/ShallowTraversal.js
+++ b/src/ShallowTraversal.js
@@ -19,7 +19,11 @@ export function childrenOfNode(node) {
   if (!node) return [];
   const maybeArray = propsOfNode(node).children;
   const result = [];
-  React.Children.forEach(maybeArray, child => result.push(child));
+  React.Children.forEach(maybeArray, child => {
+    if (child !== null && child !== false && typeof child !== 'undefined') {
+      result.push(child);
+    }
+  });
   return result;
 }
 
@@ -29,7 +33,7 @@ export function hasClassName(node, className) {
 }
 
 export function treeForEach(tree, fn) {
-  if (tree !== null && tree !== false) {
+  if (tree !== null && tree !== false && typeof tree !== 'undefined') {
     fn(tree);
   }
   childrenOfNode(tree).forEach(node => treeForEach(node, fn));

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -1019,6 +1019,31 @@ describe('shallow', () => {
       expect(wrapper.children().length).to.equal(0);
     });
 
+    it('should skip the falsy children', () => {
+      const wrapper = shallow(
+        <div>
+          <div>
+            {false}
+            {[false, false]}
+            <p>foo</p>
+          </div>
+          <div>
+            {undefined}
+            {[undefined, undefined]}
+            <p>bar</p>
+          </div>
+          <div>
+            {null}
+            {[null, null]}
+            <p>baz</p>
+          </div>
+        </div>
+      );
+      expect(wrapper.childAt(0).children().length).to.equal(1);
+      expect(wrapper.childAt(1).children().length).to.equal(1);
+      expect(wrapper.childAt(2).children().length).to.equal(1);
+    });
+
     it('should return the children nodes of the root', () => {
       const wrapper = shallow(
         <div>


### PR DESCRIPTION
Like [#151](https://github.com/airbnb/enzyme/issues/151)

I have a problem like below.

```js
test('component should have no children', t => {
    const component = shallow(
        <div>
            {undefined}
            {undefined}
        </div>
    );
    t.same(component.children().length, 0) // This should be success, but fail since length is 1.
});
```

I expect `null`, `undefined` and `false` should not be counted as a child node.
What do you think??