### PR TITLE
Fix children() for stateless children

### DIFF
--- a/src/MountedTraversal.js
+++ b/src/MountedTraversal.js
@@ -125,6 +125,10 @@ export function childrenOfInstInternal(inst) {
       if (REACT013 && !renderedChildren[key].getPublicInstance) {
         continue;
       }
+      if (!REACT013 && typeof renderedChildren[key]._currentElement.type === 'function') {
+        children.push(renderedChildren[key]._instance);
+        continue;
+      }
       children.push(renderedChildren[key].getPublicInstance());
     }
     return children;

--- a/test/ReactWrapper-spec.js
+++ b/test/ReactWrapper-spec.js
@@ -90,6 +90,23 @@ describeWithDOM('mount', () => {
       expect(wrapper.find('.bar')).to.have.length(1);
       expect(wrapper.find('.qoo').text()).to.equal('qux');
     });
+
+    it('works with nested stateless', () => {
+      const TestItem = (props) => (
+        <div className="item">1</div>
+      );
+      const Test = (props) => (
+        <div className="box">
+          <TestItem test="123"/>
+          <TestItem/>
+          <TestItem/>
+        </div>
+      );
+      const wrapper = mount(<Test />);
+      const children = wrapper.find('.box').children();
+      expect(children).to.have.length(3);
+      expect(children.at(0).props().test).to.equal('123');
+    })
   });
 
   describe('.contains(node)', () => {


### PR DESCRIPTION
Children method did not work with nested stateless component. It always returns [null]
This patch fixes it