### PR TITLE
Corrects version of react in webpack.md

### DIFF
--- a/docs/guides/webpack.md
+++ b/docs/guides/webpack.md
@@ -32,9 +32,9 @@ externals: {
 // ...
 ```
 
-## React 0.13 Compatibility
+## React 0.14 Compatibility
 
-If you are using React 0.13, the instructions above will be the same but with a different list of 
+If you are using React 0.14, the instructions above will be the same but with a different list of 
 externals:
 
 ```


### PR DESCRIPTION
As in the Browserify guide: #247, the version of React used in the Webpack documentation is wrong, it should specify 0.14, rather than 0.13