### PR TITLE
Fixing the example for filterWhere

### DIFF
--- a/docs/api/ReactWrapper/filterWhere.md
+++ b/docs/api/ReactWrapper/filterWhere.md
@@ -20,7 +20,7 @@ provided predicate function, return true.
 
 ```jsx
 const wrapper = mount(<MyComponent />);
-const complexFoo = wrapper.find('.foo').filterWhere(n => typeof n.type() !== 'string');
+const complexComponents = wrapper.find('.foo').filterWhere(n => typeof n.type() !== 'string');
 expect(complexComponents).to.have.length(4);
 ```
 


### PR DESCRIPTION
minor fix, variable name.