### PR TITLE
Move React 15 support tests from RC1 to RC2

### DIFF
--- a/docs/installation/react-15.md
+++ b/docs/installation/react-15.md
@@ -1,16 +1,16 @@
 # Working with React 15
 
-If you are wanting to use Enzyme with React 0.14, but don't already have React 15 and react-dom
+If you are wanting to use Enzyme with React 15, but don't already have React 15 and react-dom
 installed, you should do so:
 
 ```bash
-npm i --save react@15.0.0-rc.1 react-dom@15.0.0-rc.1
+npm i --save react@15.0.0-rc.2 react-dom@15.0.0-rc.2
 ```
 
 Further, enzyme requires the test utilities addon be installed:
 
 ```bash
-npm i --save-dev react-addons-test-utils@15.0.0-rc.1
+npm i --save-dev react-addons-test-utils@15.0.0-rc.2
 ```
 
 Next, to get started with enzyme, you can simply install it with npm:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react:clean": "rimraf node_modules/react node_modules/react-dom node_modules/react-addons-test-utils",
     "react:13": "npm run react:clean && npm i react@0.13",
     "react:14": "npm run react:clean && npm i react@0.14 react-dom@0.14 react-addons-test-utils@0.14",
-    "react:15": "npm run react:clean && npm i react@15.0.0-rc.1 react-dom@15.0.0-rc.1 react-addons-test-utils@15.0.0-rc.1",
+    "react:15": "npm run react:clean && npm i react@15.0.0-rc.2 react-dom@15.0.0-rc.2 react-addons-test-utils@15.0.0-rc.2",
     "docs:clean": "rimraf _book",
     "docs:prepare": "gitbook install",
     "docs:build": "npm run docs:prepare && gitbook build",
@@ -80,6 +80,6 @@
     "sinon": "^1.15.4"
   },
   "peerDependencies": {
-    "react": "0.13.x || 0.14.x || 15.* || 15.0.0-rc.1"
+    "react": "0.13.x || 0.14.x || 15.* || 15.0.0-rc.2"
   }
 }


### PR DESCRIPTION
This changes the React 15 support scripts from using RC1 to using RC2. The docs have been updated as well.