### PR TITLE
Fix issue finding nested SFCs by constructor in mount

### DIFF
--- a/src/MountedTraversal.js
+++ b/src/MountedTraversal.js
@@ -5,6 +5,7 @@ import {
   coercePropValue,
   nodeEqual,
   propsOfNode,
+  isFunctionalComponent,
   isSimpleSelector,
   splitSelector,
   selectorError,
@@ -60,12 +61,17 @@ export function instHasId(inst, id) {
   return instId === id;
 }
 
+function isFunctionalComponentWithType(inst, func) {
+  return isFunctionalComponent(inst) && getNode(inst).type === func;
+}
+
 export function instHasType(inst, type) {
   switch (typeof type) {
     case 'string':
       return nodeHasType(getNode(inst), type);
     case 'function':
-      return isCompositeComponentWithType(inst, type);
+      return isCompositeComponentWithType(inst, type) ||
+        isFunctionalComponentWithType(inst, type);
     default:
       return false;
   }
@@ -249,8 +255,7 @@ function findAllInRenderedTreeInternal(inst, test) {
     const internal = internalInstance(inst);
     return findAllInRenderedTreeInternal(internal, test);
   }
-
-  const publicInst = inst.getPublicInstance();
+  const publicInst = inst.getPublicInstance() || inst._instance;
   let ret = test(publicInst) ? [publicInst] : [];
   const currentElement = inst._currentElement;
   if (isDOMComponent(publicInst)) {

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -19,6 +19,10 @@ export function internalInstance(inst) {
     inst[internalInstanceKey(inst)];
 }
 
+export function isFunctionalComponent(inst) {
+  return inst && inst.constructor && inst.constructor.name === 'StatelessComponent';
+}
+
 export function propsOfNode(node) {
   if (REACT013 && node && node._store) {
     return (node._store.props) || {};

--- a/test/ReactWrapper-spec.js
+++ b/test/ReactWrapper-spec.js
@@ -128,6 +128,8 @@ describeWithDOM('mount', () => {
       const children = wrapper.find('.box').children();
       expect(children).to.have.length(3);
       expect(children.at(0).props().test).to.equal('123');
+      expect(wrapper.find(TestItem)).to.have.length(3);
+      expect(wrapper.find(TestItem).first().props().test).to.equal('123');
     });
   });
 


### PR DESCRIPTION
This fixes an issue where calling `.find` with an SFC constructor/function would fail to return instances of the the SFC in the tree.

This seems like a round-about way of getting at this. Is there a better way?

Fixes #262