### PR TITLE
Add options to ShallowWrapper#shallow

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -49,7 +49,7 @@
     * [setContext(context)](/docs/api/ShallowWrapper/setContext.md)
     * [setProps(nextProps)](/docs/api/ShallowWrapper/setProps.md)
     * [setState(nextState)](/docs/api/ShallowWrapper/setState.md)
-    * [shallow()](/docs/api/ShallowWrapper/shallow.md)
+    * [shallow([options])](/docs/api/ShallowWrapper/shallow.md)
     * [simulate(event[, data])](/docs/api/ShallowWrapper/simulate.md)
     * [some(selector)](/docs/api/ShallowWrapper/some.md)
     * [someWhere(predicate)](/docs/api/ShallowWrapper/someWhere.md)

--- a/docs/api/ShallowWrapper/shallow.md
+++ b/docs/api/ShallowWrapper/shallow.md
@@ -1,9 +1,14 @@
-# `.shallow() => ShallowWrapper`
+# `.shallow([options]) => ShallowWrapper`
 
 Shallow renders the current node and returns a shallow wrapper around it.
 
 NOTE: can only be called on wrapper of a single node.
 
+
+#### Arguments
+
+1. `options` (`Object` [optional]):
+- `options.context`: (`Object` [optional]): Context to be passed into the component
 
 
 

--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -97,7 +97,7 @@ Get a wrapper with the direct parent of the current node.
 #### [`.closest(selector) => ShallowWrapper`](ShallowWrapper/closest.md)
 Get a wrapper with the first ancestor of the current node to match the provided selector.
 
-#### [`.shallow() => ShallowWrapper`](ShallowWrapper/shallow.md)
+#### [`.shallow([options]) => ShallowWrapper`](ShallowWrapper/shallow.md)
 Shallow renders the current node and returns a shallow wrapper around it.
 
 #### [`.render() => CheerioWrapper`](ShallowWrapper/render.md)

--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -464,10 +464,11 @@ export default class ShallowWrapper {
    *
    * NOTE: can only be called on wrapper of a single node.
    *
+   * @param options object
    * @returns {ShallowWrapper}
    */
-  shallow() {
-    return this.single((n) => new ShallowWrapper(n));
+  shallow(options) {
+    return this.single((n) => new ShallowWrapper(n, null, options));
   }
 
   /**

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -1802,7 +1802,6 @@ describe('shallow', () => {
   });
 
   describe('.shallow()', () => {
-
     it('should return a shallow rendered instance of the current node', () => {
       class Bar extends React.Component {
         render() {
@@ -1828,6 +1827,80 @@ describe('shallow', () => {
       expect(wrapper.find(Bar).shallow().find('.in-bar')).to.have.length(1);
     });
 
+    describe('context', () => {
+      it('can pass in context', () => {
+        class Bar extends React.Component {
+          render() {
+            return <div>{this.context.name}</div>;
+          }
+        }
+        Bar.contextTypes = {
+          name: React.PropTypes.string,
+        };
+        class Foo extends React.Component {
+          render() {
+            return (
+              <div>
+                <Bar />
+              </div>
+            );
+          }
+        }
+
+        const context = { name: 'foo' };
+        const wrapper = shallow(<Foo />);
+        expect(wrapper.find(Bar)).to.have.length(1);
+        expect(wrapper.find(Bar).shallow({ context }).text()).to.equal('foo');
+      });
+
+      it('should not throw if context is passed in but contextTypes is missing', () => {
+        class Bar extends React.Component {
+          render() {
+            return <div>{this.context.name}</div>;
+          }
+        }
+        class Foo extends React.Component {
+          render() {
+            return (
+              <div>
+                <Bar />
+              </div>
+            );
+          }
+        }
+
+        const context = { name: 'foo' };
+        const wrapper = shallow(<Foo />);
+        expect(() => wrapper.find(Bar).shallow({ context })).to.not.throw(Error);
+      });
+
+      it('is instrospectable through context API', () => {
+        class Bar extends React.Component {
+          render() {
+            return <div>{this.context.name}</div>;
+          }
+        }
+        Bar.contextTypes = {
+          name: React.PropTypes.string,
+        };
+        class Foo extends React.Component {
+          render() {
+            return (
+              <div>
+                <Bar />
+              </div>
+            );
+          }
+        }
+
+        const context = { name: 'foo' };
+        const wrapper = shallow(<Foo />).find(Bar).shallow({ context });
+
+        expect(wrapper.context().name).to.equal(context.name);
+        expect(wrapper.context('name')).to.equal(context.name);
+      });
+    });
+
     describeIf(!REACT013, 'stateless function components', () => {
       it('should return a shallow rendered instance of the current node', () => {
         const Bar = () => (
@@ -1845,6 +1918,57 @@ describe('shallow', () => {
         expect(wrapper.find('.in-bar')).to.have.length(0);
         expect(wrapper.find(Bar)).to.have.length(1);
         expect(wrapper.find(Bar).shallow().find('.in-bar')).to.have.length(1);
+      });
+
+      describe('context', () => {
+        it('can pass in context', () => {
+          const Bar = (props, context) => (
+            <div>{context.name}</div>
+          );
+          Bar.contextTypes = { name: React.PropTypes.string };
+          const Foo = () => (
+            <div>
+              <Bar />
+            </div>
+          );
+
+          const context = { name: 'foo' };
+          const wrapper = shallow(<Foo />);
+          expect(wrapper.find(Bar).shallow({ context }).text()).to.equal('foo');
+        });
+
+        it('should not throw if context is passed in but contextTypes is missing', () => {
+          const Bar = (props, context) => (
+            <div>{context.name}</div>
+          );
+          const Foo = () => (
+            <div>
+              <Bar />
+            </div>
+          );
+
+          const context = { name: 'foo' };
+          const wrapper = shallow(<Foo />);
+          expect(() => wrapper.find(Bar).shallow({ context })).to.not.throw(Error);
+        });
+
+        it('is instrospectable through context API', () => {
+          const Bar = (props, context) => (
+            <div>{context.name}</div>
+          );
+          Bar.contextTypes = { name: React.PropTypes.string };
+          const Foo = () => (
+            <div>
+              <Bar />
+            </div>
+          );
+
+          const context = { name: 'foo' };
+          const wrapper = shallow(<Foo />).find(Bar).shallow({ context });
+
+          expect(wrapper.context().name).to.equal(context.name);
+          expect(wrapper.context('name')).to.equal(context.name);
+        });
       });
     });
 


### PR DESCRIPTION
I have just enhanced the `ShallowWrapper#shallow` to support the same `options` arg as the top level `shallow` method.

It is useful when your component is wrapped by an high-order component like the ones provided in popular Flux implementations : 
- http://fluxible.io/addons/connectToStores.html
- https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options

For example :
```javascript
class MyComponent {
  [...]
}
MyComponent.contextTypes = {
  foo: React.PropTypes.string
}

export default connectToStore(MyComponent, [], () => {
  [...]
})
```

Then you can easily shallow render `MyComponent`:
```javascript
const context = {foo: 'bar'};
const wrapper = shallow(MyComponent).shallow({ context })
```

I added the same context tests of `shallow` method to `ShallowWrapper#shallow`.