### PR TITLE
Add second() selector

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -92,6 +92,7 @@
     * [reduceRight(fn[, initialValue])](/docs/api/ReactWrapper/reduceRight.md)
     * [ref(refName)](/docs/api/ReactWrapper/ref.md)
     * [render()](/docs/api/ReactWrapper/render.md)
+    * [second()](/docs/api/ReactWrapper/second.md)
     * [setContext(context)](/docs/api/ReactWrapper/setContext.md)
     * [setProps(nextProps)](/docs/api/ReactWrapper/setProps.md)
     * [setState(nextState)](/docs/api/ReactWrapper/setState.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@
     * [reduce(fn[, initialValue])](/docs/api/ShallowWrapper/reduce.md)
     * [reduceRight(fn[, initialValue])](/docs/api/ShallowWrapper/reduceRight.md)
     * [render()](/docs/api/ShallowWrapper/render.md)
+    * [second()](/docs/api/ShallowWrapper/second.md)
     * [setContext(context)](/docs/api/ShallowWrapper/setContext.md)
     * [setProps(nextProps)](/docs/api/ShallowWrapper/setProps.md)
     * [setState(nextState)](/docs/api/ShallowWrapper/setState.md)

--- a/docs/api/ReactWrapper/second.md
+++ b/docs/api/ReactWrapper/second.md
@@ -1,0 +1,18 @@
+# `.second() => ReactWrapper`
+
+Reduce the set of matched nodes to the second in the set.
+
+
+
+#### Returns
+
+`ReactWrapper`: A new wrapper that wraps the second node in the set.
+
+
+
+#### Examples
+
+```jsx
+const wrapper = mount(<MyComponent />);
+expect(wrapper.find(Foo).second().props().foo).to.equal("bar");
+```

--- a/docs/api/ShallowWrapper/second.md
+++ b/docs/api/ShallowWrapper/second.md
@@ -1,0 +1,18 @@
+# `.second() => ShallowWrapper`
+
+Reduce the set of matched nodes to the second in the set.
+
+
+
+#### Returns
+
+`ShallowWrapper`: A new wrapper that wraps the second node in the set.
+
+
+
+#### Examples
+
+```jsx
+const wrapper = shallow(<MyComponent />);
+expect(wrapper.find(Foo).second().props().foo).to.equal("bar");
+```

--- a/docs/api/mount.md
+++ b/docs/api/mount.md
@@ -114,6 +114,9 @@ Returns a wrapper of the node at the provided index of the current wrapper.
 #### [`.first() => ReactWrapper`](ReactWrapper/first.md)
 Returns a wrapper of the first node of the current wrapper.
 
+#### [`.second() => ReactWrapper`](ReactWrapper/second.md)
+Returns a wrapper of the second node of the current wrapper.
+
 #### [`.last() => ReactWrapper`](ReactWrapper/last.md)
 Returns a wrapper of the last node of the current wrapper.
 

--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -121,6 +121,9 @@ Returns a wrapper of the node at the provided index of the current wrapper.
 #### [`.first() => ShallowWrapper`](ShallowWrapper/first.md)
 Returns a wrapper of the first node of the current wrapper.
 
+#### [`.second() => ReactWrapper`](ReactWrapper/second.md)
+Returns a wrapper of the second node of the current wrapper.
+
 #### [`.last() => ShallowWrapper`](ShallowWrapper/last.md)
 Returns a wrapper of the last node of the current wrapper.
 

--- a/src/ReactWrapper.js
+++ b/src/ReactWrapper.js
@@ -676,6 +676,15 @@ export default class ReactWrapper {
   }
 
   /**
+   * Returns a wrapper around the second node of the current wrapper.
+   *
+   * @returns {ReactWrapper}
+   */
+  second() {
+    return this.at(1);
+  }
+
+  /**
    * Returns a wrapper around the last node of the current wrapper.
    *
    * @returns {ReactWrapper}

--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -661,6 +661,15 @@ export default class ShallowWrapper {
   }
 
   /**
+   * Returns a wrapper around the second node of the current wrapper.
+   *
+   * @returns {ShallowWrapper}
+   */
+  second() {
+    return this.at(1);
+  }
+
+  /**
    * Returns a wrapper around the last node of the current wrapper.
    *
    * @returns {ShallowWrapper}

--- a/test/ReactWrapper-spec.js
+++ b/test/ReactWrapper-spec.js
@@ -1625,6 +1625,20 @@ describeWithDOM('mount', () => {
     });
   });
 
+  describe('.second()', () => {
+    it('should return the second node in the current set', () => {
+      const wrapper = mount(
+        <div>
+          <div className="bar" />
+          <div className="bar baz" />
+          <div className="bar" />
+          <div className="bar" />
+        </div>
+      );
+      expect(wrapper.find('.bar').second().hasClass('baz')).to.equal(true);
+    });
+  });
+
   describe('.last()', () => {
     it('should return the last node in the current set', () => {
       const wrapper = mount(

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -1988,6 +1988,20 @@ describe('shallow', () => {
     });
   });
 
+  describe('.second()', () => {
+    it('should return the second node in the current set', () => {
+      const wrapper = shallow(
+        <div>
+          <div className="bar" />
+          <div className="bar baz" />
+          <div className="bar" />
+          <div className="bar" />
+        </div>
+      );
+      expect(wrapper.find('.bar').second().hasClass('baz')).to.equal(true);
+    });
+  });
+
   describe('.last()', () => {
     it('should return the last node in the current set', () => {
       const wrapper = shallow(


### PR DESCRIPTION
Along with `.first()` and `.last()`, this PR adds a functionality for `.second()` for reducing matched nodes. 

Don't get me wrong, if someone will do a PR with `.third()` or `.before_last()` - I will be totally against this kind of methods. In my mind, `.second()` is nice to have method for many people.