### PR TITLE
adds json to moduleFileExtensions in docs

### DIFF
--- a/docs/guides/jest.md
+++ b/docs/guides/jest.md
@@ -11,6 +11,9 @@ react and enzyme to be unmocked in your `package.json`:
   "unmockedModulePathPatterns": [
     "react",
     "enzyme"
+  ],
+  "moduleFileExtensions": [
+    "json"
   ]
 }
 ```


### PR DESCRIPTION
Fixes issue #286

Under Jest, Enzyme fails to load due to its dependency 'Cheerio', which
requires its package.json file without specifying the '.json' file
extension. This can be mitigated by adding '.json' to the
mduleFileExtension Jest config item in a projet's package.json.