### PR TITLE
Fix pathToNode with a sibling node which has children

### DIFF
--- a/src/ShallowTraversal.js
+++ b/src/ShallowTraversal.js
@@ -49,15 +49,20 @@ export function treeFilter(tree, fn) {
   return results;
 }
 
+function pathFilter(path, fn) {
+  return path.filter(tree => treeFilter(tree, fn).length !== 0);
+}
+
 export function pathToNode(node, root) {
   const queue = [root];
   const path = [];
 
+  const hasNode = (testNode) => node === testNode;
+
   while (queue.length) {
     const current = queue.pop();
     const children = childrenOfNode(current);
-
-    if (current === node) return path;
+    if (current === node) return pathFilter(path, hasNode);
 
     path.push(current);
 

--- a/test/ShallowTraversal-spec.js
+++ b/test/ShallowTraversal-spec.js
@@ -9,6 +9,7 @@ import {
   nodeHasProperty,
   treeForEach,
   treeFilter,
+  pathToNode,
 } from '../src/ShallowTraversal';
 
 describe('ShallowTraversal', () => {
@@ -209,6 +210,45 @@ describe('ShallowTraversal', () => {
     it('should filter for truthiness', () => {
       expect(treeFilter(tree, node => node.type === 'nav').length).to.equal(1);
       expect(treeFilter(tree, node => node.type === 'button').length).to.equal(2);
+    });
+
+  });
+
+  describe('pathToNode', () => {
+    it('should return trees from the root node', () => {
+      const node = <label />;
+      const tree = (
+        <div>
+          <button />
+          <nav>
+            {node}
+            <input />
+          </nav>
+        </div>
+      );
+
+      const result = pathToNode(node, tree);
+      expect(result.length).to.equal(2);
+      expect(result[0].type).to.equal('div');
+      expect(result[1].type).to.equal('nav');
+    });
+
+    it('should return trees from the root node except the sibling node', () => {
+      const node = <label />;
+      const tree = (
+        <div>
+          <button />
+          <nav>
+            {node}
+            <div><input /></div>
+          </nav>
+        </div>
+      );
+
+      const result = pathToNode(node, tree);
+      expect(result.length).to.equal(2);
+      expect(result[0].type).to.equal('div');
+      expect(result[1].type).to.equal('nav');
     });
 
   });

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -1475,6 +1475,23 @@ describe('shallow', () => {
       expect(wrapper.find('.baz').parent().hasClass('bar')).to.equal(true);
     });
 
+    it('should work when the sibling node has children', () => {
+      const wrapper = shallow(
+        <div className="bax">
+          <div className="foo">
+            <div className="bar">
+              <div className="baz" />
+              <div>
+                <div />
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+
+      expect(wrapper.find('.baz').parent().hasClass('bar')).to.equal(true);
+    });
+
     it('should work for multiple nodes', () => {
       const wrapper = shallow(
         <div>


### PR DESCRIPTION
Currently, the following test is failed.

```js
const wrapper = shallow(
  <div className="bax">
    <div className="foo">
      <div className="bar">
        <div className="baz" />
        <div>
          <div />
        </div>
      </div>
    </div>
  </div>
);

expect(wrapper.find('.baz').parent().hasClass('bar')).to.equal(true);
```

This is because `pathToNode` returns trees which are including the sibling node.
This PR makes `pathToNode` return only nodes including the current node.

Thanks