### PR TITLE
Fix ESLint errors

### DIFF
--- a/src/MountedTraversal.js
+++ b/src/MountedTraversal.js
@@ -229,6 +229,7 @@ export function buildInstPredicate(selector) {
           // selector is a string. match to DOM tag or constructor displayName
           return inst => instHasType(inst, selector);
       }
+      break;
 
     case 'object':
       if (!Array.isArray(selector) && selector !== null && !isEmpty(selector)) {

--- a/src/ShallowTraversal.js
+++ b/src/ShallowTraversal.js
@@ -135,6 +135,7 @@ export function buildPredicate(selector) {
           // selector is a string. match to DOM tag or constructor displayName
           return node => nodeHasType(node, selector);
       }
+      break;
 
     case 'object':
       if (!Array.isArray(selector) && selector !== null && !isEmpty(selector)) {

--- a/test/_helpers.js
+++ b/test/_helpers.js
@@ -61,4 +61,3 @@ export function describeWithDOM(a, b) {
 
 describeWithDOM.only = only;
 describeWithDOM.skip = skip;
-


### PR DESCRIPTION
* before

```
➜  npm test

> enzyme@2.2.0 test /Users/koba04/repos/github/enzyme
> npm run lint && npm run test:only


> enzyme@2.2.0 lint /Users/koba04/repos/github/enzyme
> eslint src/** test/**


/Users/koba04/repos/github/enzyme/src/MountedTraversal.js
  233:5  error  Expected a "break" statement before "case"  no-fallthrough

/Users/koba04/repos/github/enzyme/src/ShallowTraversal.js
  139:5  error  Expected a "break" statement before "case"  no-fallthrough

/Users/koba04/repos/github/enzyme/test/_helpers.js
  65:2  error  Too many blank lines at the end of file. Max of 1 allowed  no-multiple-empty-lines

✖ 3 problems (3 errors, 0 warnings)
```

* after

```
➜  npm test

> enzyme@2.2.0 test /Users/koba04/repos/github/enzyme
> npm run lint && npm run test:only


> enzyme@2.2.0 lint /Users/koba04/repos/github/enzyme
> eslint src/** test/**


> enzyme@2.2.0 test:only /Users/koba04/repos/github/enzyme
> mocha --require withDom.js --compilers js:babel-core/register --recursive test/*.js --reporter dot



  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․Warning: render(): Rendering components directly into document.body is discouraged, since its children are often manipulated by third-party scripts and browser extensions. This may lead to subtle reconciliation issues. Try rendering into a container element created for your app.
․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․

  316 passing (755ms)
```