### PR TITLE
Add tap() into ShallowWrapper and ReactWrapper

### DIFF
--- a/docs/api/ReactWrapper/tap.md
+++ b/docs/api/ReactWrapper/tap.md
@@ -1,0 +1,33 @@
+# `.tap(intercepter) => Self`
+
+Invokes intercepter and returns itself. intercepter is called with itself.
+This is helpful when debugging nodes in method chains.
+
+#### Arguments
+
+1. `intercepter` (`Self`): the current ReactWrapper instance.
+
+
+
+#### Returns
+
+`Self`: the current ReactWrapper instance.
+
+
+
+#### Example
+
+
+```jsx
+const result = mount(
+  <ul>
+    <li>xxx</li>
+    <li>yyy</li>
+    <li>zzz</li>
+  </ul>
+)
+.find('li')
+.tap(n => console.log(n.debug()))
+.map(n => n.text())
+;
+```

--- a/docs/api/ShallowWrapper/tap.md
+++ b/docs/api/ShallowWrapper/tap.md
@@ -1,0 +1,33 @@
+# `.tap(intercepter) => Self`
+
+Invokes intercepter and returns itself. intercepter is called with itself.
+This is helpful when debugging nodes in method chains.
+
+#### Arguments
+
+1. `intercepter` (`Self`): the current ShallowWrapper instance.
+
+
+
+#### Returns
+
+`Self`: the current ShallowWrapper instance.
+
+
+
+#### Example
+
+
+```jsx
+const result = shallow(
+  <ul>
+    <li>xxx</li>
+    <li>yyy</li>
+    <li>zzz</li>
+  </ul>
+)
+.find('li')
+.tap(n => console.log(n.debug()))
+.map(n => n.text())
+;
+```

--- a/src/ReactWrapper.js
+++ b/src/ReactWrapper.js
@@ -734,6 +734,17 @@ export default class ReactWrapper {
   }
 
   /**
+   * Invokes intercepter and returns itself. intercepter is called with itself.
+   * This is helpful when debugging nodes in method chains.
+   * @param fn
+   * @returns {ReactWrapper}
+   */
+  tap(intercepter) {
+    intercepter(this);
+    return this;
+  }
+
+  /**
    * Detaches the react tree from the DOM. Runs `ReactDOM.unmountComponentAtNode()` under the hood.
    *
    * This method will most commonly be used as a "cleanup" method if you decide to use the

--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -721,4 +721,15 @@ export default class ShallowWrapper {
   debug() {
     return debugNodes(this.nodes);
   }
+
+  /**
+   * Invokes intercepter and returns itself. intercepter is called with itself.
+   * This is helpful when debugging nodes in method chains.
+   * @param fn
+   * @returns {ShallowWrapper}
+   */
+  tap(intercepter) {
+    intercepter(this);
+    return this;
+  }
 }

--- a/test/ReactWrapper-spec.js
+++ b/test/ReactWrapper-spec.js
@@ -1764,6 +1764,22 @@ describeWithDOM('mount', () => {
     });
   });
 
+  describe('.tap()', () => {
+    it('should call the passed function with current ShallowWrapper and returns itself', () => {
+      const spy = sinon.spy();
+      const wrapper = mount(
+        <ul>
+          <li>xxx</li>
+          <li>yyy</li>
+          <li>zzz</li>
+        </ul>
+      ).find('li');
+      const result = wrapper.tap(spy);
+      expect(spy.calledWith(wrapper)).to.equal(true);
+      expect(result).to.equal(wrapper);
+    });
+  });
+
   describe('attachTo option', () => {
     it('should attach and stuff', () => {
       class Foo extends React.Component {

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -2198,4 +2198,21 @@ describe('shallow', () => {
     expect(rendered.length).to.equal(0);
     expect(rendered.html()).to.equal(null);
   });
+
+  describe('.tap()', () => {
+    it('should call the passed function with current ShallowWrapper and returns itself', () => {
+      const spy = sinon.spy();
+      const wrapper = shallow(
+        <ul>
+          <li>xxx</li>
+          <li>yyy</li>
+          <li>zzz</li>
+        </ul>
+      ).find('li');
+      const result = wrapper.tap(spy);
+      expect(spy.calledWith(wrapper)).to.equal(true);
+      expect(result).to.equal(wrapper);
+    });
+  });
+
 });


### PR DESCRIPTION
This is similar to underscore's `tap()`.

http://underscorejs.org/#tap

## motivation

When I'm testing complex React Element tree using method chains, I sometimes would like to inject a debug code between the method chains.

```js
wrapper
.find('.foo')
.findWhere(n => n.text() === 'bar')
// ???
.at(0)
```

* Using `tap()`

```js
wrapper
.find('.foo')
.findWhere(n => n.text() === 'bar')
.tap(n => console.log(n.debug())
.at(0)
```

* without `tap()`

```js
wrapper
.find('.foo')
.findWhere(n => n.text() === 'bar')
.map(n => {
  console.log(n.debug());
  return n;
})
.at(0)
```

I think this is not an essential feature, but it would be nice if enzyme has it.
How do you think about this? :+1:? :-1:?

Thanks.
