### PR TITLE
Remove babelrc from npm package.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -16,6 +16,9 @@ coverage
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
 
+# babel configuration
+.babelrc
+
 # node-waf configuration
 .lock-wscript
 


### PR DESCRIPTION
I have a case where I need to compile node_modules with babel but because enzyme ships with its own babelrc, it breaks my babel setup. I don't think there is a reason why the babelrc needs to be part of the package, so let's remove it, maybe? :)