### PR TITLE
Add `dblclick` to properly map the native event.

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -227,7 +227,8 @@ export function mapNativeEventNames(event) {
     keyup: 'keyUp',
     keypress: 'keyPress',
     contextmenu: 'contextMenu',
-    doubleclick: 'doubleClick',
+    dblclick: 'doubleClick',
+    doubleclick: 'doubleClick', // kept for legacy. TODO: remove with next major.
     dragend: 'dragEnd',
     dragenter: 'dragEnter',
     dragexist: 'dragExit',

--- a/test/ReactWrapper-spec.js
+++ b/test/ReactWrapper-spec.js
@@ -813,18 +813,21 @@ describeWithDOM('mount', () => {
     describe('Normalizing JS event names', () => {
       it('should convert lowercase events to React camelcase', () => {
         const spy = sinon.spy();
+        const clickSpy = sinon.spy();
         class Foo extends React.Component {
           render() {
             return (
-              <a onDoubleClick={spy}>foo</a>
+              <a onClick={clickSpy} onDoubleClick={spy}>foo</a>
             );
           }
         }
 
         const wrapper = mount(<Foo />);
 
-        wrapper.simulate('doubleclick');
+        wrapper.simulate('dblclick');
         expect(spy.calledOnce).to.equal(true);
+        wrapper.simulate('click');
+        expect(clickSpy.calledOnce).to.equal(true);
       });
 
       describeIf(!REACT013, 'normalizing mouseenter', () => {

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -919,18 +919,22 @@ describe('shallow', () => {
     describe('Normalizing JS event names', () => {
       it('should convert lowercase events to React camelcase', () => {
         const spy = sinon.spy();
+        const clickSpy = sinon.spy();
         class Foo extends React.Component {
           render() {
             return (
-              <a onDoubleClick={spy}>foo</a>
+              <a onClick={clickSpy} onDoubleClick={spy}>foo</a>
             );
           }
         }
 
         const wrapper = shallow(<Foo />);
 
-        wrapper.simulate('doubleclick');
+        wrapper.simulate('dblclick');
         expect(spy.calledOnce).to.equal(true);
+
+        wrapper.simulate('click');
+        expect(clickSpy.calledOnce).to.equal(true);
       });
 
       describeIf(!REACT013, 'normalizing mouseenter', () => {


### PR DESCRIPTION
Fixes #310.