### PR TITLE
Support all Component Lifecycle methods in ShallowRenderer

### DIFF
--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -173,7 +173,11 @@ export default class ShallowWrapper {
           }
           if (shouldRender) {
             this.unrendered = React.cloneElement(this.unrendered, props);
+            // dirty hack: avoid calling shouldComponentUpdate twice
+            const originalShouldComponentUpdate = instance.shouldComponentUpdate;
+            instance.shouldComponentUpdate = () => true;
             this.renderer.render(this.unrendered, context);
+            instance.shouldComponentUpdate = originalShouldComponentUpdate;
             if (
               this.options.lifecycleExperimental &&
               instance &&
@@ -251,7 +255,11 @@ export default class ShallowWrapper {
           shouldRender = instance.shouldComponentUpdate(props, state, context);
         }
         if (shouldRender) {
+          // dirty hack: avoid calling shouldComponentUpdate twice
+          const originalShouldComponentUpdate = instance.shouldComponentUpdate;
+          instance.shouldComponentUpdate = () => true;
           this.renderer.render(this.unrendered, context);
+          instance.shouldComponentUpdate = originalShouldComponentUpdate;
           if (
             this.options.lifecycleExperimental &&
             instance &&

--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -160,6 +160,18 @@ export default class ShallowWrapper {
         const nextContext = context || prevContext;
         batchedUpdates(() => {
           let shouldRender = true;
+          // dirty hack:
+          // make sure that componentWillReceiveProps is called before shouldComponentUpdate
+          let originalComponentWillReceiveProps;
+          if (
+            this.options.lifecycleExperimental &&
+            instance &&
+            typeof instance.componentWillReceiveProps === 'function'
+          ) {
+            instance.componentWillReceiveProps(nextProps, nextContext);
+            originalComponentWillReceiveProps = instance.componentWillReceiveProps;
+            instance.componentWillReceiveProps = () => {};
+          }
           if (
             this.options.lifecycleExperimental &&
             instance &&
@@ -182,6 +194,9 @@ export default class ShallowWrapper {
               instance.componentDidUpdate(prevProps, state, prevContext);
             }
             this.update();
+          }
+          if (originalComponentWillReceiveProps) {
+            instance.componentWillReceiveProps = originalComponentWillReceiveProps;
           }
         });
       });

--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -150,18 +150,19 @@ export default class ShallowWrapper {
     }
     this.single(() => {
       withSetStateAllowed(() => {
-        const prevProps = this.instance().props;
-        const prevState = this.instance().state;
         const instance = this.instance();
+        const prevProps = instance.props;
+        const state = instance.state;
+        const context = instance.context;
         let shouldRender = true;
         if (instance && typeof instance.shouldComponentUpdate === 'function') {
-          shouldRender = instance.shouldComponentUpdate(props, null);
+          shouldRender = instance.shouldComponentUpdate(props, state, context);
         }
         if (shouldRender) {
           this.unrendered = React.cloneElement(this.unrendered, props);
-          this.renderer.render(this.unrendered, this.options.context);
+          this.renderer.render(this.unrendered, context);
           if (instance && typeof instance.componentDidUpdate === 'function') {
-            instance.componentDidUpdate(prevProps, prevState);
+            instance.componentDidUpdate(prevProps, state, context);
           }
           this.update();
         }
@@ -217,8 +218,21 @@ export default class ShallowWrapper {
         'a context option'
       );
     }
-    this.renderer.render(this.unrendered, context);
-    this.update();
+    const instance = this.instance();
+    const props = instance.props;
+    const state = instance.state;
+    const prevContext = instance.context;
+    let shouldRender = true;
+    if (instance && typeof instance.shouldComponentUpdate === 'function') {
+      shouldRender = instance.shouldComponentUpdate(props, state, context);
+    }
+    if (shouldRender) {
+      this.renderer.render(this.unrendered, context);
+      if (instance && typeof instance.componentDidUpdate === 'function') {
+        instance.componentDidUpdate(props, state, prevContext);
+      }
+      this.update();
+    }
     return this;
   }
 

--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -71,7 +71,11 @@ export default class ShallowWrapper {
         batchedUpdates(() => {
           this.renderer.render(nodes, options.context);
           const instance = this.instance();
-          if (instance && typeof instance.componentDidMount === 'function') {
+          if (
+            options.lifecycleExperimental &&
+            instance &&
+            typeof instance.componentDidMount === 'function'
+          ) {
             instance.componentDidMount();
           }
         });
@@ -160,13 +164,21 @@ export default class ShallowWrapper {
         const context = instance.context;
         batchedUpdates(() => {
           let shouldRender = true;
-          if (instance && typeof instance.shouldComponentUpdate === 'function') {
+          if (
+            this.options.lifecycleExperimental &&
+            instance &&
+            typeof instance.shouldComponentUpdate === 'function'
+          ) {
             shouldRender = instance.shouldComponentUpdate(props, state, context);
           }
           if (shouldRender) {
             this.unrendered = React.cloneElement(this.unrendered, props);
             this.renderer.render(this.unrendered, context);
-            if (instance && typeof instance.componentDidUpdate === 'function') {
+            if (
+              this.options.lifecycleExperimental &&
+              instance &&
+              typeof instance.componentDidUpdate === 'function'
+            ) {
               instance.componentDidUpdate(prevProps, state, context);
             }
             this.update();
@@ -231,12 +243,20 @@ export default class ShallowWrapper {
     withSetStateAllowed(() => {
       batchedUpdates(() => {
         let shouldRender = true;
-        if (instance && typeof instance.shouldComponentUpdate === 'function') {
+        if (
+          this.options.lifecycleExperimental &&
+          instance &&
+          typeof instance.shouldComponentUpdate === 'function'
+        ) {
           shouldRender = instance.shouldComponentUpdate(props, state, context);
         }
         if (shouldRender) {
           this.renderer.render(this.unrendered, context);
-          if (instance && typeof instance.componentDidUpdate === 'function') {
+          if (
+            this.options.lifecycleExperimental &&
+            instance &&
+            typeof instance.componentDidUpdate === 'function'
+          ) {
             instance.componentDidUpdate(props, state, prevContext);
           }
           this.update();

--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -140,6 +140,56 @@ export default class ShallowWrapper {
   }
 
   /**
+   * A method is for re-render with new props and context.
+   * This calls componentDidUpdate method if lifecycleExperimental is enabled.
+   *
+   * NOTE: can only be called on a wrapper instance that is also the root instance.
+   *
+   * @param {Object} props
+   * @param {Object} context
+   * @returns {ShallowWrapper}
+   */
+  rerender(props, context) {
+    this.single(() => {
+      withSetStateAllowed(() => {
+        const instance = this.instance();
+        const state = instance.state;
+        const prevProps = instance.props;
+        const prevContext = instance.context;
+        const nextProps = props || prevProps;
+        const nextContext = context || prevContext;
+        batchedUpdates(() => {
+          let shouldRender = true;
+          if (
+            this.options.lifecycleExperimental &&
+            instance &&
+            typeof instance.shouldComponentUpdate === 'function'
+          ) {
+            shouldRender = instance.shouldComponentUpdate(nextProps, state, nextContext);
+          }
+          if (shouldRender) {
+            if (props) this.unrendered = React.cloneElement(this.unrendered, props);
+            // dirty hack: avoid calling shouldComponentUpdate twice
+            const originalShouldComponentUpdate = instance.shouldComponentUpdate;
+            instance.shouldComponentUpdate = () => true;
+            this.renderer.render(this.unrendered, nextContext);
+            instance.shouldComponentUpdate = originalShouldComponentUpdate;
+            if (
+              this.options.lifecycleExperimental &&
+              instance &&
+              typeof instance.componentDidUpdate === 'function'
+            ) {
+              instance.componentDidUpdate(prevProps, state, prevContext);
+            }
+            this.update();
+          }
+        });
+      });
+    });
+    return this;
+  }
+
+  /**
    * A method that sets the props of the root component, and re-renders. Useful for when you are
    * wanting to test how the component behaves over time with changing props. Calling this, for
    * instance, will call the `componentWillReceiveProps` lifecycle method.
@@ -156,41 +206,7 @@ export default class ShallowWrapper {
     if (this.root !== this) {
       throw new Error('ShallowWrapper::setProps() can only be called on the root');
     }
-    this.single(() => {
-      withSetStateAllowed(() => {
-        const instance = this.instance();
-        const prevProps = instance.props;
-        const state = instance.state;
-        const context = instance.context;
-        batchedUpdates(() => {
-          let shouldRender = true;
-          if (
-            this.options.lifecycleExperimental &&
-            instance &&
-            typeof instance.shouldComponentUpdate === 'function'
-          ) {
-            shouldRender = instance.shouldComponentUpdate(props, state, context);
-          }
-          if (shouldRender) {
-            this.unrendered = React.cloneElement(this.unrendered, props);
-            // dirty hack: avoid calling shouldComponentUpdate twice
-            const originalShouldComponentUpdate = instance.shouldComponentUpdate;
-            instance.shouldComponentUpdate = () => true;
-            this.renderer.render(this.unrendered, context);
-            instance.shouldComponentUpdate = originalShouldComponentUpdate;
-            if (
-              this.options.lifecycleExperimental &&
-              instance &&
-              typeof instance.componentDidUpdate === 'function'
-            ) {
-              instance.componentDidUpdate(prevProps, state, context);
-            }
-            this.update();
-          }
-        });
-      });
-    });
-    return this;
+    return this.rerender(props);
   }
 
   /**
@@ -240,38 +256,7 @@ export default class ShallowWrapper {
         'a context option'
       );
     }
-    const instance = this.instance();
-    const props = instance.props;
-    const state = instance.state;
-    const prevContext = instance.context;
-    withSetStateAllowed(() => {
-      batchedUpdates(() => {
-        let shouldRender = true;
-        if (
-          this.options.lifecycleExperimental &&
-          instance &&
-          typeof instance.shouldComponentUpdate === 'function'
-        ) {
-          shouldRender = instance.shouldComponentUpdate(props, state, context);
-        }
-        if (shouldRender) {
-          // dirty hack: avoid calling shouldComponentUpdate twice
-          const originalShouldComponentUpdate = instance.shouldComponentUpdate;
-          instance.shouldComponentUpdate = () => true;
-          this.renderer.render(this.unrendered, context);
-          instance.shouldComponentUpdate = originalShouldComponentUpdate;
-          if (
-            this.options.lifecycleExperimental &&
-            instance &&
-            typeof instance.componentDidUpdate === 'function'
-          ) {
-            instance.componentDidUpdate(props, state, prevContext);
-          }
-          this.update();
-        }
-      });
-    });
-    return this;
+    return this.rerender(null, context);
   }
 
   /**

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -2634,7 +2634,7 @@ describe('shallow', () => {
         expect(result.state('count')).to.equal(1);
       });
 
-      it('should provoke an another render to call setState in componentWillUpdate twice', () => {
+      it('should provoke an another render to call setState twice in componentWillUpdate', () => {
         const spy = sinon.spy();
         class Foo extends React.Component {
           constructor(props) {
@@ -2663,7 +2663,7 @@ describe('shallow', () => {
         expect(result.state('count')).to.equal(1);
       });
 
-      it('should provoke an another render to call setState in componentDidUpdate twice', () => {
+      it('should provoke an another render to call setState twice in componentDidUpdate', () => {
         const spy = sinon.spy();
         class Foo extends React.Component {
           constructor(props) {
@@ -2792,7 +2792,7 @@ describe('shallow', () => {
         expect(spy.args).to.deep.equal([['render'], ['shouldComponentUpdate']]);
       });
 
-      it('should provoke an another render to call setState in componentWillUpdate twice', () => {
+      it('should provoke an another render to call setState twice in componentWillUpdate', () => {
         const spy = sinon.spy();
         class Foo extends React.Component {
           constructor(props) {
@@ -2822,7 +2822,7 @@ describe('shallow', () => {
         expect(result.state('count')).to.equal(1);
       });
 
-      it('should provoke an another render to call setState in componentDidUpdate twice', () => {
+      it('should provoke an another render to call setState twice in componentDidUpdate', () => {
         const spy = sinon.spy();
         class Foo extends React.Component {
           constructor(props) {
@@ -2953,7 +2953,7 @@ describe('shallow', () => {
         expect(spy.args).to.deep.equal([['render'], ['shouldComponentUpdate']]);
       });
 
-      it('should provoke an another render to call setState in componentWillUpdate twice', () => {
+      it('should provoke an another render to call setState twice in componentWillUpdate', () => {
         const spy = sinon.spy();
         class Foo extends React.Component {
           constructor(props) {
@@ -2988,7 +2988,7 @@ describe('shallow', () => {
         expect(result.state('count')).to.equal(1);
       });
 
-      it('should provoke an another render to call setState in componentDidUpdate twice', () => {
+      it('should provoke an another render to call setState twice in componentDidUpdate', () => {
         const spy = sinon.spy();
         class Foo extends React.Component {
           constructor(props) {

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -2597,6 +2597,7 @@ describe('shallow', () => {
         expect(
           spy.calledWith({ foo: 'bar' }, { foo: 'baz' }, { foo: 'state' }, { foo: 'context' })
         ).to.equal(true);
+        expect(spy.callCount).to.equal(1);
       });
 
       it('should call componentWillUpdate', () => {
@@ -2808,6 +2809,7 @@ describe('shallow', () => {
         expect(
           spy.calledWith({ foo: 'props' }, { foo: 'bar' }, { foo: 'baz' }, { foo: 'context' })
         ).to.equal(true);
+        expect(spy.callCount).to.equal(1);
       });
 
       it('should call componentWillUpdate', () => {
@@ -2992,6 +2994,7 @@ describe('shallow', () => {
         );
         wrapper.setContext({ foo: 'baz' });
         expect(spy.calledWith({ foo: 'bar' }, { foo: 'baz' })).to.equal(true);
+        expect(spy.callCount).to.equal(1);
       });
 
       it('should call componentWillUpdate', () => {

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -2486,65 +2486,138 @@ describe('shallow', () => {
     });
 
     context('updating props', () => {
+
       it('should call componentWillReceiveProps', () => {
         const spy = sinon.spy();
+
         class Foo extends React.Component {
-          componentWillReceiveProps(nextProps) {
-            spy(this.props, nextProps);
+          componentWillReceiveProps(nextProps, nextContext) {
+            spy(this.props, nextProps, nextContext);
           }
           render() {
             return <div>foo</div>;
           }
         }
+        Foo.contextTypes = {
+          foo: React.PropTypes.string,
+        };
+
+        const wrapper = shallow(<Foo foo="bar" />, { context: { foo: 'context' } });
+        wrapper.setProps({ foo: 'baz' });
+        expect(
+          spy.calledWith({ foo: 'bar' }, { foo: 'baz' }, { foo: 'context' })
+        ).to.equal(true);
+      });
+
+      it('is able to call setState in componentWillReceiveProps', () => {
+
+        class Foo extends React.Component {
+          constructor(...args) {
+            super(...args);
+            this.state = {
+              foo: 'bar',
+            };
+          }
+          componentWillReceiveProps() {
+            this.setState({ foo: 'baz' });
+          }
+          render() {
+            return <div>foo</div>;
+          }
+        }
+
         const wrapper = shallow(<Foo foo="bar" />);
         wrapper.setProps({ foo: 'baz' });
-        expect(spy.calledWith({ foo: 'bar' }, { foo: 'baz' })).to.equal(true);
+        expect(wrapper.state('foo')).to.equal('baz');
       });
+
       it('should call shouldComponentUpdate', () => {
         const spy = sinon.spy();
+
         class Foo extends React.Component {
-          shouldComponentUpdate(nextProps) {
-            spy(this.props, nextProps);
+          constructor(...args) {
+            super(...args);
+            this.state = {
+              foo: 'state',
+            };
+          }
+          shouldComponentUpdate(nextProps, nextState, nextContext) {
+            spy(this.props, nextProps, nextState, nextContext);
             return true;
           }
           render() {
             return <div>foo</div>;
           }
         }
-        const wrapper = shallow(<Foo foo="bar" />);
+        Foo.contextTypes = {
+          foo: React.PropTypes.string,
+        };
+
+        const wrapper = shallow(<Foo foo="bar" />, { context: { foo: 'context' } });
         wrapper.setProps({ foo: 'baz' });
-        expect(spy.calledWith({ foo: 'bar' }, { foo: 'baz' })).to.equal(true);
+        expect(
+          spy.calledWith({ foo: 'bar' }, { foo: 'baz' }, { foo: 'state' }, { foo: 'context' })
+        ).to.equal(true);
       });
+
       it('should call componentWillUpdate', () => {
         const spy = sinon.spy();
+
         class Foo extends React.Component {
-          componentWillUpdate(nextProps) {
-            spy(this.props, nextProps);
+          constructor(...args) {
+            super(...args);
+            this.state = {
+              foo: 'state',
+            };
+          }
+          componentWillUpdate(nextProps, nextState, nextContext) {
+            spy(this.props, nextProps, nextState, nextContext);
           }
           render() {
             return <div>foo</div>;
           }
         }
-        const wrapper = shallow(<Foo foo="bar" />);
+        Foo.contextTypes = {
+          foo: React.PropTypes.string,
+        };
+
+        const wrapper = shallow(<Foo foo="bar" />, { context: { foo: 'context' } });
         wrapper.setProps({ foo: 'baz' });
-        expect(spy.calledWith({ foo: 'bar' }, { foo: 'baz' })).to.equal(true);
+        expect(
+          spy.calledWith({ foo: 'bar' }, { foo: 'baz' }, { foo: 'state' }, { foo: 'context' })
+        ).to.equal(true);
       });
+
       it('should call componentDidUpdate', () => {
         const spy = sinon.spy();
         class Foo extends React.Component {
-          componentDidUpdate(prevProps) {
-            spy(prevProps, this.props);
+          constructor(...args) {
+            super(...args);
+            this.state = {
+              foo: 'state',
+            };
+          }
+          componentDidUpdate(prevProps, prevState, prevContext) {
+            spy(prevProps, this.props, prevState, prevContext);
           }
           render() {
             return <div>foo</div>;
           }
         }
-        const wrapper = shallow(<Foo foo="bar" />);
+        Foo.contextTypes = {
+          foo: React.PropTypes.string,
+        };
+
+        const wrapper = shallow(<Foo foo="bar" />, { context: { foo: 'context' } });
         wrapper.setProps({ foo: 'baz' });
-        expect(spy.calledWith({ foo: 'bar' }, { foo: 'baz' })).to.equal(true);
+        expect(
+          spy.calledWith({ foo: 'bar' }, { foo: 'baz' }, { foo: 'state' }, { foo: 'context' })
+        ).to.equal(true);
       });
+
       it('should cancel rendering when Component returns false in shouldComponentUpdate', () => {
         const spy = sinon.spy();
+
         class Foo extends React.Component {
           shouldComponentUpdate() {
             return false;
@@ -2559,6 +2632,7 @@ describe('shallow', () => {
             return <div>foo</div>;
           }
         }
+
         const wrapper = shallow(<Foo foo="bar" />);
         wrapper.setProps({ foo: 'baz' });
         expect(spy.callCount).to.equal(0);
@@ -2566,67 +2640,92 @@ describe('shallow', () => {
     });
 
     context('updating state', () => {
+
       it('should call shouldComponentUpdate', () => {
         const spy = sinon.spy();
+
         class Foo extends React.Component {
-          constructor(props) {
-            super(props);
+          constructor(...args) {
+            super(...args);
             this.state = {
               foo: 'bar',
             };
           }
-          shouldComponentUpdate(nextProps, nextState) {
-            spy(this.state, nextState);
+          shouldComponentUpdate(nextProps, nextState, nextContext) {
+            spy(nextProps, this.state, nextState, nextContext);
             return true;
           }
           render() {
             return <div>foo</div>;
           }
         }
-        const wrapper = shallow(<Foo />);
+        Foo.contextTypes = {
+          foo: React.PropTypes.string,
+        };
+
+        const wrapper = shallow(<Foo foo="props" />, { context: { foo: 'context' } });
         wrapper.setState({ foo: 'baz' });
-        expect(spy.calledWith({ foo: 'bar' }, { foo: 'baz' })).to.equal(true);
+        expect(
+          spy.calledWith({ foo: 'props' }, { foo: 'bar' }, { foo: 'baz' }, { foo: 'context' })
+        ).to.equal(true);
       });
+
       it('should call componentWillUpdate', () => {
         const spy = sinon.spy();
+
         class Foo extends React.Component {
-          constructor(props) {
-            super(props);
+          constructor(...args) {
+            super(...args);
             this.state = {
               foo: 'bar',
             };
           }
-          componentWillUpdate(nextProps, nextState) {
-            spy(this.state, nextState);
+          componentWillUpdate(nextProps, nextState, nextContext) {
+            spy(nextProps, this.state, nextState, nextContext);
           }
           render() {
             return <div>foo</div>;
           }
         }
-        const wrapper = shallow(<Foo />);
+        Foo.contextTypes = {
+          foo: React.PropTypes.string,
+        };
+
+        const wrapper = shallow(<Foo foo="props" />, { context: { foo: 'context' } });
         wrapper.setState({ foo: 'baz' });
-        expect(spy.calledWith({ foo: 'bar' }, { foo: 'baz' })).to.equal(true);
+        expect(
+          spy.calledWith({ foo: 'props' }, { foo: 'bar' }, { foo: 'baz' }, { foo: 'context' })
+        ).to.equal(true);
       });
+
       it('should call componentDidUpdate', () => {
         const spy = sinon.spy();
+
         class Foo extends React.Component {
-          constructor(props) {
-            super(props);
+          constructor(...args) {
+            super(...args);
             this.state = {
               foo: 'bar',
             };
           }
-          componentDidUpdate(prevProps, prevState) {
-            spy(prevState, this.state);
+          componentDidUpdate(prevProps, prevState, prevContext) {
+            spy(prevProps, prevState, this.state, prevContext);
           }
           render() {
             return <div>foo</div>;
           }
         }
-        const wrapper = shallow(<Foo />);
+        Foo.contextTypes = {
+          foo: React.PropTypes.string,
+        };
+
+        const wrapper = shallow(<Foo foo="props" />, { context: { foo: 'context' } });
         wrapper.setState({ foo: 'baz' });
-        expect(spy.calledWith({ foo: 'bar' }, { foo: 'baz' })).to.equal(true);
+        expect(
+          spy.calledWith({ foo: 'props' }, { foo: 'bar' }, { foo: 'baz' }, { foo: 'context' })
+        ).to.equal(true);
       });
+
       it('should cancel rendering when Component returns false in shouldComponentUpdate', () => {
         const spy = sinon.spy();
         class Foo extends React.Component {
@@ -2655,7 +2754,90 @@ describe('shallow', () => {
       });
     });
 
+    context('updating context', () => {
+
+      it('should call shouldComponentUpdate', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          shouldComponentUpdate(nextProps, nextState, nextContext) {
+            spy(this.context, nextContext);
+            return true;
+          }
+          render() {
+            return <div>foo</div>;
+          }
+        }
+        Foo.contextTypes = {
+          foo: React.PropTypes.string,
+        };
+        const wrapper = shallow(<Foo />, { context: { foo: 'bar' } });
+        wrapper.setContext({ foo: 'baz' });
+        expect(spy.calledWith({ foo: 'bar' }, { foo: 'baz' })).to.equal(true);
+      });
+
+      it('should call componentWillUpdate', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          componentWillUpdate(nextProps, nextState, nextContext) {
+            spy(this.context, nextContext);
+          }
+          render() {
+            return <div>foo</div>;
+          }
+        }
+        Foo.contextTypes = {
+          foo: React.PropTypes.string,
+        };
+        const wrapper = shallow(<Foo />, { context: { foo: 'bar' } });
+        wrapper.setContext({ foo: 'baz' });
+        expect(spy.calledWith({ foo: 'bar' }, { foo: 'baz' })).to.equal(true);
+      });
+
+      it('should call componentDidUpdate', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          componentDidUpdate(prevProps, prevState, prevContext) {
+            spy(prevContext, this.context);
+          }
+          render() {
+            return <div>foo</div>;
+          }
+        }
+        Foo.contextTypes = {
+          foo: React.PropTypes.string,
+        };
+        const wrapper = shallow(<Foo />, { context: { foo: 'bar' } });
+        wrapper.setContext({ foo: 'baz' });
+        expect(spy.calledWith({ foo: 'bar' }, { foo: 'baz' })).to.equal(true);
+      });
+
+      it('should cancel rendering when Component returns false in shouldComponentUpdate', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          shouldComponentUpdate() {
+            return false;
+          }
+          componentWillUpdate() {
+            spy();
+          }
+          componentDidUpdate() {
+            spy();
+          }
+          render() {
+            return <div>foo</div>;
+          }
+        }
+        Foo.contextTypes = {
+          foo: React.PropTypes.string,
+        };
+        const wrapper = shallow(<Foo />, { context: { foo: 'bar' } });
+        wrapper.setContext({ foo: 'baz' });
+        expect(spy.callCount).to.equal(0);
+      });
+    });
+
     context('unmounting', () => {
+
       it('should calll componentWillUnmount', () => {
         const spy = sinon.spy();
         class Foo extends React.Component {

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -2626,9 +2626,10 @@ describe('shallow', () => {
           }
         }
         const result = shallow(<Foo />, { lifecycleExperimental: true });
+        expect(spy).to.have.property('callCount', 1);
         result.setProps({ name: 'bar' });
+        expect(spy).to.have.property('callCount', 2);
         expect(result.state('count')).to.equal(1);
-        expect(spy.callCount).to.equal(2);
       });
 
       it('should be batching updates in componentWillUpdate', () => {
@@ -2654,9 +2655,10 @@ describe('shallow', () => {
           }
         }
         const result = shallow(<Foo />, { lifecycleExperimental: true });
+        expect(spy).to.have.property('callCount', 1);
         result.setProps({ name: 'bar' });
+        expect(spy).to.have.property('callCount', 3);
         expect(result.state('count')).to.equal(1);
-        expect(spy.callCount).to.equal(3);
       });
 
       it('should be batching updates in componentDidUpdate', () => {
@@ -2684,9 +2686,10 @@ describe('shallow', () => {
           }
         }
         const result = shallow(<Foo />, { lifecycleExperimental: true });
+        expect(spy).to.have.property('callCount', 1);
         result.setProps({ name: 'bar' });
+        expect(spy).to.have.property('callCount', 3);
         expect(result.state('count')).to.equal(1);
-        expect(spy.callCount).to.equal(3);
       });
 
     });
@@ -2809,9 +2812,10 @@ describe('shallow', () => {
           }
         }
         const result = shallow(<Foo />, { lifecycleExperimental: true });
+        expect(spy).to.have.property('callCount', 1);
         result.setState({ name: 'bar' });
+        expect(spy).to.have.property('callCount', 3);
         expect(result.state('count')).to.equal(1);
-        expect(spy.callCount).to.equal(3);
       });
 
       it('should be batching updates in componentDidUpdate', () => {
@@ -2840,9 +2844,10 @@ describe('shallow', () => {
           }
         }
         const result = shallow(<Foo />, { lifecycleExperimental: true });
+        expect(spy).to.have.property('callCount', 1);
         result.setState({ name: 'bar' });
+        expect(spy).to.have.property('callCount', 3);
         expect(result.state('count')).to.equal(1);
-        expect(spy.callCount).to.equal(3);
       });
 
     });
@@ -2971,9 +2976,10 @@ describe('shallow', () => {
             lifecycleExperimental: true,
           }
         );
+        expect(spy).to.have.property('callCount', 1);
         result.setContext({ foo: 'baz' });
+        expect(spy).to.have.property('callCount', 3);
         expect(result.state('count')).to.equal(1);
-        expect(spy.callCount).to.equal(3);
       });
 
       it('should be batching updates in componentDidUpdate', () => {
@@ -3007,9 +3013,10 @@ describe('shallow', () => {
             lifecycleExperimental: true,
           }
         );
+        expect(spy).to.have.property('callCount', 1);
         result.setContext({ foo: 'baz' });
+        expect(spy).to.have.property('callCount', 3);
         expect(result.state('count')).to.equal(1);
-        expect(spy.callCount).to.equal(3);
       });
 
     });

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -2455,6 +2455,224 @@ describe('shallow', () => {
 
   });
 
+  describe('Component Lifecycle methods', () => {
+    context('mounting', () => {
+      it('should call componentWillMount', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          componentWillMount() {
+            spy();
+          }
+          render() {
+            return <div>foo</div>;
+          }
+        }
+        shallow(<Foo />);
+        expect(spy.calledOnce).to.equal(true);
+      });
+      it('should call componentDidMount', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          componentDidMount() {
+            spy();
+          }
+          render() {
+            return <div>foo</div>;
+          }
+        }
+        shallow(<Foo />);
+        expect(spy.calledOnce).to.equal(true);
+      });
+    });
+
+    context('updating props', () => {
+      it('should call componentWillReceiveProps', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          componentWillReceiveProps(nextProps) {
+            spy(this.props, nextProps);
+          }
+          render() {
+            return <div>foo</div>;
+          }
+        }
+        const wrapper = shallow(<Foo foo="bar" />);
+        wrapper.setProps({ foo: 'baz' });
+        expect(spy.calledWith({ foo: 'bar' }, { foo: 'baz' })).to.equal(true);
+      });
+      it('should call shouldComponentUpdate', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          shouldComponentUpdate(nextProps) {
+            spy(this.props, nextProps);
+            return true;
+          }
+          render() {
+            return <div>foo</div>;
+          }
+        }
+        const wrapper = shallow(<Foo foo="bar" />);
+        wrapper.setProps({ foo: 'baz' });
+        expect(spy.calledWith({ foo: 'bar' }, { foo: 'baz' })).to.equal(true);
+      });
+      it('should call componentWillUpdate', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          componentWillUpdate(nextProps) {
+            spy(this.props, nextProps);
+          }
+          render() {
+            return <div>foo</div>;
+          }
+        }
+        const wrapper = shallow(<Foo foo="bar" />);
+        wrapper.setProps({ foo: 'baz' });
+        expect(spy.calledWith({ foo: 'bar' }, { foo: 'baz' })).to.equal(true);
+      });
+      it('should call componentDidUpdate', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          componentDidUpdate(prevProps) {
+            spy(prevProps, this.props);
+          }
+          render() {
+            return <div>foo</div>;
+          }
+        }
+        const wrapper = shallow(<Foo foo="bar" />);
+        wrapper.setProps({ foo: 'baz' });
+        expect(spy.calledWith({ foo: 'bar' }, { foo: 'baz' })).to.equal(true);
+      });
+      it('should cancel rendering when Component returns false in shouldComponentUpdate', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          shouldComponentUpdate() {
+            return false;
+          }
+          componentWillUpdate() {
+            spy();
+          }
+          componentDidUpdate() {
+            spy();
+          }
+          render() {
+            return <div>foo</div>;
+          }
+        }
+        const wrapper = shallow(<Foo foo="bar" />);
+        wrapper.setProps({ foo: 'baz' });
+        expect(spy.callCount).to.equal(0);
+      });
+    });
+
+    context('updating state', () => {
+      it('should call shouldComponentUpdate', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          constructor(props) {
+            super(props);
+            this.state = {
+              foo: 'bar',
+            };
+          }
+          shouldComponentUpdate(nextProps, nextState) {
+            spy(this.state, nextState);
+            return true;
+          }
+          render() {
+            return <div>foo</div>;
+          }
+        }
+        const wrapper = shallow(<Foo />);
+        wrapper.setState({ foo: 'baz' });
+        expect(spy.calledWith({ foo: 'bar' }, { foo: 'baz' })).to.equal(true);
+      });
+      it('should call componentWillUpdate', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          constructor(props) {
+            super(props);
+            this.state = {
+              foo: 'bar',
+            };
+          }
+          componentWillUpdate(nextProps, nextState) {
+            spy(this.state, nextState);
+          }
+          render() {
+            return <div>foo</div>;
+          }
+        }
+        const wrapper = shallow(<Foo />);
+        wrapper.setState({ foo: 'baz' });
+        expect(spy.calledWith({ foo: 'bar' }, { foo: 'baz' })).to.equal(true);
+      });
+      it('should call componentDidUpdate', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          constructor(props) {
+            super(props);
+            this.state = {
+              foo: 'bar',
+            };
+          }
+          componentDidUpdate(prevProps, prevState) {
+            spy(prevState, this.state);
+          }
+          render() {
+            return <div>foo</div>;
+          }
+        }
+        const wrapper = shallow(<Foo />);
+        wrapper.setState({ foo: 'baz' });
+        expect(spy.calledWith({ foo: 'bar' }, { foo: 'baz' })).to.equal(true);
+      });
+      it('should cancel rendering when Component returns false in shouldComponentUpdate', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          constructor(props) {
+            super(props);
+            this.state = {
+              foo: 'bar',
+            };
+          }
+          shouldComponentUpdate() {
+            return false;
+          }
+          componentWillUpdate() {
+            spy();
+          }
+          componentDidUpdate() {
+            spy();
+          }
+          render() {
+            return <div>foo</div>;
+          }
+        }
+        const wrapper = shallow(<Foo />);
+        wrapper.setState({ foo: 'baz' });
+        expect(spy.callCount).to.equal(0);
+      });
+    });
+
+    context('unmounting', () => {
+      it('should calll componentWillUnmount', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          componentWillUnmount() {
+            spy();
+          }
+          render() {
+            return <div>foo</div>;
+          }
+        }
+        const wrapper = shallow(<Foo />);
+        wrapper.unmount();
+        expect(spy.calledOnce).to.equal(true);
+      });
+    });
+  });
+
   it('works with class components that return null', () => {
     class Foo extends React.Component {
       render() {

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -2455,7 +2455,7 @@ describe('shallow', () => {
 
   });
 
-  describe('Component Lifecycle methods', () => {
+  describe('lifecycleExperimental', () => {
     context('mounting', () => {
       it('should call componentWillMount', () => {
         const spy = sinon.spy();
@@ -2467,7 +2467,7 @@ describe('shallow', () => {
             return <div>foo</div>;
           }
         }
-        shallow(<Foo />);
+        shallow(<Foo />, { lifecycleExperimental: true });
         expect(spy.calledOnce).to.equal(true);
       });
       it('should call componentDidMount', () => {
@@ -2480,7 +2480,7 @@ describe('shallow', () => {
             return <div>foo</div>;
           }
         }
-        shallow(<Foo />);
+        shallow(<Foo />, { lifecycleExperimental: true });
         expect(spy.calledOnce).to.equal(true);
       });
 
@@ -2506,7 +2506,7 @@ describe('shallow', () => {
             return <div>{this.state.count}</div>;
           }
         }
-        const result = shallow(<Foo />);
+        const result = shallow(<Foo />, { lifecycleExperimental: true });
         expect(result.state('count')).to.equal(2);
         expect(spy.callCount).to.equal(2);
       });
@@ -2529,7 +2529,13 @@ describe('shallow', () => {
           foo: React.PropTypes.string,
         };
 
-        const wrapper = shallow(<Foo foo="bar" />, { context: { foo: 'context' } });
+        const wrapper = shallow(
+          <Foo foo="bar" />,
+          {
+            context: { foo: 'context' },
+            lifecycleExperimental: true,
+          }
+        );
         wrapper.setProps({ foo: 'baz' });
         expect(
           spy.calledWith({ foo: 'bar' }, { foo: 'baz' }, { foo: 'context' })
@@ -2553,7 +2559,7 @@ describe('shallow', () => {
           }
         }
 
-        const wrapper = shallow(<Foo foo="bar" />);
+        const wrapper = shallow(<Foo foo="bar" />, { lifecycleExperimental: true });
         wrapper.setProps({ foo: 'baz' });
         expect(wrapper.state('foo')).to.equal('baz');
       });
@@ -2580,7 +2586,13 @@ describe('shallow', () => {
           foo: React.PropTypes.string,
         };
 
-        const wrapper = shallow(<Foo foo="bar" />, { context: { foo: 'context' } });
+        const wrapper = shallow(
+          <Foo foo="bar" />,
+          {
+            context: { foo: 'context' },
+            lifecycleExperimental: true,
+          }
+        );
         wrapper.setProps({ foo: 'baz' });
         expect(
           spy.calledWith({ foo: 'bar' }, { foo: 'baz' }, { foo: 'state' }, { foo: 'context' })
@@ -2608,7 +2620,13 @@ describe('shallow', () => {
           foo: React.PropTypes.string,
         };
 
-        const wrapper = shallow(<Foo foo="bar" />, { context: { foo: 'context' } });
+        const wrapper = shallow(
+          <Foo foo="bar" />,
+          {
+            context: { foo: 'context' },
+            lifecycleExperimental: true,
+          }
+        );
         wrapper.setProps({ foo: 'baz' });
         expect(
           spy.calledWith({ foo: 'bar' }, { foo: 'baz' }, { foo: 'state' }, { foo: 'context' })
@@ -2635,7 +2653,13 @@ describe('shallow', () => {
           foo: React.PropTypes.string,
         };
 
-        const wrapper = shallow(<Foo foo="bar" />, { context: { foo: 'context' } });
+        const wrapper = shallow(
+          <Foo foo="bar" />,
+          {
+            context: { foo: 'context' },
+            lifecycleExperimental: true,
+          }
+        );
         wrapper.setProps({ foo: 'baz' });
         expect(
           spy.calledWith({ foo: 'bar' }, { foo: 'baz' }, { foo: 'state' }, { foo: 'context' })
@@ -2660,7 +2684,7 @@ describe('shallow', () => {
           }
         }
 
-        const wrapper = shallow(<Foo foo="bar" />);
+        const wrapper = shallow(<Foo foo="bar" />, { lifecycleExperimental: true });
         wrapper.setProps({ foo: 'baz' });
         expect(spy.callCount).to.equal(0);
       });
@@ -2683,7 +2707,7 @@ describe('shallow', () => {
             return <div>{this.props.foo}</div>;
           }
         }
-        const result = shallow(<Foo />);
+        const result = shallow(<Foo />, { lifecycleExperimental: true });
         result.setProps({ name: 'bar' });
         expect(result.state('count')).to.equal(1);
         expect(spy.callCount).to.equal(2);
@@ -2711,7 +2735,7 @@ describe('shallow', () => {
             return <div>{this.props.foo}</div>;
           }
         }
-        const result = shallow(<Foo />);
+        const result = shallow(<Foo />, { lifecycleExperimental: true });
         result.setProps({ name: 'bar' });
         expect(result.state('count')).to.equal(1);
         expect(spy.callCount).to.equal(3);
@@ -2741,7 +2765,7 @@ describe('shallow', () => {
             return <div>{this.props.foo}</div>;
           }
         }
-        const result = shallow(<Foo />);
+        const result = shallow(<Foo />, { lifecycleExperimental: true });
         result.setProps({ name: 'bar' });
         expect(result.state('count')).to.equal(1);
         expect(spy.callCount).to.equal(3);
@@ -2773,7 +2797,13 @@ describe('shallow', () => {
           foo: React.PropTypes.string,
         };
 
-        const wrapper = shallow(<Foo foo="props" />, { context: { foo: 'context' } });
+        const wrapper = shallow(
+          <Foo foo="props" />,
+          {
+            context: { foo: 'context' },
+            lifecycleExperimental: true,
+          }
+        );
         wrapper.setState({ foo: 'baz' });
         expect(
           spy.calledWith({ foo: 'props' }, { foo: 'bar' }, { foo: 'baz' }, { foo: 'context' })
@@ -2801,7 +2831,13 @@ describe('shallow', () => {
           foo: React.PropTypes.string,
         };
 
-        const wrapper = shallow(<Foo foo="props" />, { context: { foo: 'context' } });
+        const wrapper = shallow(
+          <Foo foo="props" />,
+          {
+            context: { foo: 'context' },
+            lifecycleExperimental: true,
+          }
+        );
         wrapper.setState({ foo: 'baz' });
         expect(
           spy.calledWith({ foo: 'props' }, { foo: 'bar' }, { foo: 'baz' }, { foo: 'context' })
@@ -2829,7 +2865,13 @@ describe('shallow', () => {
           foo: React.PropTypes.string,
         };
 
-        const wrapper = shallow(<Foo foo="props" />, { context: { foo: 'context' } });
+        const wrapper = shallow(
+          <Foo foo="props" />,
+          {
+            context: { foo: 'context' },
+            lifecycleExperimental: true,
+          }
+        );
         wrapper.setState({ foo: 'baz' });
         expect(
           spy.calledWith({ foo: 'props' }, { foo: 'bar' }, { foo: 'baz' }, { foo: 'context' })
@@ -2858,7 +2900,7 @@ describe('shallow', () => {
             return <div>foo</div>;
           }
         }
-        const wrapper = shallow(<Foo />);
+        const wrapper = shallow(<Foo />, { lifecycleExperimental: true });
         wrapper.setState({ foo: 'baz' });
         expect(spy.callCount).to.equal(0);
       });
@@ -2886,7 +2928,7 @@ describe('shallow', () => {
             return <div>{this.state.name}</div>;
           }
         }
-        const result = shallow(<Foo />);
+        const result = shallow(<Foo />, { lifecycleExperimental: true });
         result.setState({ name: 'bar' });
         expect(result.state('count')).to.equal(1);
         expect(spy.callCount).to.equal(3);
@@ -2917,7 +2959,7 @@ describe('shallow', () => {
             return <div>{this.state.name}</div>;
           }
         }
-        const result = shallow(<Foo />);
+        const result = shallow(<Foo />, { lifecycleExperimental: true });
         result.setState({ name: 'bar' });
         expect(result.state('count')).to.equal(1);
         expect(spy.callCount).to.equal(3);
@@ -2941,7 +2983,13 @@ describe('shallow', () => {
         Foo.contextTypes = {
           foo: React.PropTypes.string,
         };
-        const wrapper = shallow(<Foo />, { context: { foo: 'bar' } });
+        const wrapper = shallow(
+          <Foo />,
+          {
+            context: { foo: 'bar' },
+            lifecycleExperimental: true,
+          }
+        );
         wrapper.setContext({ foo: 'baz' });
         expect(spy.calledWith({ foo: 'bar' }, { foo: 'baz' })).to.equal(true);
       });
@@ -2959,7 +3007,13 @@ describe('shallow', () => {
         Foo.contextTypes = {
           foo: React.PropTypes.string,
         };
-        const wrapper = shallow(<Foo />, { context: { foo: 'bar' } });
+        const wrapper = shallow(
+          <Foo />,
+          {
+            context: { foo: 'bar' },
+            lifecycleExperimental: true,
+          }
+        );
         wrapper.setContext({ foo: 'baz' });
         expect(spy.calledWith({ foo: 'bar' }, { foo: 'baz' })).to.equal(true);
       });
@@ -2977,7 +3031,13 @@ describe('shallow', () => {
         Foo.contextTypes = {
           foo: React.PropTypes.string,
         };
-        const wrapper = shallow(<Foo />, { context: { foo: 'bar' } });
+        const wrapper = shallow(
+          <Foo />,
+          {
+            context: { foo: 'bar' },
+            lifecycleExperimental: true,
+          }
+        );
         wrapper.setContext({ foo: 'baz' });
         expect(spy.calledWith({ foo: 'bar' }, { foo: 'baz' })).to.equal(true);
       });
@@ -3001,7 +3061,13 @@ describe('shallow', () => {
         Foo.contextTypes = {
           foo: React.PropTypes.string,
         };
-        const wrapper = shallow(<Foo />, { context: { foo: 'bar' } });
+        const wrapper = shallow(
+          <Foo />,
+          {
+            context: { foo: 'bar' },
+            lifecycleExperimental: true,
+          }
+        );
         wrapper.setContext({ foo: 'baz' });
         expect(spy.callCount).to.equal(0);
       });
@@ -3028,7 +3094,13 @@ describe('shallow', () => {
             return <div>{this.state.name}</div>;
           }
         }
-        const result = shallow(<Foo />, { context: { foo: 'bar' } });
+        const result = shallow(
+          <Foo />,
+          {
+            context: { foo: 'bar' },
+            lifecycleExperimental: true,
+          }
+        );
         result.setContext({ foo: 'baz' });
         expect(result.state('count')).to.equal(1);
         expect(spy.callCount).to.equal(3);
@@ -3058,7 +3130,13 @@ describe('shallow', () => {
             return <div>{this.state.name}</div>;
           }
         }
-        const result = shallow(<Foo />, { context: { foo: 'bar' } });
+        const result = shallow(
+          <Foo />,
+          {
+            context: { foo: 'bar' },
+            lifecycleExperimental: true,
+          }
+        );
         result.setContext({ foo: 'baz' });
         expect(result.state('count')).to.equal(1);
         expect(spy.callCount).to.equal(3);
@@ -3078,10 +3156,24 @@ describe('shallow', () => {
             return <div>foo</div>;
           }
         }
-        const wrapper = shallow(<Foo />);
+        const wrapper = shallow(<Foo />, { lifecycleExperimental: true });
         wrapper.unmount();
         expect(spy.calledOnce).to.equal(true);
       });
+    });
+
+    it('should not call when lifecycleExperimental flag is false', () => {
+      const spy = sinon.spy();
+      class Foo extends React.Component {
+        componentDidMount() {
+          spy();
+        }
+        render() {
+          return <div>foo</div>;
+        }
+      }
+      shallow(<Foo />, { lifecycleExperimental: false });
+      expect(spy.calledOnce).to.equal(false);
     });
   });
 

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -2467,12 +2467,14 @@ describe('shallow', () => {
             spy('componentDidMount');
           }
           render() {
+            spy('render');
             return <div>foo</div>;
           }
         }
         shallow(<Foo />, { lifecycleExperimental: true });
         expect(spy.args).to.deep.equal([
           ['componentWillMount'],
+          ['render'],
           ['componentDidMount'],
         ]);
       });
@@ -2531,6 +2533,7 @@ describe('shallow', () => {
             spy('componentDidUpdate', prevProps, this.props, prevState, this.state, prevContext);
           }
           render() {
+            spy('render');
             return <div>foo</div>;
           }
         }
@@ -2549,6 +2552,9 @@ describe('shallow', () => {
         expect(spy.args).to.deep.equal(
           [
             [
+              'render',
+            ],
+            [
               'shouldComponentUpdate',
               { foo: 'bar' }, { foo: 'baz' },
               { foo: 'state' }, { foo: 'state' },
@@ -2564,6 +2570,9 @@ describe('shallow', () => {
               { foo: 'bar' }, { foo: 'baz' },
               { foo: 'state' }, { foo: 'state' },
               { foo: 'context' },
+            ],
+            [
+              'render',
             ],
             [
               'componentDidUpdate',
@@ -2705,6 +2714,7 @@ describe('shallow', () => {
             spy('componentDidUpdate', prevProps, this.props, prevState, this.state, prevContext);
           }
           render() {
+            spy('render');
             return <div>foo</div>;
           }
         }
@@ -2722,6 +2732,9 @@ describe('shallow', () => {
         wrapper.setState({ foo: 'baz' });
         expect(spy.args).to.deep.equal([
           [
+            'render',
+          ],
+          [
             'shouldComponentUpdate',
             { foo: 'props' }, { foo: 'props' },
             { foo: 'bar' }, { foo: 'baz' },
@@ -2732,6 +2745,9 @@ describe('shallow', () => {
             { foo: 'props' }, { foo: 'props' },
             { foo: 'bar' }, { foo: 'baz' },
             { foo: 'context' },
+          ],
+          [
+            'render',
           ],
           [
             'componentDidUpdate',
@@ -2853,6 +2869,7 @@ describe('shallow', () => {
             spy('componentDidUpdate', prevProps, this.props, prevState, this.state, prevContext);
           }
           render() {
+            spy('render');
             return <div>foo</div>;
           }
         }
@@ -2869,6 +2886,9 @@ describe('shallow', () => {
         wrapper.setContext({ foo: 'baz' });
         expect(spy.args).to.deep.equal([
           [
+            'render',
+          ],
+          [
             'shouldComponentUpdate',
             { foo: 'props' }, { foo: 'props' },
             { foo: 'state' }, { foo: 'state' },
@@ -2879,6 +2899,9 @@ describe('shallow', () => {
             { foo: 'props' }, { foo: 'props' },
             { foo: 'state' }, { foo: 'state' },
             { foo: 'baz' },
+          ],
+          [
+            'render',
           ],
           [
             'componentDidUpdate',

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -2484,7 +2484,7 @@ describe('shallow', () => {
         expect(spy.calledOnce).to.equal(true);
       });
 
-      it.skip('should be batching updates', () => {
+      it('should be batching updates', () => {
         const spy = sinon.spy();
         class Foo extends React.Component {
           constructor(props) {
@@ -2689,7 +2689,7 @@ describe('shallow', () => {
         expect(spy.callCount).to.equal(2);
       });
 
-      it.skip('should be batching updates in componentWillUpdate', () => {
+      it('should be batching updates in componentWillUpdate', () => {
         const spy = sinon.spy();
         class Foo extends React.Component {
           constructor(props) {
@@ -2717,7 +2717,7 @@ describe('shallow', () => {
         expect(spy.callCount).to.equal(3);
       });
 
-      it.skip('should be batching updates in componentDidUpdate', () => {
+      it('should be batching updates in componentDidUpdate', () => {
         const spy = sinon.spy();
         class Foo extends React.Component {
           constructor(props) {
@@ -3006,7 +3006,7 @@ describe('shallow', () => {
         expect(spy.callCount).to.equal(0);
       });
 
-      it.skip('should be batching updates in componentWillUpdate', () => {
+      it('should be batching updates in componentWillUpdate', () => {
         const spy = sinon.spy();
         class Foo extends React.Component {
           constructor(props) {
@@ -3034,7 +3034,7 @@ describe('shallow', () => {
         expect(spy.callCount).to.equal(3);
       });
 
-      it.skip('should be batching updates in componentDidUpdate', () => {
+      it('should be batching updates in componentDidUpdate', () => {
         const spy = sinon.spy();
         class Foo extends React.Component {
           constructor(props) {

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -2607,7 +2607,7 @@ describe('shallow', () => {
         expect(spy.callCount).to.equal(0);
       });
 
-      it('should be batching updates in componentWillReceiveProps', () => {
+      it('should not provoke another renders to call setState in componentWillReceiveProps', () => {
         const spy = sinon.spy();
         class Foo extends React.Component {
           constructor(props) {
@@ -2632,7 +2632,7 @@ describe('shallow', () => {
         expect(result.state('count')).to.equal(1);
       });
 
-      it('should be batching updates in componentWillUpdate', () => {
+      it('should provoke an another render to call setState in componentWillUpdate twice', () => {
         const spy = sinon.spy();
         class Foo extends React.Component {
           constructor(props) {
@@ -2661,7 +2661,7 @@ describe('shallow', () => {
         expect(result.state('count')).to.equal(1);
       });
 
-      it('should be batching updates in componentDidUpdate', () => {
+      it('should provoke an another render to call setState in componentDidUpdate twice', () => {
         const spy = sinon.spy();
         class Foo extends React.Component {
           constructor(props) {
@@ -2788,7 +2788,7 @@ describe('shallow', () => {
         expect(spy.callCount).to.equal(0);
       });
 
-      it('should be batching updates in componentWillUpdate', () => {
+      it('should provoke an another render to call setState in componentWillUpdate twice', () => {
         const spy = sinon.spy();
         class Foo extends React.Component {
           constructor(props) {
@@ -2818,7 +2818,7 @@ describe('shallow', () => {
         expect(result.state('count')).to.equal(1);
       });
 
-      it('should be batching updates in componentDidUpdate', () => {
+      it('should provoke an another render to call setState in componentDidUpdate twice', () => {
         const spy = sinon.spy();
         class Foo extends React.Component {
           constructor(props) {
@@ -2947,7 +2947,7 @@ describe('shallow', () => {
         expect(spy.callCount).to.equal(0);
       });
 
-      it('should be batching updates in componentWillUpdate', () => {
+      it('should provoke an another render to call setState in componentWillUpdate twice', () => {
         const spy = sinon.spy();
         class Foo extends React.Component {
           constructor(props) {
@@ -2982,7 +2982,7 @@ describe('shallow', () => {
         expect(result.state('count')).to.equal(1);
       });
 
-      it('should be batching updates in componentDidUpdate', () => {
+      it('should provoke an another render to call setState in componentDidUpdate twice', () => {
         const spy = sinon.spy();
         class Foo extends React.Component {
           constructor(props) {

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -3041,7 +3041,7 @@ describe('shallow', () => {
         }
         const wrapper = shallow(<Foo />, { lifecycleExperimental: true });
         wrapper.unmount();
-        expect(spy.calledOnce).to.equal(true);
+        expect(spy).to.have.property('callCount', 1);
       });
     });
 
@@ -3056,7 +3056,7 @@ describe('shallow', () => {
         }
       }
       shallow(<Foo />, { lifecycleExperimental: false });
-      expect(spy.called).to.equal(false);
+      expect(spy).to.have.property('callCount', 0);
     });
   });
 

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -2483,6 +2483,33 @@ describe('shallow', () => {
         shallow(<Foo />);
         expect(spy.calledOnce).to.equal(true);
       });
+
+      it.skip('should be batching updates', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          constructor(props) {
+            super(props);
+            this.state = {
+              count: 0,
+            };
+          }
+          componentWillMount() {
+            this.setState({ count: this.state.count + 1 });
+            this.setState({ count: this.state.count + 1 });
+          }
+          componentDidMount() {
+            this.setState({ count: this.state.count + 1 });
+            this.setState({ count: this.state.count + 1 });
+          }
+          render() {
+            spy();
+            return <div>{this.state.count}</div>;
+          }
+        }
+        const result = shallow(<Foo />);
+        expect(result.state('count')).to.equal(2);
+        expect(spy.callCount).to.equal(2);
+      });
     });
 
     context('updating props', () => {
@@ -2637,6 +2664,89 @@ describe('shallow', () => {
         wrapper.setProps({ foo: 'baz' });
         expect(spy.callCount).to.equal(0);
       });
+
+      it('should be batching updates in componentWillReceiveProps', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          constructor(props) {
+            super(props);
+            this.state = {
+              count: 0,
+            };
+          }
+          componentWillReceiveProps() {
+            this.setState({ count: this.state.count + 1 });
+            this.setState({ count: this.state.count + 1 });
+          }
+          render() {
+            spy();
+            return <div>{this.props.foo}</div>;
+          }
+        }
+        const result = shallow(<Foo />);
+        result.setProps({ name: 'bar' });
+        expect(result.state('count')).to.equal(1);
+        expect(spy.callCount).to.equal(2);
+      });
+
+      it.skip('should be batching updates in componentWillUpdate', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          constructor(props) {
+            super(props);
+            this.updated = false;
+            this.state = {
+              count: 0,
+            };
+          }
+          componentWillUpdate() {
+            if (!this.updated) {
+              this.updated = true;
+              this.setState({ count: this.state.count + 1 });
+              this.setState({ count: this.state.count + 1 });
+            }
+          }
+          render() {
+            spy();
+            return <div>{this.props.foo}</div>;
+          }
+        }
+        const result = shallow(<Foo />);
+        result.setProps({ name: 'bar' });
+        expect(result.state('count')).to.equal(1);
+        expect(spy.callCount).to.equal(3);
+      });
+
+      it.skip('should be batching updates in componentDidUpdate', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          constructor(props) {
+            super(props);
+            this.updated = false;
+            this.state = {
+              count: 0,
+            };
+          }
+          componentDidUpdate() {
+            if (!this.updated) {
+              this.updated = true;
+              /* eslint-disable react/no-did-update-set-state */
+              this.setState({ count: this.state.count + 1 });
+              this.setState({ count: this.state.count + 1 });
+              /* eslint-enable react/no-did-update-set-state */
+            }
+          }
+          render() {
+            spy();
+            return <div>{this.props.foo}</div>;
+          }
+        }
+        const result = shallow(<Foo />);
+        result.setProps({ name: 'bar' });
+        expect(result.state('count')).to.equal(1);
+        expect(spy.callCount).to.equal(3);
+      });
+
     });
 
     context('updating state', () => {
@@ -2752,6 +2862,67 @@ describe('shallow', () => {
         wrapper.setState({ foo: 'baz' });
         expect(spy.callCount).to.equal(0);
       });
+
+      it('should be batching updates in componentWillUpdate', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          constructor(props) {
+            super(props);
+            this.updated = false;
+            this.state = {
+              name: 'foo',
+              count: 0,
+            };
+          }
+          componentWillUpdate() {
+            if (!this.updated) {
+              this.updated = true;
+              this.setState({ count: this.state.count + 1 });
+              this.setState({ count: this.state.count + 1 });
+            }
+          }
+          render() {
+            spy();
+            return <div>{this.state.name}</div>;
+          }
+        }
+        const result = shallow(<Foo />);
+        result.setState({ name: 'bar' });
+        expect(result.state('count')).to.equal(1);
+        expect(spy.callCount).to.equal(3);
+      });
+
+      it('should be batching updates in componentDidUpdate', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          constructor(props) {
+            super(props);
+            this.updated = false;
+            this.state = {
+              name: 'foo',
+              count: 0,
+            };
+          }
+          componentDidUpdate() {
+            if (!this.updated) {
+              this.updated = true;
+              /* eslint-disable react/no-did-update-set-state */
+              this.setState({ count: this.state.count + 1 });
+              this.setState({ count: this.state.count + 1 });
+              /* eslint-enable react/no-did-update-set-state */
+            }
+          }
+          render() {
+            spy();
+            return <div>{this.state.name}</div>;
+          }
+        }
+        const result = shallow(<Foo />);
+        result.setState({ name: 'bar' });
+        expect(result.state('count')).to.equal(1);
+        expect(spy.callCount).to.equal(3);
+      });
+
     });
 
     context('updating context', () => {
@@ -2834,6 +3005,65 @@ describe('shallow', () => {
         wrapper.setContext({ foo: 'baz' });
         expect(spy.callCount).to.equal(0);
       });
+
+      it.skip('should be batching updates in componentWillUpdate', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          constructor(props) {
+            super(props);
+            this.updated = false;
+            this.state = {
+              count: 0,
+            };
+          }
+          componentWillUpdate() {
+            if (!this.updated) {
+              this.updated = true;
+              this.setState({ count: this.state.count + 1 });
+              this.setState({ count: this.state.count + 1 });
+            }
+          }
+          render() {
+            spy();
+            return <div>{this.state.name}</div>;
+          }
+        }
+        const result = shallow(<Foo />, { context: { foo: 'bar' } });
+        result.setContext({ foo: 'baz' });
+        expect(result.state('count')).to.equal(1);
+        expect(spy.callCount).to.equal(3);
+      });
+
+      it.skip('should be batching updates in componentDidUpdate', () => {
+        const spy = sinon.spy();
+        class Foo extends React.Component {
+          constructor(props) {
+            super(props);
+            this.updated = false;
+            this.state = {
+              count: 0,
+            };
+          }
+          componentDidUpdate() {
+            if (!this.updated) {
+              this.updated = true;
+              /* eslint-disable react/no-did-update-set-state */
+              this.setState({ count: this.state.count + 1 });
+              this.setState({ count: this.state.count + 1 });
+              /* eslint-enable react/no-did-update-set-state */
+            }
+          }
+          render() {
+            spy();
+            return <div>{this.state.name}</div>;
+          }
+        }
+        const result = shallow(<Foo />, { context: { foo: 'bar' } });
+        result.setContext({ foo: 'baz' });
+        expect(result.state('count')).to.equal(1);
+        expect(spy.callCount).to.equal(3);
+      });
+
     });
 
     context('unmounting', () => {

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -3056,7 +3056,7 @@ describe('shallow', () => {
         }
       }
       shallow(<Foo />, { lifecycleExperimental: false });
-      expect(spy.calledOnce).to.equal(false);
+      expect(spy.called).to.equal(false);
     });
   });
 

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -2555,14 +2555,14 @@ describe('shallow', () => {
               'render',
             ],
             [
-              'shouldComponentUpdate',
+              'componentWillReceiveProps',
               { foo: 'bar' }, { foo: 'baz' },
-              { foo: 'state' }, { foo: 'state' },
               { foo: 'context' },
             ],
             [
-              'componentWillReceiveProps',
+              'shouldComponentUpdate',
               { foo: 'bar' }, { foo: 'baz' },
+              { foo: 'state' }, { foo: 'state' },
               { foo: 'context' },
             ],
             [

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -2589,22 +2589,24 @@ describe('shallow', () => {
 
         class Foo extends React.Component {
           shouldComponentUpdate() {
+            spy('shouldComponentUpdate');
             return false;
           }
           componentWillUpdate() {
-            spy();
+            spy('componentWillUpdate');
           }
           componentDidUpdate() {
-            spy();
+            spy('componentDidUpdate');
           }
           render() {
+            spy('render');
             return <div>foo</div>;
           }
         }
 
         const wrapper = shallow(<Foo foo="bar" />, { lifecycleExperimental: true });
         wrapper.setProps({ foo: 'baz' });
-        expect(spy.callCount).to.equal(0);
+        expect(spy.args).to.deep.equal([['render'], ['shouldComponentUpdate']]);
       });
 
       it('should not provoke another renders to call setState in componentWillReceiveProps', () => {
@@ -2771,21 +2773,23 @@ describe('shallow', () => {
             };
           }
           shouldComponentUpdate() {
+            spy('shouldComponentUpdate');
             return false;
           }
           componentWillUpdate() {
-            spy();
+            spy('componentWillUpdate');
           }
           componentDidUpdate() {
-            spy();
+            spy('componentDidUpdate');
           }
           render() {
+            spy('render');
             return <div>foo</div>;
           }
         }
         const wrapper = shallow(<Foo />, { lifecycleExperimental: true });
         wrapper.setState({ foo: 'baz' });
-        expect(spy.callCount).to.equal(0);
+        expect(spy.args).to.deep.equal([['render'], ['shouldComponentUpdate']]);
       });
 
       it('should provoke an another render to call setState in componentWillUpdate twice', () => {
@@ -2921,15 +2925,17 @@ describe('shallow', () => {
         const spy = sinon.spy();
         class Foo extends React.Component {
           shouldComponentUpdate() {
+            spy('shouldComponentUpdate');
             return false;
           }
           componentWillUpdate() {
-            spy();
+            spy('componentWillUpdate');
           }
           componentDidUpdate() {
-            spy();
+            spy('componentDidUpdate');
           }
           render() {
+            spy('render');
             return <div>foo</div>;
           }
         }
@@ -2944,7 +2950,7 @@ describe('shallow', () => {
           }
         );
         wrapper.setContext({ foo: 'baz' });
-        expect(spy.callCount).to.equal(0);
+        expect(spy.args).to.deep.equal([['render'], ['shouldComponentUpdate']]);
       });
 
       it('should provoke an another render to call setState in componentWillUpdate twice', () => {

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -2456,32 +2456,25 @@ describe('shallow', () => {
   });
 
   describe('lifecycleExperimental', () => {
-    context('mounting', () => {
-      it('should call componentWillMount', () => {
-        const spy = sinon.spy();
+    context('mounting phase', () => {
+      it('should call componentWillMount and componentDidMount', () => {
+        const spyComponentWillMount = sinon.spy();
+        const spyComponentDidMount = sinon.spy();
         class Foo extends React.Component {
           componentWillMount() {
-            spy();
+            spyComponentWillMount();
           }
-          render() {
-            return <div>foo</div>;
-          }
-        }
-        shallow(<Foo />, { lifecycleExperimental: true });
-        expect(spy.calledOnce).to.equal(true);
-      });
-      it('should call componentDidMount', () => {
-        const spy = sinon.spy();
-        class Foo extends React.Component {
           componentDidMount() {
-            spy();
+            spyComponentDidMount();
           }
           render() {
             return <div>foo</div>;
           }
         }
         shallow(<Foo />, { lifecycleExperimental: true });
-        expect(spy.calledOnce).to.equal(true);
+        expect(spyComponentWillMount.calledOnce).to.equal(true);
+        expect(spyComponentDidMount.calledOnce).to.equal(true);
+
       });
 
       it('should be batching updates', () => {
@@ -2564,8 +2557,10 @@ describe('shallow', () => {
         expect(wrapper.state('foo')).to.equal('baz');
       });
 
-      it('should call shouldComponentUpdate', () => {
-        const spy = sinon.spy();
+      it('should call shouldComponentUpdate, componentWillUpdate and componentDidUpdate', () => {
+        const spyShouldComponentUpdate = sinon.spy();
+        const spyComponentWillUpdate = sinon.spy();
+        const spyComponentDidUpdate = sinon.spy();
 
         class Foo extends React.Component {
           constructor(...args) {
@@ -2575,76 +2570,14 @@ describe('shallow', () => {
             };
           }
           shouldComponentUpdate(nextProps, nextState, nextContext) {
-            spy(this.props, nextProps, nextState, nextContext);
+            spyShouldComponentUpdate(this.props, nextProps, nextState, nextContext);
             return true;
           }
-          render() {
-            return <div>foo</div>;
-          }
-        }
-        Foo.contextTypes = {
-          foo: React.PropTypes.string,
-        };
-
-        const wrapper = shallow(
-          <Foo foo="bar" />,
-          {
-            context: { foo: 'context' },
-            lifecycleExperimental: true,
-          }
-        );
-        wrapper.setProps({ foo: 'baz' });
-        expect(
-          spy.calledWith({ foo: 'bar' }, { foo: 'baz' }, { foo: 'state' }, { foo: 'context' })
-        ).to.equal(true);
-        expect(spy.callCount).to.equal(1);
-      });
-
-      it('should call componentWillUpdate', () => {
-        const spy = sinon.spy();
-
-        class Foo extends React.Component {
-          constructor(...args) {
-            super(...args);
-            this.state = {
-              foo: 'state',
-            };
-          }
           componentWillUpdate(nextProps, nextState, nextContext) {
-            spy(this.props, nextProps, nextState, nextContext);
-          }
-          render() {
-            return <div>foo</div>;
-          }
-        }
-        Foo.contextTypes = {
-          foo: React.PropTypes.string,
-        };
-
-        const wrapper = shallow(
-          <Foo foo="bar" />,
-          {
-            context: { foo: 'context' },
-            lifecycleExperimental: true,
-          }
-        );
-        wrapper.setProps({ foo: 'baz' });
-        expect(
-          spy.calledWith({ foo: 'bar' }, { foo: 'baz' }, { foo: 'state' }, { foo: 'context' })
-        ).to.equal(true);
-      });
-
-      it('should call componentDidUpdate', () => {
-        const spy = sinon.spy();
-        class Foo extends React.Component {
-          constructor(...args) {
-            super(...args);
-            this.state = {
-              foo: 'state',
-            };
+            spyComponentWillUpdate(this.props, nextProps, nextState, nextContext);
           }
           componentDidUpdate(prevProps, prevState, prevContext) {
-            spy(prevProps, this.props, prevState, prevContext);
+            spyComponentDidUpdate(prevProps, this.props, prevState, prevContext);
           }
           render() {
             return <div>foo</div>;
@@ -2663,7 +2596,22 @@ describe('shallow', () => {
         );
         wrapper.setProps({ foo: 'baz' });
         expect(
-          spy.calledWith({ foo: 'bar' }, { foo: 'baz' }, { foo: 'state' }, { foo: 'context' })
+          spyShouldComponentUpdate.calledWith(
+            { foo: 'bar' }, { foo: 'baz' }, { foo: 'state' }, { foo: 'context' }
+          )
+        ).to.equal(true);
+        expect(spyShouldComponentUpdate.callCount).to.equal(1);
+
+        expect(
+          spyComponentWillUpdate.calledWith(
+            { foo: 'bar' }, { foo: 'baz' }, { foo: 'state' }, { foo: 'context' }
+          )
+        ).to.equal(true);
+
+        expect(
+          spyComponentDidUpdate.calledWith(
+            { foo: 'bar' }, { foo: 'baz' }, { foo: 'state' }, { foo: 'context' }
+          )
         ).to.equal(true);
       });
 
@@ -2776,8 +2724,10 @@ describe('shallow', () => {
 
     context('updating state', () => {
 
-      it('should call shouldComponentUpdate', () => {
-        const spy = sinon.spy();
+      it('should call shouldComponentUpdate, componentWillUpdate and componentDidUpdate', () => {
+        const spyShouldComponentUpdate = sinon.spy();
+        const spyComponentWillUpdate = sinon.spy();
+        const spyComponentDidUpdate = sinon.spy();
 
         class Foo extends React.Component {
           constructor(...args) {
@@ -2787,77 +2737,14 @@ describe('shallow', () => {
             };
           }
           shouldComponentUpdate(nextProps, nextState, nextContext) {
-            spy(nextProps, this.state, nextState, nextContext);
+            spyShouldComponentUpdate(nextProps, this.state, nextState, nextContext);
             return true;
           }
-          render() {
-            return <div>foo</div>;
-          }
-        }
-        Foo.contextTypes = {
-          foo: React.PropTypes.string,
-        };
-
-        const wrapper = shallow(
-          <Foo foo="props" />,
-          {
-            context: { foo: 'context' },
-            lifecycleExperimental: true,
-          }
-        );
-        wrapper.setState({ foo: 'baz' });
-        expect(
-          spy.calledWith({ foo: 'props' }, { foo: 'bar' }, { foo: 'baz' }, { foo: 'context' })
-        ).to.equal(true);
-        expect(spy.callCount).to.equal(1);
-      });
-
-      it('should call componentWillUpdate', () => {
-        const spy = sinon.spy();
-
-        class Foo extends React.Component {
-          constructor(...args) {
-            super(...args);
-            this.state = {
-              foo: 'bar',
-            };
-          }
           componentWillUpdate(nextProps, nextState, nextContext) {
-            spy(nextProps, this.state, nextState, nextContext);
-          }
-          render() {
-            return <div>foo</div>;
-          }
-        }
-        Foo.contextTypes = {
-          foo: React.PropTypes.string,
-        };
-
-        const wrapper = shallow(
-          <Foo foo="props" />,
-          {
-            context: { foo: 'context' },
-            lifecycleExperimental: true,
-          }
-        );
-        wrapper.setState({ foo: 'baz' });
-        expect(
-          spy.calledWith({ foo: 'props' }, { foo: 'bar' }, { foo: 'baz' }, { foo: 'context' })
-        ).to.equal(true);
-      });
-
-      it('should call componentDidUpdate', () => {
-        const spy = sinon.spy();
-
-        class Foo extends React.Component {
-          constructor(...args) {
-            super(...args);
-            this.state = {
-              foo: 'bar',
-            };
+            spyComponentWillUpdate(nextProps, this.state, nextState, nextContext);
           }
           componentDidUpdate(prevProps, prevState, prevContext) {
-            spy(prevProps, prevState, this.state, prevContext);
+            spyComponentDidUpdate(prevProps, prevState, this.state, prevContext);
           }
           render() {
             return <div>foo</div>;
@@ -2876,7 +2763,22 @@ describe('shallow', () => {
         );
         wrapper.setState({ foo: 'baz' });
         expect(
-          spy.calledWith({ foo: 'props' }, { foo: 'bar' }, { foo: 'baz' }, { foo: 'context' })
+          spyShouldComponentUpdate.calledWith(
+            { foo: 'props' }, { foo: 'bar' }, { foo: 'baz' }, { foo: 'context' }
+          )
+        ).to.equal(true);
+        expect(spyShouldComponentUpdate.callCount).to.equal(1);
+
+        expect(
+          spyComponentWillUpdate.calledWith(
+            { foo: 'props' }, { foo: 'bar' }, { foo: 'baz' }, { foo: 'context' }
+          )
+        ).to.equal(true);
+
+        expect(
+          spyComponentDidUpdate.calledWith(
+            { foo: 'props' }, { foo: 'bar' }, { foo: 'baz' }, { foo: 'context' }
+          )
         ).to.equal(true);
       });
 
@@ -2971,61 +2873,20 @@ describe('shallow', () => {
 
     context('updating context', () => {
 
-      it('should call shouldComponentUpdate', () => {
-        const spy = sinon.spy();
+      it('should call shouldComponentUpdate, componentWillUpdate and componentDidUpdate', () => {
+        const spyShouldComponentUpdate = sinon.spy();
+        const spyComponentWillUpdate = sinon.spy();
+        const spyComponentDidUpdate = sinon.spy();
         class Foo extends React.Component {
           shouldComponentUpdate(nextProps, nextState, nextContext) {
-            spy(this.context, nextContext);
+            spyShouldComponentUpdate(this.context, nextContext);
             return true;
           }
-          render() {
-            return <div>foo</div>;
-          }
-        }
-        Foo.contextTypes = {
-          foo: React.PropTypes.string,
-        };
-        const wrapper = shallow(
-          <Foo />,
-          {
-            context: { foo: 'bar' },
-            lifecycleExperimental: true,
-          }
-        );
-        wrapper.setContext({ foo: 'baz' });
-        expect(spy.calledWith({ foo: 'bar' }, { foo: 'baz' })).to.equal(true);
-        expect(spy.callCount).to.equal(1);
-      });
-
-      it('should call componentWillUpdate', () => {
-        const spy = sinon.spy();
-        class Foo extends React.Component {
           componentWillUpdate(nextProps, nextState, nextContext) {
-            spy(this.context, nextContext);
+            spyComponentWillUpdate(this.context, nextContext);
           }
-          render() {
-            return <div>foo</div>;
-          }
-        }
-        Foo.contextTypes = {
-          foo: React.PropTypes.string,
-        };
-        const wrapper = shallow(
-          <Foo />,
-          {
-            context: { foo: 'bar' },
-            lifecycleExperimental: true,
-          }
-        );
-        wrapper.setContext({ foo: 'baz' });
-        expect(spy.calledWith({ foo: 'bar' }, { foo: 'baz' })).to.equal(true);
-      });
-
-      it('should call componentDidUpdate', () => {
-        const spy = sinon.spy();
-        class Foo extends React.Component {
           componentDidUpdate(prevProps, prevState, prevContext) {
-            spy(prevContext, this.context);
+            spyComponentDidUpdate(prevContext, this.context);
           }
           render() {
             return <div>foo</div>;
@@ -3042,7 +2903,19 @@ describe('shallow', () => {
           }
         );
         wrapper.setContext({ foo: 'baz' });
-        expect(spy.calledWith({ foo: 'bar' }, { foo: 'baz' })).to.equal(true);
+        expect(
+          spyShouldComponentUpdate.calledWith({ foo: 'bar' }, { foo: 'baz' })
+        ).to.equal(true);
+        expect(spyShouldComponentUpdate.callCount).to.equal(1);
+
+        expect(
+          spyComponentWillUpdate.calledWith({ foo: 'bar' }, { foo: 'baz' })
+        ).to.equal(true);
+
+        expect(
+          spyComponentDidUpdate.calledWith({ foo: 'bar' }, { foo: 'baz' })
+        ).to.equal(true);
+
       });
 
       it('should cancel rendering when Component returns false in shouldComponentUpdate', () => {
@@ -3147,7 +3020,7 @@ describe('shallow', () => {
 
     });
 
-    context('unmounting', () => {
+    context('unmounting phase', () => {
 
       it('should calll componentWillUnmount', () => {
         const spy = sinon.spy();


### PR DESCRIPTION
This is a feature request which is supporting all React Component Lifecycle methods.
This is including some breaking changes.

This implementation is working on progress, and no (tests is passed)

Does this make sense?
If you are interested in this PR, please give me your feedbacks.
I'd like to work on it 😄 

Thanks.