### PR TITLE
Add default events object to shallow wrapper simulate

### DIFF
--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -350,8 +350,11 @@ export default class ShallowWrapper {
     const handler = this.prop(propFromEvent(event));
     if (handler) {
       withSetStateAllowed(() => {
-        // TODO(lmr): create/use synthetic events
         // TODO(lmr): emulate React's event propagation
+        if (!args.length && window) {
+          args.push(new window.Event(event));
+        }
+
         handler(...args);
         this.root.update();
       });

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -862,7 +862,23 @@ describe('shallow', () => {
       expect(wrapper.find('.clicks-0').length).to.equal(1);
       wrapper.simulate('click');
       expect(wrapper.find('.clicks-1').length).to.equal(1);
+    });
 
+    it('should pass in default event data', () => {
+      const spy = sinon.spy();
+      class Foo extends React.Component {
+        render() {
+          return (
+            <a onClick={spy}>foo</a>
+          );
+        }
+      }
+
+      const wrapper = shallow(<Foo />);
+
+      wrapper.simulate('click');
+      expect(spy.args[0][0].type).to.equal('click');
+      expect(spy.args[0][0].preventDefault).to.a('function');
     });
 
 


### PR DESCRIPTION
Hey,

I had to pass preventDefault mock lot of times to simulate event in shallow rendering, so I thought it would be nice to have it by default there.

Fixes: https://github.com/airbnb/enzyme/issues/277