### PR TITLE
prioritize `displayName` over `name`

### DIFF
--- a/src/ShallowTraversal.js
+++ b/src/ShallowTraversal.js
@@ -165,7 +165,7 @@ export function getTextFromNode(node) {
   }
 
   if (node.type && typeof node.type === 'function') {
-    return `<${node.type.name || node.type.displayName} />`;
+    return `<${node.type.displayName || node.type.name} />`;
   }
 
   return childrenOfNode(node).map(getTextFromNode).join('').replace(/\s+/, ' ');

--- a/test/ShallowTraversal-spec.js
+++ b/test/ShallowTraversal-spec.js
@@ -10,6 +10,7 @@ import {
   treeForEach,
   treeFilter,
   pathToNode,
+  getTextFromNode,
 } from '../src/ShallowTraversal';
 
 describe('ShallowTraversal', () => {
@@ -249,6 +250,36 @@ describe('ShallowTraversal', () => {
       expect(result.length).to.equal(2);
       expect(result[0].type).to.equal('div');
       expect(result[1].type).to.equal('nav');
+    });
+
+  });
+
+  describe('getTextFromNode', () => {
+    it('should return displayName for functions that provides one', () => {
+      class Subject extends React.Component {
+        render() {
+          return (
+            <div />
+          );
+        }
+      }
+      Subject.displayName = 'CustomSubject';
+      const node = <Subject />;
+      const result = getTextFromNode(node);
+      expect(result).to.equal('<CustomSubject />');
+    });
+
+    it('should return function name if displayName is not provided', () => {
+      class Subject extends React.Component {
+        render() {
+          return (
+            <div />
+          );
+        }
+      }
+      const node = <Subject />;
+      const result = getTextFromNode(node);
+      expect(result).to.equal('<Subject />');
     });
 
   });


### PR DESCRIPTION
React provides the ability to override a component's display name by
using the `displayName` property. When `displayName` is provided it
should take precedence over `name`. Prior to this pull request,
`displayName` would only ever be used if `name` is not present but it
should have been the other way around.