### PR TITLE
Update docs to externalize react/addons for newer versions of React

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ npm install && npm run react:14
 ```
 
 
-### Switching between React 0.14 and React 0.13
+### Switching between React 15, React 0.14 and React 0.13
 
 ```bash
 # switch to React 0.13
@@ -32,6 +32,11 @@ npm run react:13
 ```bash
 # switch to React 0.14
 npm run react:14
+```
+
+```bash
+# switch to React 15
+npm run react:15
 ```
 
 
@@ -86,8 +91,8 @@ Before you submit a pull request from your forked repo, check that it meets thes
 1. If the pull request fixes a bug, it should include tests that fail without the changes, and pass
 with them.
 1. If the pull request adds functionality, the docs should be updated as part of the same PR.
-1. The pull request should work for both React 0.14 and React 0.13. The CI server should run the
-tests in both versions automatically when you push the PR, but if you'd like to check locally, you
+1. The pull request should work for React 15, React 0.14 and React 0.13. The CI server should run the
+tests in all versions automatically when you push the PR, but if you'd like to check locally, you
 can do so (see above).
 1. Please rebase and resolve all conflicts before submitting.
 

--- a/docs/guides/browserify.md
+++ b/docs/guides/browserify.md
@@ -14,6 +14,7 @@ In your browserify configuration, you simply need to make sure that the followin
 labeled as "external", which means they will be ignored:
 
 ```
+react/addons
 react/lib/ReactContext
 react/lib/ExecutionEnvironment
 ```
@@ -26,6 +27,7 @@ var browserify = require('browserify');
 var b = browserify();
 
 // make sure to mark these as external!
+b.external('react/addons');
 b.external('react/lib/ReactContext');
 b.external('react/lib/ExecutionEnvironment');
 

--- a/docs/guides/karma.md
+++ b/docs/guides/karma.md
@@ -30,6 +30,7 @@ webpack: { //kind of a copy of your webpack config
   },
   externals: {
     'cheerio': 'window',
+    'react/addons': true,
     'react/lib/ExecutionEnvironment': true,
     'react/lib/ReactContext': true
   }
@@ -49,6 +50,7 @@ browserify: {
   ],
   configure: function(bundle) {
     bundle.on('prebundle', function() {
+      bundle.external('react/addons');
       bundle.external('react/lib/ReactContext');
       bundle.external('react/lib/ExecutionEnvironment');
     });


### PR DESCRIPTION
Deprecated CommonJS `react/addons` entry point was removed in React 15.
https://facebook.github.io/react/blog/2016/04/07/react-v15.html

resolves #325