### PR TITLE
Update doc regarding webpack and React 15

### DIFF
--- a/docs/guides/webpack.md
+++ b/docs/guides/webpack.md
@@ -46,6 +46,20 @@ react-dom/server
 react-addons-test-utils
 ```
 
+## React 15 Compatability
+
+If you are using React 15, your config should include these externals:
+
+```js
+/* webpack.config.js */
+// ...
+externals: {
+  'react/addons': true,
+  'react/lib/ExecutionEnvironment': true,
+  'react/lib/ReactContext': true
+}
+// ...
+```
 
 ## Example Projects
 


### PR DESCRIPTION
I've updated doc regarding webpack and React 15, which came from the [advice here](https://github.com/airbnb/enzyme/issues/47#issuecomment-207498885).

What I had to do to get things working with webpack and React 0.14 was different than in the guide, and I wrote about it [here](https://github.com/airbnb/enzyme/issues/47#issuecomment-213032872). I did not include it in this PR due to not really understanding what's going on and if my solution is a universal one, but I think a better guide will make sure people don't abandon using enzyme because they feel it's too hard to set up.