### PR TITLE
ShallowRenderer.simulate supports batched updates

### DIFF
--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -29,6 +29,7 @@ import {
 import {
   createShallowRenderer,
   renderToStaticMarkup,
+  batchedUpdates,
 } from './react-compat';
 
 /**
@@ -468,7 +469,9 @@ export default class ShallowWrapper {
       withSetStateAllowed(() => {
         // TODO(lmr): create/use synthetic events
         // TODO(lmr): emulate React's event propagation
-        handler(...args);
+        batchedUpdates(() => {
+          handler(...args);
+        });
         this.root.update();
       });
     }

--- a/src/react-compat.js
+++ b/src/react-compat.js
@@ -10,9 +10,9 @@ let findDOMNode;
 let childrenToArray;
 let renderWithOptions;
 let unmountComponentAtNode;
+let batchedUpdates;
 
 const React = require('react');
-const batchedUpdates = require('react/lib/ReactUpdates').batchedUpdates;
 
 if (REACT013) {
   renderToStaticMarkup = React.renderToStaticMarkup;
@@ -21,6 +21,7 @@ if (REACT013) {
   unmountComponentAtNode = React.unmountComponentAtNode;
   /* eslint-enable react/no-deprecated */
   TestUtils = require('react/addons').addons.TestUtils;
+  batchedUpdates = require('react/addons').addons.batchedUpdates;
   const ReactContext = require('react/lib/ReactContext');
 
   // Shallow rendering in 0.13 did not properly support context. This function provides a shim
@@ -77,6 +78,7 @@ if (REACT013) {
   renderToStaticMarkup = require('react-dom/server').renderToStaticMarkup;
   findDOMNode = ReactDOM.findDOMNode;
   unmountComponentAtNode = ReactDOM.unmountComponentAtNode;
+  batchedUpdates = ReactDOM.unstable_batchedUpdates;
   // We require the testutils, but they don't come with 0.14 out of the box, so we
   // require them here through this node module. The bummer is that we are not able
   // to list this as a dependency in package.json and have 0.13 work properly.

--- a/src/react-compat.js
+++ b/src/react-compat.js
@@ -12,6 +12,7 @@ let renderWithOptions;
 let unmountComponentAtNode;
 
 const React = require('react');
+const batchedUpdates = require('react/lib/ReactUpdates').batchedUpdates;
 
 if (REACT013) {
   renderToStaticMarkup = React.renderToStaticMarkup;
@@ -163,4 +164,5 @@ export {
   childrenToArray,
   renderWithOptions,
   unmountComponentAtNode,
+  batchedUpdates,
 };

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -1022,6 +1022,34 @@ describe('shallow', () => {
       });
     });
 
+    it('should be batched updates', () => {
+      let renderCount = 0;
+      class Foo extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            count: 0,
+          };
+          this.onClick = this.onClick.bind(this);
+        }
+        onClick() {
+          this.setState({ count: this.state.count + 1 });
+          this.setState({ count: this.state.count + 1 });
+        }
+        render() {
+          ++renderCount;
+          return (
+            <a onClick={this.onClick}>{this.state.count}</a>
+          );
+        }
+      }
+
+      const wrapper = shallow(<Foo />);
+      wrapper.simulate('click');
+      expect(wrapper.text()).to.equal('1');
+      expect(renderCount).to.equal(2);
+    });
+
   });
 
   describe('.setState(newState)', () => {


### PR DESCRIPTION
This PR is for `ShallowWrapper.simulate()` supports batched updates using `ReactUpdates.batchedUpdates`.

`React.addons.TestUtils.Simulate.{eventName}` is supporting batched updates.
ref. https://jsfiddle.net/koba04/6Lchbest/

`ReactUpdates.batchedUpdates` is exported as `ReactDOM. unstable_batchedUpdates` from React v0.14. In React v0.13, it is exported as  `React.addons.batchedUpdates`.

It might be better I use the exported interface.
But I guess it makes your configurations complex than using `ReactUpdates.batchedUpdates` directly.

FYI: This batched updates feature is required #318.

Thanks.