### PR TITLE
Typofix in props.md

### DIFF
--- a/docs/api/ShallowWrapper/props.md
+++ b/docs/api/ShallowWrapper/props.md
@@ -16,6 +16,6 @@ expect(wrapper.props().foo).to.equal(10);
 
 #### Related Methods
 
-- [`.prop() => Object`](prop.md)
+- [`.prop(key) => Any`](prop.md)
 - [`.state([key]) => Any`](state.md)
 - [`.context([key]) => Any`](context.md)


### PR DESCRIPTION
Fixes `.prop` method signature in "Related Methods"