### PR TITLE
Implement matchesClass method for class name matching with RegExp

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "license": "MIT",
   "dependencies": {
     "cheerio": "^0.20.0",
+    "is-regex": "^1.0.3",
     "is-subset": "^0.1.1",
     "lodash": "^4.8.2",
     "object.assign": "^4.0.3",

--- a/src/MountedTraversal.js
+++ b/src/MountedTraversal.js
@@ -55,6 +55,14 @@ export function instHasClassName(inst, className) {
   return ` ${classes} `.indexOf(` ${className} `) > -1;
 }
 
+export function instMatchesClassName(inst, regex) {
+  if (!isDOMComponent(inst)) {
+    return false;
+  }
+  const classes = findDOMNode(inst).className || '';
+  return regex.test(classes);
+}
+
 export function instHasId(inst, id) {
   if (!isDOMComponent(inst)) return false;
   const instId = findDOMNode(inst).id || '';

--- a/src/ReactWrapper.js
+++ b/src/ReactWrapper.js
@@ -3,9 +3,11 @@ import cheerio from 'cheerio';
 import flatten from 'lodash/flatten';
 import unique from 'lodash/uniq';
 import compact from 'lodash/compact';
+import isRegex from 'is-regex';
 import createWrapperComponent from './ReactWrapperComponent';
 import {
   instHasClassName,
+  instMatchesClassName,
   childrenOfInst,
   parentsOfInst,
   buildInstPredicate,
@@ -532,6 +534,25 @@ export default class ReactWrapper {
       );
     }
     return this.single(n => instHasClassName(n, className));
+  }
+
+  /**
+   * Returns whether or not the current root node has a class matching the
+   * passed regular expression
+   *
+   * NOTE: can only be called on a wrapper of a single node.
+   *
+   * @param {RegExp} regex
+   * @returns {Boolean}
+   */
+  matchesClass(regex) {
+    if (!isRegex(regex)) {
+      throw new Error(
+        `ReactWrapper::matchesClass() expects a regular expression,
+        receieved a ${typeof regex} instead.`
+      );
+    }
+    return this.single(n => instMatchesClassName(n, regex));
   }
 
   /**

--- a/src/ShallowTraversal.js
+++ b/src/ShallowTraversal.js
@@ -32,6 +32,11 @@ export function hasClassName(node, className) {
   return ` ${classes} `.indexOf(` ${className} `) > -1;
 }
 
+export function matchesClassName(node, regex) {
+  const classes = propsOfNode(node).className || '';
+  return regex.test(classes);
+}
+
 export function treeForEach(tree, fn) {
   if (tree !== null && tree !== false && typeof tree !== 'undefined') {
     fn(tree);

--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -3,6 +3,7 @@ import flatten from 'lodash/flatten';
 import unique from 'lodash/uniq';
 import compact from 'lodash/compact';
 import cheerio from 'cheerio';
+import isRegex from 'is-regex';
 import {
   nodeEqual,
   containsChildrenSubArray,
@@ -17,6 +18,7 @@ import {
 import {
   getTextFromNode,
   hasClassName,
+  matchesClassName,
   childrenOfNode,
   parentsOfNode,
   treeFilter,
@@ -520,6 +522,24 @@ export default class ShallowWrapper {
       );
     }
     return this.single(n => hasClassName(n, className));
+  }
+
+  /**
+   * Returns whether or not the current root node has the given class name or not.
+   *
+   * NOTE: can only be called on a wrapper of a single node.
+   *
+   * @param className
+   * @returns {Boolean}
+   */
+  matchesClass(regex) {
+    if (!isRegex(regex)) {
+      throw new Error(
+        `ShallowWrapper::matchesClass() expects a regular expression
+         receieved a ${typeof regex} instead.`
+      );
+    }
+    return this.single(n => matchesClassName(n, regex));
   }
 
   /**

--- a/test/ReactWrapper-spec.js
+++ b/test/ReactWrapper-spec.js
@@ -1374,6 +1374,26 @@ describeWithDOM('mount', () => {
     });
   });
 
+  describe('.matchesClass(regex)', () => {
+    it('should match class names with a regular expression', () => {
+      const wrapper = mount(
+        <div className="foo bar baz some-long-string FoOo bling-42" />
+      );
+
+      expect(wrapper.matchesClass(/foo/)).to.equal(true);
+      expect(wrapper.matchesClass(/bar/)).to.equal(true);
+      expect(wrapper.matchesClass(/baz/)).to.equal(true);
+      expect(wrapper.matchesClass(/some-long-string/)).to.equal(true);
+      expect(wrapper.matchesClass(/FoOo/)).to.equal(true);
+      expect(wrapper.matchesClass(/bling/)).to.equal(true);
+      expect(wrapper.matchesClass(/doesnt-exist/)).to.equal(false);
+    });
+    it('should throw if the argument is not a regular expression', () => {
+      const wrapper = mount(<div className="foo" />);
+      expect(() => wrapper.matchesClass('string')).to.throw(Error);
+    });
+  });
+
   describe('.forEach(fn)', () => {
     it('should call a function for each node in the wrapper', () => {
       const wrapper = mount(

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -1582,6 +1582,26 @@ describe('shallow', () => {
     });
   });
 
+  describe('.matchesClass(regex)', () => {
+    it('should match class names with a regular expression', () => {
+      const wrapper = shallow(
+        <div className="foo bar baz some-long-string FoOo bling-42" />
+      );
+
+      expect(wrapper.matchesClass(/foo/)).to.equal(true);
+      expect(wrapper.matchesClass(/bar/)).to.equal(true);
+      expect(wrapper.matchesClass(/baz/)).to.equal(true);
+      expect(wrapper.matchesClass(/some-long-string/)).to.equal(true);
+      expect(wrapper.matchesClass(/FoOo/)).to.equal(true);
+      expect(wrapper.matchesClass(/bling/)).to.equal(true);
+      expect(wrapper.matchesClass(/doesnt-exist/)).to.equal(false);
+    });
+    it('should throw if the argument is not a regular expression', () => {
+      const wrapper = shallow(<div className="foo" />);
+      expect(() => wrapper.matchesClass('string')).to.throw(Error);
+    });
+  });
+
   describe('.forEach(fn)', () => {
     it('should call a function for each node in the wrapper', () => {
       const wrapper = shallow(


### PR DESCRIPTION
This allows you do so stuff like:

```js
expect(wrapper.hasClass(/foo/)).to.be(true)
```

This is especially useful in instances where folks may be using CSS modules that are being scoped with appended hash values. 