### PR TITLE
Return component._instance if getPublicInstance returns null

### DIFF
--- a/src/ReactWrapperComponent.jsx
+++ b/src/ReactWrapperComponent.jsx
@@ -54,7 +54,7 @@ export default function createWrapperComponent(node, options = {}) {
       const component = this._reactInternalInstance._renderedComponent;
       const inst = component.getPublicInstance();
       if (inst === null) {
-        return component;
+        return component._instance;
       }
       return inst;
     },

--- a/test/ReactWrapper-spec.js
+++ b/test/ReactWrapper-spec.js
@@ -113,6 +113,15 @@ describeWithDOM('mount', () => {
       expect(wrapper.find('.qoo').text()).to.equal('qux');
     });
 
+    it('supports findDOMNode with stateless components', () => {
+      const Foo = ({ foo }) => (
+        <div>{foo}</div>
+      );
+
+      const wrapper = mount(<Foo foo="qux" />);
+      expect(wrapper.text()).to.equal('qux');
+    });
+
     it('works with nested stateless', () => {
       const TestItem = () => (
         <div className="item">1</div>


### PR DESCRIPTION
Resolves #356 


[`getPublicInstance` returns `null` for SFCs](https://github.com/facebook/react/blob/master/src/renderers/shared/reconciler/ReactCompositeComponent.js#L1202)  and the `_renderedComponent` appears to be a wrapper component that doesn't actually have a `render` method. This causes `findDOMNode` to fail as it uses the `render` method to validate that an object is a React component.

This returns the internal `_instance` instead of returning `component` when `inst === null`. 

I was thinking of maybe doing `return component._instance || component` to be extra safe but it didn't seem to make a difference.