### PR TITLE
Test on node v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
+  - "6"
   - "5"
   - "4"
-  - "iojs"
   - "0.12"
   - "0.10"
 before_install:
@@ -26,6 +26,16 @@ sudo: false
 matrix:
   fast_finish: true
   exclude:
+  - node_js: "5"
+    env: EXAMPLE=mocha
+  - node_js: "5"
+    env: EXAMPLE=karma
+  - node_js: "5"
+    env: EXAMPLE=react-native
+  - node_js: "5"
+    env: EXAMPLE=karma-webpack
+  - node_js: "5"
+    env: EXAMPLE=jest
   - node_js: "4"
     env: EXAMPLE=mocha
   - node_js: "4"


### PR DESCRIPTION
Io.js is not maintained anymore, and v6 is the latest

(example of io.js not maintained: https://nodejs.org/en/blog/vulnerability/openssl-may-2016/)