### PR TITLE
added error checking for state, setState, context, instance methods on ShallowWrapper

### DIFF
--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -13,6 +13,7 @@ import {
   typeOfNode,
   isReactElementAlike,
   displayNameOfNode,
+  isFunctionalComponent,
 } from './Utils';
 import {
   debugNodes,
@@ -100,6 +101,9 @@ export default class ShallowWrapper {
    * @returns {ReactComponent}
    */
   instance() {
+    if (this.root !== this) {
+      throw new Error('ShallowWrapper::instance() can only be called on the root');
+    }
     return this.renderer._instance._instance;
   }
 
@@ -164,6 +168,9 @@ export default class ShallowWrapper {
   setState(state) {
     if (this.root !== this) {
       throw new Error('ShallowWrapper::setState() can only be called on the root');
+    }
+    if (isFunctionalComponent(this.instance())) {
+      throw new Error('ShallowWrapper::setState() can only be called on class components');
     }
     this.single(() => {
       withSetStateAllowed(() => {
@@ -492,6 +499,9 @@ export default class ShallowWrapper {
     if (this.root !== this) {
       throw new Error('ShallowWrapper::state() can only be called on the root');
     }
+    if (isFunctionalComponent(this.instance())) {
+      throw new Error('ShallowWrapper::state() can only be called on class components');
+    }
     const _state = this.single(() => this.instance().state);
     if (name !== undefined) {
       return _state[name];
@@ -511,6 +521,12 @@ export default class ShallowWrapper {
   context(name) {
     if (this.root !== this) {
       throw new Error('ShallowWrapper::context() can only be called on the root');
+    }
+    if (!this.options.context) {
+      throw new Error(
+        'ShallowWrapper::context() can only be called on a wrapper that was originally passed ' +
+        'a context option'
+      );
     }
     const _context = this.single(() => this.instance().context);
     if (name) {

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -101,6 +101,31 @@ describe('shallow', () => {
     });
   });
 
+  describe('.instance()', () => {
+
+    it('should return the component instance', () => {
+      class Foo extends React.Component {
+        render() { return <div />; }
+      }
+
+      const wrapper = shallow(<Foo />);
+      expect(wrapper.instance()).to.be.instanceof(Foo);
+      expect(wrapper.instance().render).to.equal(Foo.prototype.render);
+    });
+
+    it('should throw if called on something other than the root node', () => {
+      class Foo extends React.Component {
+        render() { return <div><a /></div>; }
+      }
+
+      const wrapper = shallow(<Foo />);
+      const div = wrapper.find('div');
+
+      expect(() => div.instance()).to.throw();
+    });
+
+  });
+
   describe('.contains(node)', () => {
 
     it('should allow matches on the root node', () => {

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -990,6 +990,28 @@ describe('shallow', () => {
       wrapper.setState({ id: 'bar' });
       expect(wrapper.find('.bar').length).to.equal(1);
     });
+
+    describeIf(!REACT013, 'stateless function components', () => {
+      it('should throw when trying to access state', () => {
+        const Foo = () => (
+          <div>abc</div>
+        );
+
+        const wrapper = shallow(<Foo />);
+
+        expect(() => wrapper.state()).to.throw();
+      });
+
+      it('should throw when trying to set state', () => {
+        const Foo = () => (
+          <div>abc</div>
+        );
+
+        const wrapper = shallow(<Foo />);
+
+        expect(() => wrapper.setState({ a: 1 })).to.throw();
+      });
+    });
   });
 
   describe('.is(selector)', () => {


### PR DESCRIPTION
- `.instance` was missing the `root` check even though it was mentioned in the description above.
- `state` and `setState` don't make sense for functional components so they now throw if called on a functional component (error message like the `root` one)
- also added the existing error checking of `setContext` to `context`