### PR TITLE
Fix mount::simulate() signature

### DIFF
--- a/docs/api/ReactWrapper/simulate.md
+++ b/docs/api/ReactWrapper/simulate.md
@@ -1,4 +1,4 @@
-# `.simulate(event[, ...args]) => Self`
+# `.simulate(event[, mock]) => Self`
 
 Simulate events
 
@@ -6,8 +6,7 @@ Simulate events
 #### Arguments
 
 1. `event` (`String`): The event name to be simulated
-2. `...args` (`Any` [optional]): A mock event object that will get passed through to the event
-handlers.
+2. `mock` (`Object` [optional]): A mock event object that will be merged with the event object passed to the handlers.
 
 
 

--- a/docs/api/mount.md
+++ b/docs/api/mount.md
@@ -141,7 +141,7 @@ Returns the named prop of the root component.
 #### [`.key() => String`](ReactWrapper/key.md)
 Returns the key of the root component.
 
-#### [`.simulate(event[, data]) => ReactWrapper`](ReactWrapper/simulate.md)
+#### [`.simulate(event[, mock]) => ReactWrapper`](ReactWrapper/simulate.md)
 Simulates an event on the current node.
 
 #### [`.setState(nextState) => ReactWrapper`](ReactWrapper/setState.md)

--- a/src/ReactWrapper.js
+++ b/src/ReactWrapper.js
@@ -468,7 +468,7 @@ export default class ReactWrapper {
    * testing events should be met with some skepticism.
    *
    * @param {String} event
-   * @param {Array} args
+   * @param {Object} mock (optional)
    * @returns {ReactWrapper}
    */
   simulate(event, mock = {}) {

--- a/src/ReactWrapper.js
+++ b/src/ReactWrapper.js
@@ -471,7 +471,7 @@ export default class ReactWrapper {
    * @param {Array} args
    * @returns {ReactWrapper}
    */
-  simulate(event, ...args) {
+  simulate(event, mock) {
     this.single(n => {
       const mappedEvent = mapNativeEventNames(event);
       const eventFn = Simulate[mappedEvent];
@@ -479,7 +479,7 @@ export default class ReactWrapper {
         throw new TypeError(`ReactWrapper::simulate() event '${event}' does not exist`);
       }
 
-      eventFn(findDOMNode(n), ...args);
+      eventFn(findDOMNode(n), mock);
     });
     return this;
   }

--- a/src/ReactWrapper.js
+++ b/src/ReactWrapper.js
@@ -471,7 +471,7 @@ export default class ReactWrapper {
    * @param {Array} args
    * @returns {ReactWrapper}
    */
-  simulate(event, mock) {
+  simulate(event, mock = {}) {
     this.single(n => {
       const mappedEvent = mapNativeEventNames(event);
       const eventFn = Simulate[mappedEvent];


### PR DESCRIPTION
The signature was wrong because the underlying function from React TestUtils takes only 2 arguments.
There was no test to fix because we were testing only the first argument.