### PR TITLE
Update Jest docs.

### DIFF
--- a/docs/guides/jest.md
+++ b/docs/guides/jest.md
@@ -1,19 +1,15 @@
 # Using Jest with Enzyme
 
-If you are using Jest 0.9+ with enzyme and using Jest's "automocking" feature, you will need to mark
+If you are using Jest 0.9+ with enzyme and using Jest's automocking feature, you will need to mark
 react and enzyme to be unmocked in your `package.json`:
 
 ```js
 /* package.json */
 
 "jest": {
-  "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
   "unmockedModulePathPatterns": [
-    "react",
-    "enzyme"
-  ],
-  "moduleFileExtensions": [
-    "json"
+    "node_modules/react/",
+    "node_modules/enzyme/"
   ]
 }
 ```


### PR DESCRIPTION
The moduleFileExtensions option is to list the extensions Jest looks at. If you overwrite it to `json` it will not load `js` files and will not work. See https://github.com/facebook/jest/issues/1014#issuecomment-219900877

Also updated the paths to work better (because they are paths, not module names).