### PR TITLE
Add Discord logo and link to testing channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Enzyme
 [![Join the chat at https://gitter.im/airbnb/enzyme](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/airbnb/enzyme?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [![npm Version](https://img.shields.io/npm/v/enzyme.svg)](https://www.npmjs.com/package/enzyme) [![License](https://img.shields.io/npm/l/enzyme.svg)](https://www.npmjs.com/package/enzyme) [![Build Status](https://travis-ci.org/airbnb/enzyme.svg)](https://travis-ci.org/airbnb/enzyme) [![Coverage Status](https://coveralls.io/repos/airbnb/enzyme/badge.svg?branch=master&service=github)](https://coveralls.io/github/airbnb/enzyme?branch=master)
+[![Discord Channel](https://img.shields.io/badge/discord-testing@reactiflux-738bd7.svg?style=flat-square)](https://discord.gg/0ZcbPKXt5bY8vNTA)
+
+
 
 Enzyme is a JavaScript Testing utility for React that makes it easier to assert, manipulate,
 and traverse your React Components' output.


### PR DESCRIPTION
This will let users who are looking for support know they can go to #testing in reactiflux for help, instead of just opening an issue first :)