### PR TITLE
Support additional characters in attribute selectors

### DIFF
--- a/src/MountedTraversal.js
+++ b/src/MountedTraversal.js
@@ -216,7 +216,7 @@ export function buildInstPredicate(selector) {
         case SELECTOR.ID_TYPE:
           return inst => instHasId(inst, selector.substr(1));
         case SELECTOR.PROP_TYPE: {
-          const propKey = selector.split(/\[([a-zA-Z\-\:]*?)(=|\])/)[1];
+          const propKey = selector.split(/\[([a-zA-Z\d\-\:]*?)(=|\])/)[1];
           const propValue = selector.split(/=(.*?)]/)[1];
 
           return node => instHasProperty(node, propKey, propValue);

--- a/src/MountedTraversal.js
+++ b/src/MountedTraversal.js
@@ -216,7 +216,7 @@ export function buildInstPredicate(selector) {
         case SELECTOR.ID_TYPE:
           return inst => instHasId(inst, selector.substr(1));
         case SELECTOR.PROP_TYPE: {
-          const propKey = selector.split(/\[([a-zA-Z][a-zA-Z\d\-\:]*?)(=|\])/)[1];
+          const propKey = selector.split(/\[([a-zA-Z][a-zA-Z_\d\-\:]*?)(=|\])/)[1];
           const propValue = selector.split(/=(.*?)]/)[1];
 
           return node => instHasProperty(node, propKey, propValue);

--- a/src/MountedTraversal.js
+++ b/src/MountedTraversal.js
@@ -216,7 +216,7 @@ export function buildInstPredicate(selector) {
         case SELECTOR.ID_TYPE:
           return inst => instHasId(inst, selector.substr(1));
         case SELECTOR.PROP_TYPE: {
-          const propKey = selector.split(/\[([a-zA-Z\d\-\:]*?)(=|\])/)[1];
+          const propKey = selector.split(/\[([a-zA-Z][a-zA-Z\d\-\:]*?)(=|\])/)[1];
           const propValue = selector.split(/=(.*?)]/)[1];
 
           return node => instHasProperty(node, propKey, propValue);

--- a/test/ReactWrapper-spec.js
+++ b/test/ReactWrapper-spec.js
@@ -369,12 +369,13 @@ describeWithDOM('mount', () => {
     it('should support data prop selectors', () => {
       const wrapper = mount(
         <div>
-          <span data-foo="bar" />
+          <span data-foo="bar" data-foo123="bar" />
         </div>
       );
 
       expect(wrapper.find('[data-foo="bar"]')).to.have.length(1);
       expect(wrapper.find('[data-foo]')).to.have.length(1);
+      expect(wrapper.find('[data-foo123]')).to.have.length(1);
     });
 
     it('should find components with multiple matching props', () => {

--- a/test/ReactWrapper-spec.js
+++ b/test/ReactWrapper-spec.js
@@ -387,6 +387,7 @@ describeWithDOM('mount', () => {
           <span data-foo="bar" />
           <span data-foo-123="bar2" />
           <span data-123-foo="bar3" />
+          <span data-foo_bar="bar4" />
         </div>
       );
 
@@ -398,6 +399,9 @@ describeWithDOM('mount', () => {
 
       expect(wrapper.find('[data-123-foo]')).to.have.length(1);
       expect(wrapper.find('[data-123-foo="bar3"]')).to.have.length(1);
+
+      expect(wrapper.find('[data-foo_bar]')).to.have.length(1);
+      expect(wrapper.find('[data-foo_bar="bar4"]')).to.have.length(1);
     });
 
     it('should find components with multiple matching props', () => {

--- a/test/ReactWrapper-spec.js
+++ b/test/ReactWrapper-spec.js
@@ -392,8 +392,12 @@ describeWithDOM('mount', () => {
 
       expect(wrapper.find('[data-foo="bar"]')).to.have.length(1);
       expect(wrapper.find('[data-foo]')).to.have.length(1);
+
       expect(wrapper.find('[data-foo-123]')).to.have.length(1);
+      expect(wrapper.find('[data-foo-123="bar2"]')).to.have.length(1);
+
       expect(wrapper.find('[data-123-foo]')).to.have.length(1);
+      expect(wrapper.find('[data-123-foo="bar3"]')).to.have.length(1);
     });
 
     it('should find components with multiple matching props', () => {

--- a/test/ReactWrapper-spec.js
+++ b/test/ReactWrapper-spec.js
@@ -366,16 +366,34 @@ describeWithDOM('mount', () => {
 
     });
 
+    it('should not find components with invalid attributes', () => {
+      // Invalid attributes aren't valid JSX, so manual instantiation is necessary
+      const wrapper = mount(
+        React.createElement('div', null, React.createElement('span', {
+          '123-foo': 'bar',
+          '-foo': 'bar',
+          ':foo': 'bar',
+        }))
+      );
+
+      expect(wrapper.find('[-foo]')).to.have.length(0, '-foo');
+      expect(wrapper.find('[:foo]')).to.have.length(0, ':foo');
+      expect(wrapper.find('[123-foo]')).to.have.length(0, '123-foo');
+    });
+
     it('should support data prop selectors', () => {
       const wrapper = mount(
         <div>
-          <span data-foo="bar" data-foo123="bar" />
+          <span data-foo="bar" />
+          <span data-foo-123="bar2" />
+          <span data-123-foo="bar3" />
         </div>
       );
 
       expect(wrapper.find('[data-foo="bar"]')).to.have.length(1);
       expect(wrapper.find('[data-foo]')).to.have.length(1);
-      expect(wrapper.find('[data-foo123]')).to.have.length(1);
+      expect(wrapper.find('[data-foo-123]')).to.have.length(1);
+      expect(wrapper.find('[data-123-foo]')).to.have.length(1);
     });
 
     it('should find components with multiple matching props', () => {


### PR DESCRIPTION
This change allows `.find('[data-attr1]')` and `.find('[data-attr_foo]')` to match as expected.

According to the HTML5 data-* spec, digits are allowed in data-* attributes.

Additionally, this prevents matching of invalid attributes, such as `:foo`, `-foo`, or `123-foo`,