### PR TITLE
tests for mount#props() and prop()

### DIFF
--- a/test/ReactWrapper-spec.js
+++ b/test/ReactWrapper-spec.js
@@ -1533,7 +1533,7 @@ describeWithDOM('mount', () => {
       expect(wrapper.find('.foo').props().id).to.equal('fooId');
     });
 
-    it('should return props of root rendered node', () => {
+    it('called on root should return props of root node', () => {
       class Foo extends React.Component {
         render() {
           return (
@@ -1548,7 +1548,7 @@ describeWithDOM('mount', () => {
     });
 
     describeIf(!REACT013, 'stateless function components', () => {
-      it('should return props of root rendered node', () => {
+      it('called on root should return props of root node', () => {
         const Foo = ({ bar, foo }) => (
           <div className={bar} id={foo} />
         );

--- a/test/ReactWrapper-spec.js
+++ b/test/ReactWrapper-spec.js
@@ -1532,6 +1532,95 @@ describeWithDOM('mount', () => {
       expect(wrapper.find('.baz').props().onClick).to.equal(fn);
       expect(wrapper.find('.foo').props().id).to.equal('fooId');
     });
+
+    it('should return props of root rendered node', () => {
+      class Foo extends React.Component {
+        render() {
+          return (
+            <div className={this.props.bar} id={this.props.foo} />
+          );
+        }
+      }
+
+      const wrapper = mount(<Foo foo="hi" bar="bye" />);
+
+      expect(wrapper.props()).to.eql({ bar: 'bye', foo: 'hi' });
+    });
+
+    describeIf(!REACT013, 'stateless function components', () => {
+      it('should return props of root rendered node', () => {
+        const Foo = ({ bar, foo }) => (
+          <div className={bar} id={foo} />
+        );
+
+        const wrapper = mount(<Foo foo="hi" bar="bye" />);
+
+        expect(wrapper.props()).to.eql({ bar: 'bye', foo: 'hi' });
+      });
+    });
+  });
+
+  describe('.prop(name)', () => {
+
+    it('should return the props of key `name`', () => {
+      const fn = () => ({});
+      const wrapper = mount(
+        <div id="fooId" className="bax" onClick={fn} >
+          <div className="baz" />
+          <div className="foo" />
+        </div>
+      );
+
+      expect(wrapper.prop('className')).to.equal('bax');
+      expect(wrapper.prop('onClick')).to.equal(fn);
+      expect(wrapper.prop('id')).to.equal('fooId');
+
+    });
+
+    it('should be allowed to be used on an inner node', () => {
+      const fn = () => ({});
+      const wrapper = mount(
+        <div className="bax">
+          <div className="baz" onClick={fn} />
+          <div className="foo" id="fooId" />
+        </div>
+      );
+
+      expect(wrapper.find('.baz').prop('onClick')).to.equal(fn);
+      expect(wrapper.find('.foo').prop('id')).to.equal('fooId');
+    });
+
+    it('should return props of root rendered node', () => {
+      class Foo extends React.Component {
+        render() {
+          return (
+            <div className={this.props.bar} id={this.props.foo} />
+          );
+        }
+      }
+
+      const wrapper = mount(<Foo foo="hi" bar="bye" />);
+
+      expect(wrapper.prop('className')).to.equal(undefined);
+      expect(wrapper.prop('id')).to.equal(undefined);
+      expect(wrapper.prop('foo')).to.equal('hi');
+      expect(wrapper.prop('bar')).to.equal('bye');
+    });
+
+    describeIf(!REACT013, 'stateless function components', () => {
+      it('should return props of root rendered node', () => {
+        const Foo = ({ bar, foo }) => (
+          <div className={bar} id={foo} />
+        );
+
+        const wrapper = mount(<Foo foo="hi" bar="bye" />);
+
+        expect(wrapper.prop('className')).to.equal(undefined);
+        expect(wrapper.prop('id')).to.equal(undefined);
+        expect(wrapper.prop('foo')).to.equal('hi');
+        expect(wrapper.prop('bar')).to.equal('bye');
+      });
+    });
   });
 
   describe('.state(name)', () => {


### PR DESCRIPTION
- added test ensuring that props() returns props of the root node
- added tests for untested prop() method

~~@lelandrichardson can you confirm that this behaviour of returning the props passed to the root node instead of the props of rendered root node is indeed the desired behaviour?~~ nevermind, I see why it is like this