### PR TITLE
bug fix: getSeletors()

### DIFF
--- a/src/ComplexSelector.js
+++ b/src/ComplexSelector.js
@@ -8,8 +8,7 @@ export default class ComplexSelector {
   }
 
   getSelectors(selector) {
-    const cleaned = selector.replace(/\s{2,}/g, ' ');
-    const selectors = split(cleaned, / (?=(?:(?:[^"]*"){2})*[^"]*$)/);
+    const selectors = split(selector, / (?=(?:(?:[^"]*"){2})*[^"]*$)/);
     return selectors.reduce((list, sel) => {
       if (sel === '+' || sel === '~') {
         const temp = list.pop();

--- a/src/ComplexSelector.js
+++ b/src/ComplexSelector.js
@@ -9,7 +9,21 @@ export default class ComplexSelector {
 
   getSelectors(selector) {
     const cleaned = selector.replace(/\s{2,}/g, ' ');
-    const selectors = split(cleaned, ' ');
+    const selectors = split(cleaned, '"').reduce((p, c, i) => {
+      let ret;
+      if (i === 0) {
+        ret = split(c, ' ');
+      } else if (i % 2 === 1) {
+        ret = p;
+        ret[ret.length - 1] += `"${c}"`;
+      } else {
+        const tmp = split(c, ' ');
+        ret = p;
+        ret[ret.length - 1] += tmp.shift();
+        ret = ret.concat(tmp);
+      }
+      return ret;
+    }, []);
     return selectors.reduce((list, sel) => {
       if (sel === '+' || sel === '~') {
         const temp = list.pop();

--- a/src/ComplexSelector.js
+++ b/src/ComplexSelector.js
@@ -9,21 +9,7 @@ export default class ComplexSelector {
 
   getSelectors(selector) {
     const cleaned = selector.replace(/\s{2,}/g, ' ');
-    const selectors = split(cleaned, '"').reduce((p, c, i) => {
-      let ret;
-      if (i === 0) {
-        ret = split(c, ' ');
-      } else if (i % 2 === 1) {
-        ret = p;
-        ret[ret.length - 1] += `"${c}"`;
-      } else {
-        const tmp = split(c, ' ');
-        ret = p;
-        ret[ret.length - 1] += tmp.shift();
-        ret = ret.concat(tmp);
-      }
-      return ret;
-    }, []);
+    const selectors = split(cleaned, / (?=(?:(?:[^"]*"){2})*[^"]*$)/);
     return selectors.reduce((list, sel) => {
       if (sel === '+' || sel === '~') {
         const temp = list.pop();

--- a/test/ReactWrapper-spec.js
+++ b/test/ReactWrapper-spec.js
@@ -549,6 +549,15 @@ describeWithDOM('mount', () => {
       expect(() => wrapper.find(null)).to.throw(Error);
     });
 
+    it('Should query attributes with spaces in their values', () => {
+      const wrapper = mount(
+        <div>
+          <h1 data-foo="foo bar">Hello</h1>
+        </div>
+      );
+      expect(wrapper.find('[data-foo="foo bar"]')).to.have.length(1);
+    });
+
     describeIf(!REACT013, 'stateless function components', () => {
       it('should find a component based on a constructor', () => {
         const Foo = () => <div />;

--- a/test/ReactWrapper-spec.js
+++ b/test/ReactWrapper-spec.js
@@ -556,6 +556,7 @@ describeWithDOM('mount', () => {
         </div>
       );
       expect(wrapper.find('[data-foo="foo bar"]')).to.have.length(1);
+      expect(wrapper.find('[data-foo]')).to.have.length(1);
     });
 
     describeIf(!REACT013, 'stateless function components', () => {

--- a/test/ReactWrapper-spec.js
+++ b/test/ReactWrapper-spec.js
@@ -553,10 +553,15 @@ describeWithDOM('mount', () => {
       const wrapper = mount(
         <div>
           <h1 data-foo="foo bar">Hello</h1>
+          <h1 data-foo="bar baz quz">World</h1>
         </div>
       );
+      expect(wrapper.find('[data-foo]')).to.have.length(2);
       expect(wrapper.find('[data-foo="foo bar"]')).to.have.length(1);
-      expect(wrapper.find('[data-foo]')).to.have.length(1);
+      expect(wrapper.find('[data-foo="bar baz quz"]')).to.have.length(1);
+      expect(wrapper.find('[data-foo="bar baz"]')).to.have.length(0);
+      expect(wrapper.find('[data-foo="foo  bar"]')).to.have.length(0);
+      expect(wrapper.find('[data-foo="bar  baz quz"]')).to.have.length(0);
     });
 
     describeIf(!REACT013, 'stateless function components', () => {


### PR DESCRIPTION
selectors shouldn't be split by space, because selector itself can contain a space
Example: .find('div[data-foo="foo bar"]')