### PR TITLE
Loose contains and default props

### DIFF
--- a/test/ReactWrapper-spec.js
+++ b/test/ReactWrapper-spec.js
@@ -2616,6 +2616,26 @@ describeWithDOM('mount', () => {
         <div onClick={spy2}>Au revoir le monde</div>
       )).to.equal(false);
     });
+    it('should match custom component that looks like the rendered one', () => {
+      class TestComponent extends React.Component {
+        render() {
+          return (<div>Hello World</div>);
+        }
+      }
+
+      TestComponent.defaultProps = {
+        foo: 'bar',
+      };
+
+      const wrapper = mount(
+        <div>
+          <TestComponent foo="buzz" />
+        </div>
+      );
+      expect(wrapper.containsMatchingElement(
+        <TestComponent />
+      )).to.equal(true);
+    });
   });
   describe('.containsAllMatchingElements(nodes)', () => {
     it('should match on an array of nodes that all looks like one of rendered nodes', () => {

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -2559,6 +2559,26 @@ describe('shallow', () => {
         <div onClick={spy2}>Au revoir le monde</div>
       )).to.equal(false);
     });
+    it('should match custom component that looks like the rendered one', () => {
+      class TestComponent extends React.Component {
+        render() {
+          return (<div>Hello World</div>);
+        }
+      }
+
+      TestComponent.defaultProps = {
+        foo: 'bar',
+      };
+
+      const wrapper = shallow(
+        <div>
+          <TestComponent foo="buzz" />
+        </div>
+      );
+      expect(wrapper.containsMatchingElement(
+        <TestComponent />
+      )).to.equal(true);
+    });
   });
   describe('.containsAllMatchingElements(nodes)', () => {
     it('should match on an array of nodes that all looks like one of rendered nodes', () => {


### PR DESCRIPTION
Came across this issue today where the `.containsMatchingElement` function gets tripped up with default props. If a custom component has a default prop that is overridden when it's rendered you have to add that override to the component your matching against for `.containsMatchingElement` to work. I've added a minimal failing test for both the shallow and full dom render wrappers to illustrate it.

In my mind the `.containsMatchingElement` (and it's siblings) should not care that a default prop is different between the rendered component and the matching one since that is not what I'm testing but I can see why that is the case since at the point of checking React doesn't differentiate. Any thoughts on this?

Thanks!