### PR TITLE
Switch to using classList instead of className

### DIFF
--- a/src/MountedTraversal.js
+++ b/src/MountedTraversal.js
@@ -49,7 +49,14 @@ export function instHasClassName(inst, className) {
   if (!isDOMComponent(inst)) {
     return false;
   }
-  let classes = findDOMNode(inst).className || '';
+  const node = findDOMNode(inst);
+  if (node.classList) {
+    return node.classList.contains(className);
+  }
+  let classes = node.className || '';
+  if (typeof classes === 'object') {
+    classes = classes.baseVal;
+  }
   classes = classes.replace(/\s/g, ' ');
   return ` ${classes} `.indexOf(` ${className} `) > -1;
 }

--- a/test/ReactWrapper-spec.js
+++ b/test/ReactWrapper-spec.js
@@ -289,6 +289,15 @@ describeWithDOM('mount', () => {
       expect(wrapper.find('.foo').type()).to.equal('input');
     });
 
+    it('should find an SVG element based on a class name', () => {
+      const wrapper = mount(
+        <div>
+          <svg className="foo" />
+        </div>
+      );
+      expect(wrapper.find('.foo').type()).to.equal('svg');
+    });
+
     it('should find an element based on a tag name', () => {
       const wrapper = mount(
         <div>


### PR DESCRIPTION
The property [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) returns an object on some (possibly all?) SVG elements (despite stating in the linked documentation that it always returns a string. Maybe there is a different SVG implementation that I missed...). The object behaves under the interface [SVGAnimatedString](https://developer.mozilla.org/en-US/docs/Web/API/SVGAnimatedString), which does not have method ```replace```. If you have an SVG element somewhere within the mounted component then, as it iterates during a find, it processes the SVG element and throws ```TypeError: classes.replace is not a function```.

I tested [classList](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList) and it behaves correctly for SVG elements and regular elements alike. It also has a handy ```contains``` method too.