### PR TITLE
Fix broken link to Lab setup instructions.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@
   * [Karma](/docs/guides/karma.md)
   * [Mocha](/docs/guides/mocha.md)
   * [React Native](/docs/guides/react-native.md)
+  * [Lab](/docs/guides/lab.md)
 * [Installation](/docs/installation/README.md)
   * [Working with React 0.13.x](/docs/installation/react-013.md)
   * [Working with React 0.14.x](/docs/installation/react-014.md)


### PR DESCRIPTION
On the documentation home page, the link to the Lab instructions should lead you to a web page, instead you get the option to download a markdown file.

This ensures the link points to the generated HTML by adding the Lab page to the table of contents. The build gives many similar errors  (`x contains an hyperlink to resource outside spine`), so if you think this fix is correct I could also go over the rest.