### PR TITLE
fixes mount().debug() output with mixed children

### DIFF
--- a/src/Debug.js
+++ b/src/Debug.js
@@ -81,6 +81,10 @@ export function debugInst(inst, indentLength = 2) {
   if (typeof inst === 'string' || typeof inst === 'number') return escape(inst);
   if (!inst) return '';
 
+  if (inst._stringText) {
+    return inst._stringText;
+  }
+
   if (!inst.getPublicInstance) {
     const internal = internalInstance(inst);
     return debugInst(internal, indentLength);

--- a/test/Debug-spec.js
+++ b/test/Debug-spec.js
@@ -212,6 +212,23 @@ describe('debug', () => {
 </Foo>`);
     });
 
+    it('renders basic debug of components with mixed children', () => {
+      class Foo extends React.Component {
+        render() {
+          return (
+            <div>hello{'world'}</div>
+          );
+        }
+      }
+      expect(mount(<Foo id="2" />).debug()).to.eql(
+`<Foo id="2">
+  <div>
+    hello
+    world
+  </div>
+</Foo>`);
+    });
+
     it('renders debug of compositional components', () => {
       class Foo extends React.Component {
         render() {

--- a/test/Debug-spec.js
+++ b/test/Debug-spec.js
@@ -61,6 +61,17 @@ describe('debug', () => {
       );
     });
 
+    it('should render mixed children', () => {
+      expect(debugNode(
+        <div>hello{'world'}</div>
+      )).to.equal(
+        `<div>
+  hello
+  world
+</div>`
+      );
+    });
+
     it('should render props on root and children', () => {
       expect(debugNode(
         <div id="foo">


### PR DESCRIPTION
closes #475 

could one of the other maintainers look at this to make sure this change actually makes sense?