### PR TITLE
add tests for SFCs that return null in react 15

### DIFF
--- a/test/ReactWrapper-spec.js
+++ b/test/ReactWrapper-spec.js
@@ -1,4 +1,10 @@
-import { describeWithDOM, describeIf, itWithData, generateEmptyRenderData } from './_helpers';
+import {
+  describeWithDOM,
+  describeIf,
+  itIf,
+  itWithData,
+  generateEmptyRenderData,
+} from './_helpers';
 import React from 'react';
 import { expect } from 'chai';
 import {
@@ -2466,12 +2472,24 @@ describeWithDOM('mount', () => {
     });
   });
 
-  it('works with components that return null', () => {
+  it('works with class components that return null', () => {
     class Foo extends React.Component {
       render() {
         return null;
       }
     }
+    const wrapper = mount(<Foo />);
+    expect(wrapper).to.have.length(1);
+    expect(wrapper.type()).to.equal(Foo);
+    expect(wrapper.html()).to.equal(null);
+    const rendered = wrapper.render();
+    expect(rendered.length).to.equal(0);
+    expect(rendered.html()).to.equal(null);
+  });
+
+  itIf(REACT15, 'works with SFCs that return null', () => {
+    const Foo = () => null;
+
     const wrapper = mount(<Foo />);
     expect(wrapper).to.have.length(1);
     expect(wrapper.type()).to.equal(Foo);

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow, render, ShallowWrapper } from '../src/';
 import sinon from 'sinon';
-import { describeIf, itWithData, generateEmptyRenderData } from './_helpers';
+import { describeIf, itIf, itWithData, generateEmptyRenderData } from './_helpers';
 import { REACT013, REACT15 } from '../src/version';
 
 describe('shallow', () => {
@@ -2461,6 +2461,18 @@ describe('shallow', () => {
         return null;
       }
     }
+    const wrapper = shallow(<Foo />);
+    expect(wrapper).to.have.length(1);
+    expect(wrapper.html()).to.equal(null);
+    expect(wrapper.type()).to.equal(null);
+    const rendered = wrapper.render();
+    expect(rendered.length).to.equal(0);
+    expect(rendered.html()).to.equal(null);
+  });
+
+  itIf(REACT15, 'works with SFCs that return null', () => {
+    const Foo = () => null;
+
     const wrapper = shallow(<Foo />);
     expect(wrapper).to.have.length(1);
     expect(wrapper.html()).to.equal(null);


### PR DESCRIPTION
React 15 added support for SFCs that return null. I added tests for this scenario in mount and shallow to complement preexisting tests for class components that return null