### PR TITLE
docs: add AVA guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ testing your React components, you can consider using [jasmine-enzyme](https://g
 
 [Using Enzyme with Lab](/docs/guides/lab.md)
 
+[Using Enzyme with Tape and AVA](/docs/guides/tape-ava.md)
+
 ### [Installation](/docs/installation/README.md)
 
 To get started with enzyme, you can simply install it with npm:

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@
   * [Mocha](/docs/guides/mocha.md)
   * [React Native](/docs/guides/react-native.md)
   * [Lab](/docs/guides/lab.md)
+  * [Tape and AVA](/docs/guides/tape-ava.md)
 * [Installation](/docs/installation/README.md)
   * [Working with React 0.13.x](/docs/installation/react-013.md)
   * [Working with React 0.14.x](/docs/installation/react-014.md)

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -7,3 +7,4 @@
 - [*Using Enzyme with Jest*](guides/jest.md)
 - [*Using Enzyme with Karma*](guides/karma.md)
 - [*Using Enzyme with Mocha*](guides/mocha.md)
+- [*Using Enzyme with Tape and AVA*](guides/tape-ava.md)

--- a/docs/guides/tape-ava.md
+++ b/docs/guides/tape-ava.md
@@ -1,0 +1,55 @@
+# Using Enzyme with Tape and AVA
+
+Enzyme works well with [Tape](https://github.com/substack/tape) and [AVA](https://github.com/avajs/ava).
+Simply install it and start using it:
+
+```bash
+npm i --save-dev enzyme
+```
+
+## Tape
+
+```jsx
+import test from 'tape'
+import React from 'react'
+import { shallow, mount } from 'enzyme';
+
+import Foo from '../path/to/foo'
+
+test('shallow', t => {
+  const wrapper = shallow(<Foo />)
+  t.equal(wrapper.contains(<span>Foo</span>), true)
+})
+
+test('mount', t => {
+  const wrapper = mount(<Foo />)
+  const fooInner = wrapper.find('.foo-inner')
+  t.equal(fooInner.is('.foo-inner'), true)
+})
+```
+
+## AVA
+
+
+```jsx
+import test from 'ava'
+import React from 'react'
+import { shallow, mount } from 'enzyme';
+
+import Foo from '../path/to/foo'
+
+test('shallow', t => {
+  const wrapper = shallow(<Foo />)
+  t.is(wrapper.contains(<span>Foo</span>), true)
+})
+
+test('mount', t => {
+  const wrapper = mount(<Foo />)
+  const fooInner = wrapper.find('.foo-inner')
+  t.is(fooInner.is('.foo-inner'), true)
+})
+```
+
+## Example Projects
+
+- [enzyme-example-ava](https://github.com/mikenikles/enzyme-example-ava)


### PR DESCRIPTION
This adds an example of how to use enzyme with [AVA](https://github.com/avajs/ava).