### PR TITLE
Typo in docs

### DIFF
--- a/docs/api/ReactWrapper/matchesElement.md
+++ b/docs/api/ReactWrapper/matchesElement.md
@@ -21,7 +21,7 @@ render tree.
 
 
 ```jsx
-onst MyComponent = React.createClass({
+const MyComponent = React.createClass({
   handleClick() {
     ...
   },

--- a/docs/api/ShallowWrapper/matchesElement.md
+++ b/docs/api/ShallowWrapper/matchesElement.md
@@ -21,7 +21,7 @@ render tree.
 
 
 ```jsx
-onst MyComponent = React.createClass({
+const MyComponent = React.createClass({
   handleClick() {
     ...
   },


### PR DESCRIPTION
Hey! I found two very small typos in the docs. In both cases, `onst` should be `const`.