### PR TITLE
className may be a function

### DIFF
--- a/src/ShallowTraversal.js
+++ b/src/ShallowTraversal.js
@@ -27,6 +27,9 @@ export function childrenOfNode(node) {
 
 export function hasClassName(node, className) {
   let classes = propsOfNode(node).className || '';
+  if (typeof classes !== 'string') {
+    classes = classes.toString();
+	}
   classes = classes.replace(/\s/g, ' ');
   return ` ${classes} `.indexOf(` ${className} `) > -1;
 }


### PR DESCRIPTION
hola :) 
we use [bem-cn] (https://github.com/albburtsev/bem-cn) that returns function which react casts into string while rendering, but your framework doesn't consider it. So let's cast to string!