### PR TITLE
Throw if some() is called on a root wrapper

### DIFF
--- a/src/ReactWrapper.js
+++ b/src/ReactWrapper.js
@@ -727,6 +727,9 @@ export default class ReactWrapper {
    * @returns {Boolean}
    */
   some(selector) {
+    if (this.root === this) {
+      throw new Error('ReactWrapper::some() can not be called on the root');
+    }
     const predicate = buildInstPredicate(selector);
     return this.nodes.some(predicate);
   }

--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -806,6 +806,9 @@ export default class ShallowWrapper {
    * @returns {Boolean}
    */
   some(selector) {
+    if (this.root === this) {
+      throw new Error('ShallowWrapper::some() can not be called on the root');
+    }
     const predicate = buildPredicate(selector);
     return this.nodes.some(predicate);
   }

--- a/test/ReactWrapper-spec.js
+++ b/test/ReactWrapper-spec.js
@@ -2115,6 +2115,16 @@ describeWithDOM('mount', () => {
       expect(wrapper.find('.foo').some('.foo')).to.equal(true);
       expect(wrapper.find('.foo').some('.bar')).to.equal(false);
     });
+    it('should throw if called on root', () => {
+      const wrapper = mount(
+        <div>
+          <div className="foo" />
+        </div>
+      );
+      expect(() => wrapper.some('.foo')).to.throw(
+        'ReactWrapper::some() can not be called on the root'
+      );
+    });
   });
 
   describe('.someWhere(predicate)', () => {

--- a/test/ShallowWrapper-spec.js
+++ b/test/ShallowWrapper-spec.js
@@ -1998,6 +1998,16 @@ describe('shallow', () => {
       expect(wrapper.find('.foo').some('.foo')).to.equal(true);
       expect(wrapper.find('.foo').some('.bar')).to.equal(false);
     });
+    it('should throw if called on root', () => {
+      const wrapper = shallow(
+        <div>
+          <div className="foo" />
+        </div>
+      );
+      expect(() => wrapper.some('.foo')).to.throw(
+        'ShallowWrapper::some() can not be called on the root'
+      );
+    });
   });
 
   describe('.someWhere(predicate)', () => {


### PR DESCRIPTION
Resolves https://github.com/airbnb/enzyme/issues/510#issuecomment-236721789 per @ljharb's recommendation.