### PR TITLE
Document additional bugfix in 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 - fix id selector not working when combined with a tag selector ([#387](https://github.com/airbnb/enzyme/pull/387))
 
+- Support spaces in attribute selector values ([#427](https://github.com/airbnb/enzyme/pull/427))
 
 
 


### PR DESCRIPTION
Support for spaces in attribute selector values was added in 2.4.0 ([PR #427](https://github.com/airbnb/enzyme/pull/427)) but was not documented in the changelog.  It took me a while to sort out why my selectors `option[value="by Alice"]` were working in 2.4.1 but not 2.3.0 ([see my gradual realization here](https://github.com/code-dot-org/code-dot-org/pull/9830)).  I'm recommending this get added to the changelog to save others some time.