### PR TITLE
Fix Mount CSS prop selector for parity with Shallow

### DIFF
--- a/src/MountedTraversal.js
+++ b/src/MountedTraversal.js
@@ -84,7 +84,6 @@ export function instHasType(inst, type) {
 }
 
 export function instHasProperty(inst, propKey, stringifiedPropValue) {
-  if (!isDOMComponent(inst)) return false;
   const node = getNode(inst);
   const nodeProps = propsOfNode(node);
   const descriptor = Object.getOwnPropertyDescriptor(nodeProps, propKey);

--- a/test/ReactWrapper-spec.jsx
+++ b/test/ReactWrapper-spec.jsx
@@ -384,6 +384,20 @@ describeWithDOM('mount', () => {
 
     });
 
+    it('should find React Component based on a components prop via css selector', () => {
+      class Foo extends React.Component {
+        render() { return <div />; }
+      }
+      const wrapper = mount(
+        <div>
+          <Foo bar="baz" />
+        </div>
+      );
+
+      expect(wrapper.find('[bar]')).to.have.length(1);
+      expect(wrapper.find('Foo[bar="baz"]')).to.have.length(1);
+    });
+
     it('should not find components with invalid attributes', () => {
       // Invalid attributes aren't valid JSX, so manual instantiation is necessary
       const wrapper = mount(

--- a/test/ReactWrapper-spec.jsx
+++ b/test/ReactWrapper-spec.jsx
@@ -386,16 +386,16 @@ describeWithDOM('mount', () => {
 
     it('should find React Component based on a components prop via css selector', () => {
       class Foo extends React.Component {
-        render() { return <div />; }
+        render() { return <div {...this.props} />; }
       }
       const wrapper = mount(
         <div>
-          <Foo bar="baz" />
+          <Foo role="button" />
         </div>
       );
 
-      expect(wrapper.find('[bar]')).to.have.length(1);
-      expect(wrapper.find('Foo[bar="baz"]')).to.have.length(1);
+      expect(wrapper.find('[role]')).to.have.length(2);
+      expect(wrapper.find('Foo[role="button"]')).to.have.length(1);
     });
 
     it('should not find components with invalid attributes', () => {

--- a/test/ShallowWrapper-spec.jsx
+++ b/test/ShallowWrapper-spec.jsx
@@ -483,16 +483,16 @@ describe('shallow', () => {
 
     it('should find a React Component based on a components prop via css selector', () => {
       class Foo extends React.Component {
-        render() { return <div />; }
+        render() { return <div {...this.props} />; }
       }
       const wrapper = shallow(
         <div>
-          <Foo bar="baz" />
+          <Foo role="button" />
         </div>
       );
 
-      expect(wrapper.find('[bar]')).to.have.length(1);
-      expect(wrapper.find('Foo[bar="baz"]')).to.have.length(1);
+      expect(wrapper.find('[role]')).to.have.length(1);
+      expect(wrapper.find('Foo[role="button"]')).to.have.length(1);
     });
 
     it('should find components with multiple matching react props', () => {

--- a/test/ShallowWrapper-spec.jsx
+++ b/test/ShallowWrapper-spec.jsx
@@ -481,6 +481,20 @@ describe('shallow', () => {
       expect(wrapper.find('[data-foo]')).to.have.length(1);
     });
 
+    it('should find a React Component based on a components prop via css selector', () => {
+      class Foo extends React.Component {
+        render() { return <div />; }
+      }
+      const wrapper = shallow(
+        <div>
+          <Foo bar="baz" />
+        </div>
+      );
+
+      expect(wrapper.find('[bar]')).to.have.length(1);
+      expect(wrapper.find('Foo[bar="baz"]')).to.have.length(1);
+    });
+
     it('should find components with multiple matching react props', () => {
       function noop() {}
       const wrapper = shallow(


### PR DESCRIPTION
Selector such as `Foo[bar="baz"]` previously would not return any components when rendering with `mount`.

Resolves #534
