### PR TITLE
Support convert shallow wrapper to format compatible with pretty-format and jest-snapshot

### DIFF
--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -2,6 +2,7 @@ import React from 'react';
 import flatten from 'lodash/flatten';
 import unique from 'lodash/uniq';
 import compact from 'lodash/compact';
+import omit from 'lodash/omit';
 import cheerio from 'cheerio';
 
 import ComplexSelector from './ComplexSelector';
@@ -516,6 +517,29 @@ export default class ShallowWrapper {
       // NOTE: splitting this into two statements is required to make the linter happy.
       const isNull = this.type() === null;
       return isNull ? null : renderToStaticMarkup(n);
+    });
+  }
+
+  /**
+   * Return a JSON representation of the node.
+   *
+   * NOTE: can only be called on a wrapper of a single node.
+   *
+   * @returns {Object}
+   */
+  json() {
+    return this.single('json', () => {
+      if (this.type() == null) {
+        return this.node;
+      }
+
+      const childrens = compact(this.children().map(c => c.json()));
+      return {
+        type: this.name(),
+        props: omit(this.props(), 'children'),
+        children: (childrens.length) ? childrens : null,
+        $$typeof: Symbol.for('react.test.json'),
+      };
     });
   }
 

--- a/test/ShallowWrapper-spec.jsx
+++ b/test/ShallowWrapper-spec.jsx
@@ -2405,11 +2405,11 @@ describe('shallow', () => {
 
     it('should return json of straight components without children', () => {
       const wrapper = shallow(
-        <input className="test" />
+        <div className="test" />
       );
 
       expect(wrapper.json()).to.deep.equal({
-        type: 'input',
+        type: 'div',
         props: { className: 'test' },
         $$typeof: Symbol.for('react.test.json'),
         children: null,

--- a/test/ShallowWrapper-spec.jsx
+++ b/test/ShallowWrapper-spec.jsx
@@ -2373,6 +2373,83 @@ describe('shallow', () => {
     });
   });
 
+  describe('.json()', () => {
+    it('should return json of straight components with children', () => {
+      const wrapper = shallow(
+        <div className="test">
+          <span>Hello</span>
+          <span>World!</span>
+        </div>
+      );
+
+      expect(wrapper.json()).to.deep.equal({
+        type: 'div',
+        props: { className: 'test' },
+        $$typeof: Symbol.for('react.test.json'),
+        children: [
+          {
+            type: 'span',
+            props: {},
+            children: ['Hello'],
+            $$typeof: Symbol.for('react.test.json'),
+          },
+          {
+            type: 'span',
+            props: {},
+            children: ['World!'],
+            $$typeof: Symbol.for('react.test.json'),
+          },
+        ],
+      });
+    });
+
+    it('should return json of straight components without children', () => {
+      const wrapper = shallow(
+        <input className="test" />
+      );
+
+      expect(wrapper.json()).to.deep.equal({
+        type: 'input',
+        props: { className: 'test' },
+        $$typeof: Symbol.for('react.test.json'),
+        children: null,
+      });
+    });
+
+
+    it('should return shallow json of nested composite components', () => {
+      class Foo extends React.Component {
+        render() {
+          return (<div className="in-foo" />);
+        }
+      }
+      class Bar extends React.Component {
+        render() {
+          return (
+            <div className="in-bar">
+              <Foo fooProp={'value'} />
+            </div>
+          );
+        }
+      }
+
+      const wrapper = shallow(<Bar />);
+      expect(wrapper.json()).to.deep.equal({
+        type: 'div',
+        props: { className: 'in-bar' },
+        $$typeof: Symbol.for('react.test.json'),
+        children: [
+          {
+            type: 'Foo',
+            props: { fooProp: 'value' },
+            children: null,
+            $$typeof: Symbol.for('react.test.json'),
+          },
+        ],
+      });
+    });
+  });
+
   describe('.html()', () => {
     it('should return html of straight DOM elements', () => {
       const wrapper = shallow(


### PR DESCRIPTION
The new `.json()` method convert the shallow node to compatible object.

This allow us to use enzyme+shallow with jest-snapshot:

```jsx
import Foo from 'yyy';

const Bar = ({ value }) => (
  <div className="in-bar">
    <Foo fooProp={value} />
  </div>
);

const wrapper = shallow(<Bar value={ 'xxx' } />);
expect(wrapper.json()).toMatchSnapshot();
```

will create a snapshot as:

```jsx
exports[`example test 1`] = `
<div className="in-bar">
  <Foo fooProp="xxx" />
</div>
`;
```

More info: [pretty-format](https://github.com/thejameskyle/pretty-format) and [jest snapshot](https://facebook.github.io/jest/blog/2016/07/27/jest-14.html)