### PR TITLE
Add missing import statement in Mocha example

### DIFF
--- a/docs/guides/mocha.md
+++ b/docs/guides/mocha.md
@@ -9,6 +9,7 @@ npm i --save-dev enzyme
 
 ```jsx
 import React from 'react';
+import { expect } from 'chai';
 import { mount, shallow } from 'enzyme';
 
 describe('<Foo />', () => {


### PR DESCRIPTION
Example file: https://github.com/lelandrichardson/enzyme-example-mocha/blob/master/test/Foo-test.js

There's also `render` import in the file example, don't know what that's for, probably unused.