### PR TITLE
Fix broken links to API docs

### DIFF
--- a/docs/api/mount.md
+++ b/docs/api/mount.md
@@ -186,28 +186,28 @@ Maps the current array of nodes to another array.
 #### [`.matchesElement(node) => Boolean`](ReactWrapper/matchesElement.md)
 Returns whether or not a given react element matches the current render tree.
 
-#### [`.reduce(fn[, initialValue]) => Any`](/docs/api/ReactWrapper/reduce.md)
+#### [`.reduce(fn[, initialValue]) => Any`](ReactWrapper/reduce.md)
 Reduces the current array of nodes to a value
 
-#### [`.reduceRight(fn[, initialValue]) => Any`](/docs/api/ReactWrapper/reduceRight.md)
+#### [`.reduceRight(fn[, initialValue]) => Any`](ReactWrapper/reduceRight.md)
 Reduces the current array of nodes to a value, from right to left.
 
 #### [`.tap(intercepter) => Self`](ReactWrapper/tap.md)
 Taps into the wrapper method chain. Helpful for debugging.
 
-#### [`.some(selector) => Boolean`](/docs/api/ReactWrapper/some.md)
+#### [`.some(selector) => Boolean`](ReactWrapper/some.md)
 Returns whether or not any of the nodes in the wrapper match the provided selector.
 
-#### [`.someWhere(predicate) => Boolean`](/docs/api/ReactWrapper/someWHere.md)
+#### [`.someWhere(predicate) => Boolean`](ReactWrapper/someWhere.md)
 Returns whether or not any of the nodes in the wrapper pass the provided predicate function.
 
-#### [`.every(selector) => Boolean`](/docs/api/ReactWrapper/every.md)
+#### [`.every(selector) => Boolean`](ReactWrapper/every.md)
 Returns whether or not all of the nodes in the wrapper match the provided selector.
 
-#### [`.everyWhere(predicate) => Boolean`](/docs/api/ReactWrapper/everyWhere.md)
+#### [`.everyWhere(predicate) => Boolean`](ReactWrapper/everyWhere.md)
 Returns whether or not all of the nodes in the wrapper pass the provided predicate function.
 
-#### [`.ref(refName) => ReactWrapper`](/docs/api/ReactWrapper/ref.md)
+#### [`.ref(refName) => ReactWrapper`](ReactWrapper/ref.md)
 Returns a wrapper of the node that matches the provided reference name.
 
 #### [`.detach() => void`](ReactWrapper/detach.md)

--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -187,23 +187,23 @@ Iterates through each node of the current wrapper and executes the provided func
 #### [`.map(fn) => Array`](ShallowWrapper/map.md)
 Maps the current array of nodes to another array.
 
-#### [`.reduce(fn[, initialValue]) => Any`](/docs/api/ShallowWrapper/reduce.md)
+#### [`.reduce(fn[, initialValue]) => Any`](ShallowWrapper/reduce.md)
 Reduces the current array of nodes to a value
 
-#### [`.reduceRight(fn[, initialValue]) => Any`](/docs/api/ShallowWrapper/reduceRight.md)
+#### [`.reduceRight(fn[, initialValue]) => Any`](ShallowWrapper/reduceRight.md)
 Reduces the current array of nodes to a value, from right to left.
 
 #### [`.tap(intercepter) => Self`](ShallowWrapper/tap.md)
 Taps into the wrapper method chain. Helpful for debugging.
 
-#### [`.some(selector) => Boolean`](/docs/api/ShallowWrapper/some.md)
+#### [`.some(selector) => Boolean`](ShallowWrapper/some.md)
 Returns whether or not any of the nodes in the wrapper match the provided selector.
 
-#### [`.someWhere(predicate) => Boolean`](/docs/api/ShallowWrapper/someWhere.md)
+#### [`.someWhere(predicate) => Boolean`](ShallowWrapper/someWhere.md)
 Returns whether or not any of the nodes in the wrapper pass the provided predicate function.
 
-#### [`.every(selector) => Boolean`](/docs/api/ShallowWrapper/every.md)
+#### [`.every(selector) => Boolean`](ShallowWrapper/every.md)
 Returns whether or not all of the nodes in the wrapper match the provided selector.
 
-#### [`.everyWhere(predicate) => Boolean`](/docs/api/ShallowWrapper/everyWhere.md)
+#### [`.everyWhere(predicate) => Boolean`](ShallowWrapper/everyWhere.md)
 Returns whether or not all of the nodes in the wrapper pass the provided predicate function.


### PR DESCRIPTION
- The link to `.someWhere` in mount.md was broken due to a capitalization error
- All of the other links were broken in the web version of the docs due to absolute paths (they did work w/in Github)