### PR TITLE
Remove redundant `exposedProperties` array

### DIFF
--- a/docs/guides/jsdom.md
+++ b/docs/guides/jsdom.md
@@ -16,13 +16,10 @@ As a result, a standalone script like the one below is generally a good approach
 
 var jsdom = require('jsdom').jsdom;
 
-var exposedProperties = ['window', 'navigator', 'document'];
-
 global.document = jsdom('');
 global.window = document.defaultView;
 Object.keys(document.defaultView).forEach((property) => {
   if (typeof global[property] === 'undefined') {
-    exposedProperties.push(property);
     global[property] = document.defaultView[property];
   }
 });

--- a/withDom.js
+++ b/withDom.js
@@ -2,13 +2,10 @@ if (!global.document) {
   try {
     const jsdom = require('jsdom').jsdom; // could throw
 
-    const exposedProperties = ['window', 'navigator', 'document'];
-
     global.document = jsdom('');
     global.window = document.defaultView;
     Object.keys(document.defaultView).forEach((property) => {
       if (typeof global[property] === 'undefined') {
-        exposedProperties.push(property);
         global[property] = document.defaultView[property];
       }
     });


### PR DESCRIPTION
I couldn't see any reason for the `exposedProperties` array in `withDom.js`. Seems to be redundant so this pull request removes it. 

/cc @lelandrichardson 