### PR TITLE
Add documentation note clarifying shallow wrapper prop functions

### DIFF
--- a/docs/api/ShallowWrapper/prop.md
+++ b/docs/api/ShallowWrapper/prop.md
@@ -3,14 +3,15 @@
 Returns the prop value for the root node of the wrapper with the provided key.
 `.prop(key)` can only be called on a wrapper of a single node.
 
-NOTE: When called on a shallow wrapper, `.prop(key)` will only return values for props that exist for the parent element of the component, not the whole React component. To return the props for the
-entire React component, use `wrapper.instance().props`. See [`.instance() =>
-ReactComponent`](instance.md)
+NOTE: When called on a shallow wrapper, `.prop(key)` will return values for
+props on the root node that the component *renders*, not the component itself.
+To return the props for the entire React component, use `wrapper.instance().props`.
+See [`.instance() => ReactComponent`](instance.md)
 
 #### Arguments
 
 1. `key` (`String`): The prop name such that this will return value will be the `this.props[key]`
-of the parent element of the component.
+of the root node of the component.
 
 
 
@@ -28,7 +29,7 @@ const MyComponent = React.createClass({
 const wrapper = shallow(<MyComponent includedProp="Success!" excludedProp="I'm not included" />);
 expect(wrapper.prop('includedProp')).to.equal("Success!");
 
-// Warning: .prop(key) only returns values for props that exist in the parent element.
+// Warning: .prop(key) only returns values for props that exist in the root node.
 // See the note above about wrapper.instance().props to return all props in the React component.
 
 wrapper.prop('includedProp');

--- a/docs/api/ShallowWrapper/prop.md
+++ b/docs/api/ShallowWrapper/prop.md
@@ -1,13 +1,16 @@
 # `.prop(key) => Any`
 
-Returns the prop value for the node of the current wrapper with the provided key.
+Returns the prop value for the root node of the wrapper with the provided key.
+`.prop(key)` can only be called on a wrapper of a single node.
 
-NOTE: can only be called on a wrapper of a single node.
+NOTE: When called on a shallow wrapper, `.prop(key)` will only return values for props that exist for the parent element of the component, not the whole React component. To return the props for the
+entire React component, use `wrapper.instance().props`. See [`.instance() =>
+ReactComponent`](instance.md)
 
 #### Arguments
 
 1. `key` (`String`): The prop name such that this will return value will be the `this.props[key]`
-of the component instance.
+of the parent element of the component.
 
 
 
@@ -15,8 +18,27 @@ of the component instance.
 
 
 ```jsx
-const wrapper = shallow(<MyComponent foo={10} />);
-expect(wrapper.prop('foo')).to.equal(10);
+const MyComponent = React.createClass({
+  render() {
+    return (
+        <div className="foo bar" includedProp={this.props.includedProp}>Hello</div>
+    )
+  }
+})
+const wrapper = shallow(<MyComponent includedProp="Success!" excludedProp="I'm not included" />);
+expect(wrapper.prop('includedProp')).to.equal("Success!");
+
+// Warning: .prop(key) only returns values for props that exist in the parent element.
+// See the note above about wrapper.instance().props to return all props in the React component.
+
+wrapper.prop('includedProp');
+// "Success!"
+
+wrapper.prop('excludedProp');
+// undefined
+
+wrapper.instance().props.excludedProp;
+// "I'm not included"
 ```
 
 

--- a/docs/api/ShallowWrapper/props.md
+++ b/docs/api/ShallowWrapper/props.md
@@ -1,11 +1,12 @@
 # `.props() => Object`
 
-Returns the props hash for the root node of the wrapper. `.props()` can only be called on a wrapper of a single node.
+Returns the props hash for the root node of the wrapper. `.props()` can only be
+called on a wrapper of a single node.
 
-NOTE: When called on a shallow wrapper, `.props()` will only return the
-props for the parent element in the component, not the whole React component. To return the props for the
-entire React component, use `wrapper.instance().props`. See [`.instance() =>
-ReactComponent`](instance.md)
+NOTE: When called on a shallow wrapper, `.props()` will return values for
+props on the root node that the component *renders*, not the component itself.
+To return the props for the entire React component, use `wrapper.instance().props`.
+See [`.instance() => ReactComponent`](instance.md)
 
 
 #### Example
@@ -22,7 +23,7 @@ const MyComponent = React.createClass({
 const wrapper = shallow(<MyComponent includedProp="Success!" excludedProp="I'm not included" />);
 expect(wrapper.props().includedProp).to.equal("Success!");
 
-// Warning: .props() only returns props that are passed to the parent element,
+// Warning: .props() only returns props that are passed to the root node,
 // which does not include excludedProp in this example.
 // See the note above about wrapper.instance().props.
 

--- a/docs/api/ShallowWrapper/props.md
+++ b/docs/api/ShallowWrapper/props.md
@@ -1,16 +1,37 @@
 # `.props() => Object`
 
-Returns the props hash for the current node of the wrapper.
+Returns the props hash for the root node of the wrapper. `.props()` can only be called on a wrapper of a single node.
 
-NOTE: can only be called on a wrapper of a single node.
+NOTE: When called on a shallow wrapper, `.props()` will only return the
+props for the parent element in the component, not the whole React component. To return the props for the
+entire React component, use `wrapper.instance().props`. See [`.instance() =>
+ReactComponent`](instance.md)
 
 
 #### Example
 
 
 ```jsx
-const wrapper = shallow(<MyComponent foo={10} />);
-expect(wrapper.props().foo).to.equal(10);
+const MyComponent = React.createClass({
+  render() {
+    return (
+        <div className="foo bar" includedProp={this.props.includedProp}>Hello</div>
+    )
+  }
+})
+const wrapper = shallow(<MyComponent includedProp="Success!" excludedProp="I'm not included" />);
+expect(wrapper.props().includedProp).to.equal("Success!");
+
+// Warning: .props() only returns props that are passed to the parent element,
+// which does not include excludedProp in this example.
+// See the note above about wrapper.instance().props.
+
+wrapper.props();
+// {children: "Hello", className: "foo bar", includedProp="Success!"}
+
+wrapper.instance().props;
+// {children: "Hello", className: "foo bar", includedProp:"Success!", excludedProp: "I'm not included"}
+
 ```
 
 


### PR DESCRIPTION
Fixes #397

As many others have stated, the documentation for .props & .prop(key) are fairly ambiguous on which props are being return for shallow wrappers. It's unclear that the props that are actually being returned are from the **parent element of the component**, since it's easy to mistakenly assume that `props()` would return the props you would recieve from a React component as with `this.props`

Changes proposed:

- Add notes to both `.prop(key)` and `.props()` documentation in the ShallowWrapper API warning newcomers about what **props are being returned & what props are not**

- Add references to `instance()` to show how to retrieve the instance props as with the usual React `this.props` pattern.

- Update examples for both pages to demonstrate the key difference between the props returned & the instance props.

