### PR TITLE
Fix typo on gh-pages for const

### DIFF
--- a/docs/api/ShallowWrapper/matchesElement.html
+++ b/docs/api/ShallowWrapper/matchesElement.html
@@ -2088,7 +2088,7 @@ render tree.</li>
 <h4 id="returns"><a name="returns" class="plugin-anchor" href="#returns"><span class="fa fa-link"></span></a>Returns</h4>
 <p><code>Boolean</code>: whether or not the current <a href="../../../GLOSSARY.html#wrapper" class="glossary-term" title="A wrapper refers to the enzyme wrapper class that provides the API.">wrapper</a> match the one passed in.</p>
 <h4 id="example"><a name="example" class="plugin-anchor" href="#example"><span class="fa fa-link"></span></a>Example</h4>
-<pre><code class="lang-jsx">onst MyComponent <span class="token operator">=</span> React<span class="token punctuation">.</span><span class="token function">createClass</span><span class="token punctuation">(</span><span class="token punctuation">{</span>
+<pre><code class="lang-jsx">const MyComponent <span class="token operator">=</span> React<span class="token punctuation">.</span><span class="token function">createClass</span><span class="token punctuation">(</span><span class="token punctuation">{</span>
   <span class="token function">handleClick</span><span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
     <span class="token punctuation">.</span><span class="token punctuation">.</span><span class="token punctuation">.</span>
   <span class="token punctuation">}</span><span class="token punctuation">,</span>


### PR DESCRIPTION
Fixes `onst MyComponent = React.createClass({` typo in matchesElement documentation in gh-pages.