### PR TITLE
update docs

### DIFF
--- a/docs/api/mount.md
+++ b/docs/api/mount.md
@@ -12,11 +12,13 @@ implemented completely in JS.
 
 ```jsx
 import { mount } from 'enzyme';
+import sinon from 'sinon';
+import Foo from './Foo';
 
 describe('<Foo />', () => {
 
   it('calls componentDidMount', () => {
-    spy(Foo.prototype, 'componentDidMount');
+    sinon.spy(Foo.prototype, 'componentDidMount');
     const wrapper = mount(<Foo />);
     expect(Foo.prototype.componentDidMount.calledOnce).to.equal(true);
   });
@@ -29,7 +31,7 @@ describe('<Foo />', () => {
   });
 
   it('simulates click events', () => {
-    const onButtonClick = spy();
+    const onButtonClick = sinon.spy();
     const wrapper = mount(
       <Foo onButtonClick={onButtonClick} />
     );


### PR DESCRIPTION
Update docs to use import sinon and use sinon.spy instead of spy. This is a bit more consistent with https://github.com/airbnb/enzyme/blob/master/README.md, and may help remove confusion: https://github.com/airbnb/enzyme/issues/301