### PR TITLE
Ignore text nodes in childrenOfInstInternal

### DIFF
--- a/src/MountedTraversal.js
+++ b/src/MountedTraversal.js
@@ -124,6 +124,9 @@ export function childrenOfInstInternal(inst) {
       if (REACT013 && !node.getPublicInstance) {
         return false;
       }
+      if (typeof renderedChildren[key]._stringText !== 'undefined') {
+        return false;
+      }
       return true;
     }).map((node) => {
       if (!REACT013 && typeof node._currentElement.type === 'function') {

--- a/src/MountedTraversal.js
+++ b/src/MountedTraversal.js
@@ -124,7 +124,7 @@ export function childrenOfInstInternal(inst) {
       if (REACT013 && !node.getPublicInstance) {
         return false;
       }
-      if (typeof renderedChildren[key]._stringText !== 'undefined') {
+      if (typeof node._stringText !== 'undefined') {
         return false;
       }
       return true;

--- a/test/ReactWrapper-spec.jsx
+++ b/test/ReactWrapper-spec.jsx
@@ -1910,6 +1910,12 @@ describeWithDOM('mount', () => {
       expect(children.at(1).hasClass('baz')).to.equal(true);
     });
 
+    it('should not attempt to get an instance for text nodes', () => {
+      const wrapper = mount(<div>B<span />C</div>);
+      const children = wrapper.children();
+      expect(children.length).to.equal(1);
+    });
+
     describeIf(!REACT013, 'stateless function components', () => {
       it('should handle mixed children with and without arrays', () => {
         const Foo = props => (


### PR DESCRIPTION
Resolves https://github.com/airbnb/enzyme/issues/603

Currently React will return `null` for `_renderedChildren` if the only child is a text node. But if there is an actual DOM node as well, it will return that along with any sibling text nodes.

This change ignores text nodes when calling `wrapper.childen()` with `mount`. With `shallow`, no instances are actually needed when parsing children, so this works already. 

``` js
 const wrapper = shallow(<div>B<span />C</div>);
 const children = wrapper.children();
// children = ['B', <span/>, 'C']
```

So there's some inconsistency there. I think it makes more sense to let shallow return text nodes, but we could ignore them if we want consistency.

 cc @ljharb 
