### PR TITLE
Document CSS selectors when using shallow mounting

### DIFF
--- a/docs/api/selector.md
+++ b/docs/api/selector.md
@@ -14,6 +14,34 @@ follows:
 - id syntax (`#foo`, `#foo-bar`, etc.)
 - prop syntax (`[htmlFor="foo"]`, `[bar]`, `[baz=1]`, etc.);
 
+**Note -- shallow rendering**
+Components rendered with `shallow(<MyComponent/>)` do not render
+render the HTML of child components.
+
+``` js
+const Child = React.createClass({
+  render() {
+    return <span className="child">foo</span>;
+  }
+});
+
+const MyComponent = React.createClass({
+  render() {
+    return <div>
+        <Child />
+        <span className="hello">hello world</span>
+      </div>;
+  }
+});
+
+const wrapper = shallow(<MyComponent/>);
+
+wrapper.find('.hello').length // 1
+wrapper.find('.child').length // 0
+```
+
+If you want the HTML of child components, use `mount`.
+
 **Note -- Prop selector**
 Strings, numeric literals and boolean property values are supported for prop syntax
 in combination of the expected string syntax. For example, the following


### PR DESCRIPTION
I was a little confused by this today, and realised that selectors don't apply to rendering of child components. As far as I can see, this isn't currently documented in the selectors docs.

I propose adding a note to the docs about this. Alternatively, we could add the note to `.find` on https://github.com/airbnb/enzyme/blob/master/docs/api/ShallowWrapper/find.md instead. Let me know what you think.