### PR TITLE
[New] `shallow`: add `.dive()`

### DIFF
--- a/docs/api/ShallowWrapper/dive.md
+++ b/docs/api/ShallowWrapper/dive.md
@@ -1,0 +1,52 @@
+# `.dive([options]) => ShallowWrapper`
+
+Shallow render the one non-DOM child of the current wrapper, and return a wrapper around the result.
+
+NOTE: can only be called on wrapper of a single non-DOM component element node.
+
+
+#### Arguments
+
+1. `options` (`Object` [optional]):
+- `options.context`: (`Object` [optional]): Context to be passed into the component
+
+
+
+#### Returns
+
+`ShallowWrapper`: A new wrapper that wraps the current node after it's been shallow rendered.
+
+
+
+#### Examples
+
+```jsx
+class Bar extends React.Component {
+  render() {
+    return (
+      <div>
+        <div className="in-bar" />
+      </div>
+    );
+  }
+}
+```
+
+```jsx
+class Foo extends React.Component {
+  render() {
+    return (
+      <div>
+        <Bar />
+      </div>
+    );
+  }
+}
+```
+
+```jsx
+const wrapper = shallow(<Foo />);
+expect(wrapper.find('.in-bar')).to.have.length(0);
+expect(wrapper.find(Bar)).to.have.length(1);
+expect(wrapper.dive().find('.in-bar')).to.have.length(1);
+```

--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -207,3 +207,6 @@ Returns whether or not all of the nodes in the wrapper match the provided select
 
 #### [`.everyWhere(predicate) => Boolean`](ShallowWrapper/everyWhere.md)
 Returns whether or not all of the nodes in the wrapper pass the provided predicate function.
+
+#### [`.dive([options]) => ShallowWrapper`](ShallowWrapper/dive.md)
+Shallow render the one non-DOM child of the current wrapper, and return a wrapper around the result.

--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -15,6 +15,7 @@ import {
   isReactElementAlike,
   displayNameOfNode,
   isFunctionalComponent,
+  isCustomComponentElement,
 } from './Utils';
 import {
   debugNodes,
@@ -31,6 +32,7 @@ import {
   createShallowRenderer,
   renderToStaticMarkup,
   batchedUpdates,
+  isDOMComponentElement,
 } from './react-compat';
 
 /**
@@ -698,7 +700,7 @@ export default class ShallowWrapper {
 
   /**
    * Returns the type of the current node of this wrapper. If it's a composite component, this will
-   * be the component constructor. If it's native DOM node, it will be a string.
+   * be the component constructor. If it's a native DOM node, it will be a string.
    *
    * @returns {String|Function}
    */
@@ -958,5 +960,25 @@ export default class ShallowWrapper {
   tap(intercepter) {
     intercepter(this);
     return this;
+  }
+
+  /**
+   * Primarily useful for HOCs (higher-order components), this method may only be
+   * run on a single, non-DOM node, and will return the node, shallow-rendered.
+   *
+   * @param options object
+   * @returns {ShallowWrapper}
+   */
+  dive(options) {
+    const name = 'dive';
+    return this.single(name, (n) => {
+      if (isDOMComponentElement(n)) {
+        throw new TypeError(`ShallowWrapper::${name}() can not be called on DOM components`);
+      }
+      if (!isCustomComponentElement(n)) {
+        throw new TypeError(`ShallowWrapper::${name}() can only be called on components`);
+      }
+      return new ShallowWrapper(n, null, options);
+    });
   }
 }

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -22,7 +22,11 @@ export function internalInstance(inst) {
 }
 
 export function isFunctionalComponent(inst) {
-  return inst && inst.constructor && inst.constructor.name === 'StatelessComponent';
+  return !!inst && !!inst.constructor && inst.constructor.name === 'StatelessComponent';
+}
+
+export function isCustomComponentElement(inst) {
+  return !!inst && React.isValidElement(inst) && typeof inst.type === 'function';
 }
 
 export function propsOfNode(node) {

--- a/src/react-compat.js
+++ b/src/react-compat.js
@@ -150,6 +150,10 @@ if (REACT013) {
   };
 }
 
+function isDOMComponentElement(inst) {
+  return React.isValidElement(inst) && typeof inst.type === 'string';
+}
+
 const {
   mockComponent,
   isElement,
@@ -170,6 +174,7 @@ export {
   isElement,
   isElementOfType,
   isDOMComponent,
+  isDOMComponentElement,
   isCompositeComponent,
   isCompositeComponentWithType,
   isCompositeComponentElement,


### PR DESCRIPTION
The goal of this method is to make testing of HOCs (higher-order components) easier - [withStyles](https://www.npmjs.com/package/react-with-styles), flux-store-connected components, etc.

Typically, the workarounds are either:
 - `wrapper.find('StringNameOfComponent').shallow()`: brittle, because it's using strings (strings are bad); also annoying to type out.
 - `wrapper.childAt(0).shallow()`: doesn't check if there's more than one child, and is annoying to type out.

In addition, if suddenly there's a DOM element in there, you might suddenly start shallow-rendering it without knowing, and your tests might erroneously be passing.

This method allows `wrapper.dive()` - ie, it requires there be one non-DOM child, and shallow-renders it for you.

If you need multiples, you chain them - `wrapper.dive().dive()` - for now we have intentionally omitted the ability to dive multiple levels at once, so that tight coupling to HTML structure is discouraged.

Longer term, we have a much better solution in mind for HOCs, but this is still useful in the interim.