### PR TITLE
Update instructions for Jest versions 15+

### DIFF
--- a/docs/guides/jest.md
+++ b/docs/guides/jest.md
@@ -1,7 +1,27 @@
 # Using Jest with Enzyme
 
-If you are using Jest 0.9+ with enzyme and using Jest's automocking feature, you will need to mark
-react and enzyme to be unmocked in your `package.json`:
+## Jest version 15 and up
+
+Starting with version 15, Jest [no longer mocks modules by default](https://facebook.github.io/jest/blog/2016/09/01/jest-15.html). Because of this, you no longer have to add _any_ special configuration for Jest to use it with Enzyme.
+
+Install Jest, and its Babel integrations, as recommended in the [Jest docs](https://facebook.github.io/jest/docs/getting-started.html). Install Enzyme. Then, simply require/import React, Enzyme functions, and your module at the top of a test file.
+
+```js
+import React from 'react';
+import { shallow, mount, render } from 'enzyme';
+
+import Foo from '../Foo';
+```
+
+You do **not** need to include Jest's own renderer, unless you want to use it _only_ for Jest snapshot testing.
+
+## Example Project for Jest prior to version 15
+
+- [Example test for Jest 15+](https://github.com/vjwilson/enzyme-example-jest)
+
+## Jest prior to version 15
+
+If you are using Jest 0.9 – 14.0 with Enzyme and using Jest's automocking feature, you will need to mark react and enzyme to be unmocked in your `package.json`:
 
 ```js
 /* package.json */
@@ -16,6 +36,6 @@ react and enzyme to be unmocked in your `package.json`:
 
 If you are using a previous version of Jest together with npm3, you may need to unmock [more modules](https://github.com/airbnb/enzyme/blob/78febd90fe2fb184771b8b0356b0fcffbdad386e/docs/guides/jest.md).
 
-## Example Projects
+## Example Project for Jest prior to version 15
 
 - [enzyme-example-jest](https://github.com/lelandrichardson/enzyme-example-jest)


### PR DESCRIPTION
There was a question on Gitter about [using Enzyme with Jest](https://gitter.im/airbnb/enzyme?at=5813932183a2008d22e32837), and I noticed that the Jest guide was a little out of date. This PR updates that guide for Jest 15 and up.

The guide referenced a [sample test repo by Leland Richardson](https://github.com/lelandrichardson/enzyme-example-jest). Rather than ask him to manage updating the samples, I forked it and updated [my fork](https://github.com/vjwilson/enzyme-example-jest). This change references my updated fork.

I also left the his instructions for earlier versions of Jest that require mocking, just in case someone still has to use an earlier version.
