### PR TITLE
fix error on reduce and reduceRight doc

### DIFF
--- a/docs/api/ReactWrapper/reduce.md
+++ b/docs/api/ReactWrapper/reduce.md
@@ -41,8 +41,8 @@ class Foo extends React.Component {
 
 ```jsx
 const wrapper = mount(<Foo />);
-const total = wrapper.find(Bar).reduce((amount, n) => amount + n.prop('amount'));
-expect(total).to.equal(16);
+const total = wrapper.find(Bar).reduce((amount, n) => amount ? amount + n.prop('amount') : n.prop('amount'));
+expect(total).to.equal(14); // 2 + 4 + 8
 ```
 
 

--- a/docs/api/ReactWrapper/reduceRight.md
+++ b/docs/api/ReactWrapper/reduceRight.md
@@ -41,8 +41,8 @@ class Foo extends React.Component {
 
 ```jsx
 const wrapper = mount(<Foo />);
-const total = wrapper.find(Bar).reduceRight((amount, n) => amount + n.prop('amount'));
-expect(total).to.equal(16);
+const total = wrapper.find(Bar).reduceRight((amount, n) => amount ? amount + n.prop('amount') : n.prop('amount'));
+expect(total).to.equal(14); // 8 + 4 + 2
 ```
 
 

--- a/docs/api/ShallowWrapper/reduce.md
+++ b/docs/api/ShallowWrapper/reduce.md
@@ -41,8 +41,8 @@ class Foo extends React.Component {
 
 ```jsx
 const wrapper = shallow(<Foo />);
-const total = wrapper.find(Bar).reduce((amount, n) => amount + n.prop('amount'));
-expect(total).to.equal(16);
+const total = wrapper.find(Bar).reduce((amount, n) => amount ? amount + n.prop('amount') : n.prop('amount'));
+expect(total).to.equal(14); // 2 + 4 + 8
 ```
 
 

--- a/docs/api/ShallowWrapper/reduceRight.md
+++ b/docs/api/ShallowWrapper/reduceRight.md
@@ -41,8 +41,8 @@ class Foo extends React.Component {
 
 ```jsx
 const wrapper = shallow(<Foo />);
-const total = wrapper.find(Bar).reduce((amount, n) => amount + n.prop('amount'));
-expect(total).to.equal(16);
+const total = wrapper.find(Bar).reduceRight((amount, n) => amount ? amount + n.prop('amount') : n.prop('amount'));
+expect(total).to.equal(14); // 8 + 4 + 2
 ```
 
 


### PR DESCRIPTION
1) on first iteration `amount` is `undefined` which results in `NaN` for total.

```js
it('reduce', function () {
  const total = wrapper.find(Bar).reduce((amount, n) => {
    console.log(amount, n.prop('amount'));
    return amount + n.prop('amount');
  });
  expect(total).to.equal(16);
});
```

```shell
AssertionError: expected NaN to equal 16
  + expected - actual

    -NaN
    +16

// log
undefined 2
NaN 4
NaN 8
```
It needs a sanity check whether `amount` is defined, or have an initial value.
```js
wrapper.find(Bar).reduce((acc, n) => {
  const amount = n.prop('amount');
  return acc 
    ? acc + amount
    : amount;
});
//or
wrapper.find(Bar).reduce((amount, n) => amount + n.prop('amount'), 0);
```

2. And the total should be `14` instead of `16`