### PR TITLE
Fix ID selectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "lodash": "^4.16.4",
     "object-is": "^1.0.1",
     "object.assign": "^4.0.4",
-    "object.values": "^1.0.3"
+    "object.values": "^1.0.3",
+    "uuid": "^2.0.3"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "lodash": "^4.16.4",
     "object-is": "^1.0.1",
     "object.assign": "^4.0.4",
+    "object.entries": "^1.0.3",
     "object.values": "^1.0.3",
     "uuid": "^2.0.3"
   },

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -3,6 +3,8 @@ import isEqual from 'lodash/isEqual';
 import React from 'react';
 import is from 'object-is';
 import uuid from 'uuid';
+import entries from 'object.entries';
+import assign from 'object.assign';
 import functionName from 'function.prototype.name';
 import {
   isDOMComponent,
@@ -175,7 +177,7 @@ export function splitSelector(selector) {
   // step 1: make a map of all quoted strings with a uuid
   const quotedSegments = selector.split(/[^" ]+|("[^"]*")|.*/g)
     .filter(Boolean)
-    .reduce((obj, match) => ({ ...obj, [match]: uuid.v4() }), {});
+    .reduce((obj, match) => assign({}, obj, { [match]: uuid.v4() }), {});
 
   return selector
     // step 2: replace all quoted strings with the uuid, so we don't have to properly parse them
@@ -185,7 +187,7 @@ export function splitSelector(selector) {
     // step 4: restore the quoted strings by swapping back the uuid's for the original segments
     .map((selectorSegment) => {
       let restoredSegment = selectorSegment;
-      Object.entries(quotedSegments).forEach(([k, v]) => {
+      entries(quotedSegments).forEach(([k, v]) => {
         restoredSegment = restoredSegment.replace(v, k);
       });
       return restoredSegment;

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -2,6 +2,7 @@
 import isEqual from 'lodash/isEqual';
 import React from 'react';
 import is from 'object-is';
+import uuid from 'uuid';
 import functionName from 'function.prototype.name';
 import {
   isDOMComponent,
@@ -171,7 +172,24 @@ export function withSetStateAllowed(fn) {
 }
 
 export function splitSelector(selector) {
-  return selector.split(/(?=\.|\[.*])|(?=#|\[#.*])/);
+  // step 1: make a map of all quoted strings with a uuid
+  const quotedSegments = selector.split(/[^" ]+|("[^"]*")|.*/g)
+    .filter(Boolean)
+    .reduce((obj, match) => ({ ...obj, [match]: uuid.v4() }), {});
+
+  return selector
+    // step 2: replace all quoted strings with the uuid, so we don't have to properly parse them
+    .replace(/[^" ]+|("[^"]*")|.*/g, x => quotedSegments[x] || x)
+    // step 3: split as best we can without a proper parser
+    .split(/(?=\.|\[.*])|(?=#|\[#.*])/)
+    // step 4: restore the quoted strings by swapping back the uuid's for the original segments
+    .map((selectorSegment) => {
+      let restoredSegment = selectorSegment;
+      Object.entries(quotedSegments).forEach(([k, v]) => {
+        restoredSegment = restoredSegment.replace(v, k);
+      });
+      return restoredSegment;
+    });
 }
 
 

--- a/test/ReactWrapper-spec.jsx
+++ b/test/ReactWrapper-spec.jsx
@@ -633,6 +633,30 @@ describeWithDOM('mount', () => {
         expect(wrapper.find('[key]')).to.have.length(0);
       });
     });
+
+    describe('works with attribute selectors containing #', () => {
+      let wrapper;
+      beforeEach(() => {
+        wrapper = mount(
+          <div>
+            <a id="test" href="/page">Hello</a>
+            <a href="/page#anchor">World</a>
+          </div>
+        );
+      });
+
+      it('works with an ID', () => {
+        expect(wrapper.find('a#test')).to.have.lengthOf(1);
+      });
+
+      it('works with a normal attribute', () => {
+        expect(wrapper.find('a[href="/page"]')).to.have.lengthOf(1);
+      });
+
+      it('works with an attribute with a #', () => {
+        expect(wrapper.find('a[href="/page#anchor"]')).to.have.lengthOf(1);
+      });
+    });
   });
 
   describe('.findWhere(predicate)', () => {

--- a/test/ShallowWrapper-spec.jsx
+++ b/test/ShallowWrapper-spec.jsx
@@ -661,6 +661,30 @@ describe('shallow', () => {
         expect(wrapper.find('Foo').type()).to.equal(Foo);
       });
     });
+
+    describe('works with attribute selectors containing #', () => {
+      let wrapper;
+      beforeEach(() => {
+        wrapper = shallow(
+          <div>
+            <a id="test" href="/page">Hello</a>
+            <a href="/page#anchor">World</a>
+          </div>
+        );
+      });
+
+      it('works with an ID', () => {
+        expect(wrapper.find('a#test')).to.have.lengthOf(1);
+      });
+
+      it('works with a normal attribute', () => {
+        expect(wrapper.find('a[href="/page"]')).to.have.lengthOf(1);
+      });
+
+      it('works with an attribute with a #', () => {
+        expect(wrapper.find('a[href="/page#anchor"]')).to.have.lengthOf(1);
+      });
+    });
   });
 
   describe('.findWhere(predicate)', () => {


### PR DESCRIPTION
This fixes the unintentional breaking change in 2.4.x (and 2.5.x), by committing horrible sins with regular expressions. This also does not revert the new behavior added in 2.4.x (that caused the breakage).

We desperately need to replace this with a proper CSS parser, but this should suffice for now.

Once merged, I'll also backport this to the 2.4.x line (and 2.5.x if master already has some semver-minor stuff).