### PR TITLE
Add string-refs support with shallowWrapper

### DIFF
--- a/src/ShallowTraversal.js
+++ b/src/ShallowTraversal.js
@@ -151,3 +151,23 @@ export function getTextFromNode(node) {
     .join('')
     .replace(/\s+/, ' ');
 }
+
+export const isAReactComponentNode = node => typeof node.type === 'function';
+
+export const findRefInOwnedChildren = (node, ref, isRootNode) => {
+  const result = [];
+
+  if (node.ref === ref) {
+    result.push(node);
+  }
+
+  if (!isAReactComponentNode(node) || isRootNode) {
+    const children = childrenOfNode(node);
+
+    children.forEach((c) => {
+      result.push(...findRefInOwnedChildren(c, ref));
+    });
+  }
+
+  return result;
+};

--- a/src/ShallowTraversal.js
+++ b/src/ShallowTraversal.js
@@ -155,7 +155,7 @@ export function getTextFromNode(node) {
     .replace(/\s+/, ' ');
 }
 
-export const findRefInOwnedChildren = (node, ref, isRootNode) => {
+const findRef = (node, ref, isRootNode) => {
   const result = [];
 
   if (node.ref === ref) {
@@ -166,9 +166,11 @@ export const findRefInOwnedChildren = (node, ref, isRootNode) => {
     const children = childrenOfNode(node);
 
     children.forEach((c) => {
-      result.push(...findRefInOwnedChildren(c, ref));
+      result.push(...findRef(c, ref));
     });
   }
 
   return result;
 };
+
+export const findRefInOwnedChildren = (node, ref) => findRef(node, ref, true);

--- a/src/ShallowTraversal.js
+++ b/src/ShallowTraversal.js
@@ -12,6 +12,9 @@ import {
   nodeHasType,
   nodeHasProperty,
 } from './Utils';
+import {
+  isDOMComponentElement,
+} from './react-compat';
 
 
 export function childrenOfNode(node) {
@@ -152,8 +155,6 @@ export function getTextFromNode(node) {
     .replace(/\s+/, ' ');
 }
 
-export const isAReactComponentNode = node => typeof node.type === 'function';
-
 export const findRefInOwnedChildren = (node, ref, isRootNode) => {
   const result = [];
 
@@ -161,7 +162,7 @@ export const findRefInOwnedChildren = (node, ref, isRootNode) => {
     result.push(node);
   }
 
-  if (!isAReactComponentNode(node) || isRootNode) {
+  if (isDOMComponentElement(node) || isRootNode) {
     const children = childrenOfNode(node);
 
     children.forEach((c) => {

--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -153,8 +153,7 @@ class ShallowWrapper {
           throw new Error('There is more than one component own by the tree root with the same ref string');
         }
 
-        refObject[n.ref] = n
-        return refObject
+        return Object.assign({}, refObject, { [n.ref]: n });
       },
       {},
     );

--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -472,11 +472,8 @@ class ShallowWrapper {
 
       if (result.length === 0) return null;
       if (result.length === 1) return new ShallowWrapper(result[0], this.root);
-      if (result.length > 1) {
-        throw new Error('There is more than one component own by the tree root with the same ref string');
-      }
 
-      return false;
+      throw new Error('There is more than one component own by the tree root with the same ref string');
     });
   }
 

--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -28,6 +28,8 @@ import {
   parentsOfNode,
   treeFilter,
   buildPredicate,
+  isAReactComponentNode,
+  findRefInOwnedChildren,
 } from './ShallowTraversal';
 import {
   createShallowRenderer,
@@ -451,6 +453,32 @@ class ShallowWrapper {
    */
   find(selector) {
     return this.complexSelector.find(selector, this);
+  }
+
+  /**
+   * Finds ref of the current wrapper.
+   *
+   * NOTE: can only be called on a wrapper of a single node.
+   *
+   * @param {String} ref
+   * @returns {ShallowWrapper}
+   */
+  ref(ref) {
+    return this.single('ref', (node) => {
+      if (!isAReactComponentNode(this.unrendered)) {
+        throw new Error('The current node must be a React component.');
+      }
+
+      const result = findRefInOwnedChildren(node, ref, true);
+
+      if (result.length === 0) return false;
+      if (result.length === 1) return new ShallowWrapper(result[0], this.root);
+      if (result.length > 1) {
+        throw new Error('There is more than one component own by the tree root with the same ref string');
+      }
+
+      return false;
+    });
   }
 
   /**

--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -3,6 +3,7 @@ import flatten from 'lodash/flatten';
 import unique from 'lodash/uniq';
 import compact from 'lodash/compact';
 import cheerio from 'cheerio';
+import assign from 'object.assign';
 
 import ComplexSelector from './ComplexSelector';
 import {
@@ -153,7 +154,7 @@ class ShallowWrapper {
           throw new Error('There is more than one component own by the tree root with the same ref string');
         }
 
-        return Object.assign({}, refObject, { [n.ref]: n });
+        return assign({}, refObject, { [n.ref]: n });
       },
       {},
     );

--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -153,10 +153,8 @@ class ShallowWrapper {
           throw new Error('There is more than one component own by the tree root with the same ref string');
         }
 
-        return {
-          ...refObject,
-          [n.ref]: n,
-        };
+        refObject[n.ref] = n
+        return refObject
       },
       {},
     );

--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -28,7 +28,6 @@ import {
   parentsOfNode,
   treeFilter,
   buildPredicate,
-  isAReactComponentNode,
   findRefInOwnedChildren,
 } from './ShallowTraversal';
 import {
@@ -465,13 +464,13 @@ class ShallowWrapper {
    */
   ref(ref) {
     return this.single('ref', (node) => {
-      if (!isAReactComponentNode(this.unrendered)) {
+      if (isDOMComponentElement(this.unrendered)) {
         throw new Error('The current node must be a React component.');
       }
 
       const result = findRefInOwnedChildren(node, ref, true);
 
-      if (result.length === 0) return false;
+      if (result.length === 0) return null;
       if (result.length === 1) return new ShallowWrapper(result[0], this.root);
       if (result.length > 1) {
         throw new Error('There is more than one component own by the tree root with the same ref string');

--- a/test/ShallowTraversal-spec.jsx
+++ b/test/ShallowTraversal-spec.jsx
@@ -11,6 +11,7 @@ import {
   treeFilter,
   pathToNode,
   getTextFromNode,
+  getNodeRefs,
 } from '../src/ShallowTraversal';
 import { describeIf } from './_helpers';
 import { REACT013 } from '../src/version';
@@ -344,6 +345,74 @@ describe('ShallowTraversal', () => {
         const result = getTextFromNode(node);
         expect(result).to.equal('<Subject />');
       });
+    });
+  });
+
+  describe('getOwnedReferencedNodes()', () => {
+    const aReactComponentRef = 'aReactComponentRef';
+    const aReactComponentChildRef = 'childrenRef';
+    const aDOMElementChildRef = 'childrenRef2';
+    const aFirstLevelRef = 'aFirstLevelRef';
+    const anUnexistingRef = 'aSillyRef';
+    const rootElementRef = 'rootElementRef';
+    const aRefOwnedByChild = 'aRefOwnedByChild';
+
+    const ComponentWithChildrenRefs = React.createClass({
+      render: () => <h1 ref={aReactComponentChildRef}>Allo</h1>,
+    });
+
+    const element = (
+      <div ref={rootElementRef}>
+        <ComponentWithChildrenRefs
+          ref={aReactComponentRef}
+          aProp="something"
+        >
+          <p ref={aRefOwnedByChild} />
+        </ComponentWithChildrenRefs>
+
+        <div ref={aFirstLevelRef}>
+          <p ref={aDOMElementChildRef} />
+        </div>
+      </div>
+    );
+
+    let stringNodes;
+
+    before(() => {
+      const refs = getNodeRefs(element);
+      stringNodes = refs.stringNodes;
+    });
+
+    const expectNodesToContain = (nodes, ref) => {
+      expect(nodes).to.satisfy(
+        _nodes => _nodes.find(n => n.ref === ref),
+      );
+    };
+
+    const expectNodesToNotContain = (nodes, ref) => {
+      expect(nodes).to.satisfy(
+        _nodes => !_nodes.find(n => n.ref === ref),
+      );
+    };
+
+    it('contains the ref of the containing element', () => {
+      expectNodesToContain(stringNodes, rootElementRef);
+    });
+
+    it('contains a ref at first level', () => {
+      expectNodesToContain(stringNodes, aFirstLevelRef);
+    });
+
+    it('contains a ref nested under a dom element', () => {
+      expectNodesToContain(stringNodes, aDOMElementChildRef);
+    });
+
+    it('does not contain a unexisting ref', () => {
+      expectNodesToNotContain(stringNodes, anUnexistingRef);
+    });
+
+    it('does not contain a ref owned by a child React component', () => {
+      expectNodesToNotContain(stringNodes, aRefOwnedByChild);
     });
   });
 });

--- a/test/ShallowTraversal-spec.jsx
+++ b/test/ShallowTraversal-spec.jsx
@@ -383,16 +383,16 @@ describe('ShallowTraversal', () => {
       stringNodes = refs.stringNodes;
     });
 
+    const matchRefs = (nodes, ref) => nodes.filter(n => n.ref === ref);
+
     const expectNodesToContain = (nodes, ref) => {
-      expect(nodes).to.satisfy(
-        _nodes => _nodes.find(n => n.ref === ref),
-      );
+      const matchingRefs = matchRefs(nodes, ref);
+      expect(matchingRefs).to.have.length.above(0);
     };
 
     const expectNodesToNotContain = (nodes, ref) => {
-      expect(nodes).to.satisfy(
-        _nodes => !_nodes.find(n => n.ref === ref),
-      );
+      const matchingRefs = matchRefs(nodes, ref);
+      expect(matchingRefs).to.have.lengthOf(0);
     };
 
     it('contains the ref of the containing element', () => {

--- a/test/ShallowWrapper-spec.jsx
+++ b/test/ShallowWrapper-spec.jsx
@@ -770,12 +770,12 @@ describe('shallow', () => {
 
     it('returns false if no element is found with the requested ref', () => {
       const result = wrapper.ref(anUnexistingRef);
-      expect(result).to.equal(false);
+      expect(result).to.equal(null);
     });
 
     it('returns false if a ref owned by a child React component is requested', () => {
       const result = wrapper.ref(aRefOwnedByChild);
-      expect(result).to.equal(false);
+      expect(result).to.equal(null);
     });
 
     it('throws an error if it find more than one ref', () => {

--- a/test/ShallowWrapper-spec.jsx
+++ b/test/ShallowWrapper-spec.jsx
@@ -706,6 +706,83 @@ describe('shallow', () => {
     });
   });
 
+  describe('ref', () => {
+    const aReactComponentRef = 'aReactComponentRef';
+    const aReactComponentChildRef = 'childrenRef';
+    const aDOMElementChildRef = 'childrenRef2';
+    const aFirstLevelRef = 'aFirstLevelRef';
+    const anUnexistingRef = 'aSillyRef';
+    const aDoubleRef = 'imUsedTwiceForTheSameComponent';
+    const rootElementRef = 'rootElementRef';
+    const aRefOwnedByChild = 'aRefOwnedByChild';
+
+    const ComponentWithChildrenRefs = React.createClass({
+      render: () => <h1 ref={aReactComponentChildRef}>Allo</h1>,
+    });
+
+    const RootComponent = React.createClass({
+      render: () => (
+        <div ref={rootElementRef}>
+          <ComponentWithChildrenRefs
+            ref={aReactComponentRef}
+            aProp="something"
+          >
+            <p ref={aRefOwnedByChild} />
+          </ComponentWithChildrenRefs>
+
+          <p ref={aDoubleRef} />
+          <p ref={aDoubleRef} />
+
+          <div ref={aFirstLevelRef}>
+            <p ref={aDOMElementChildRef} />
+          </div>
+
+        </div>
+      ),
+    });
+
+    const wrapper = shallow(<RootComponent />);
+
+    it('throws if called with a dom node as root', () => {
+      const domWrapper = shallow(<div><p>banana</p></div>);
+      expect(() => domWrapper.ref('noMatterWhat')).to.throw();
+    });
+
+    it('returns the wrapper on the react component and not on the dom node when the requested ref is on a react component', () => {
+      const result = wrapper.ref(aReactComponentRef);
+      expect(result.props().aProp).to.equal('something');
+    });
+
+    it('returns the wrapper of the requested ref when it is the one of the containing element', () => {
+      const result = wrapper.ref(rootElementRef);
+      expect(result.node.ref).to.equal(rootElementRef);
+    });
+
+    it('returns the wrapper of the requested ref at first level', () => {
+      const result = wrapper.ref(aFirstLevelRef);
+      expect(result.node.ref).to.equal(aFirstLevelRef);
+    });
+
+    it('returns the wrapper of the requested ref even at DOM-nested-level', () => {
+      const result = wrapper.ref(aDOMElementChildRef);
+      expect(result.node.ref).to.equal(aDOMElementChildRef);
+    });
+
+    it('returns false if no element is found with the requested ref', () => {
+      const result = wrapper.ref(anUnexistingRef);
+      expect(result).to.equal(false);
+    });
+
+    it('returns false if a ref owned by a child React component is requested', () => {
+      const result = wrapper.ref(aRefOwnedByChild);
+      expect(result).to.equal(false);
+    });
+
+    it('throws an error if it find more than one ref', () => {
+      expect(() => wrapper.ref(aDoubleRef)).to.throw();
+    });
+  });
+
   describe('.findWhere(predicate)', () => {
     it('should return all elements for a truthy test', () => {
       const wrapper = shallow(


### PR DESCRIPTION
In response to https://github.com/airbnb/enzyme/issues/361 and my own need :)

I find it extremely useful to have a unique, local-scoped, way to identify my React Element.

Works as expected `shallowWrapper.ref('stringRef') => ShallowWrapper` or throws if more than one element has the wanted ref.