### PR TITLE
Make hasClass work for `mount`ed composite components

### DIFF
--- a/src/MountedTraversal.js
+++ b/src/MountedTraversal.js
@@ -46,9 +46,6 @@ export function instEqual(a, b, lenComp) {
 }
 
 export function instHasClassName(inst, className) {
-  if (!isDOMComponent(inst)) {
-    return false;
-  }
   const node = findDOMNode(inst);
   if (node.classList) {
     return node.classList.contains(className);
@@ -59,6 +56,13 @@ export function instHasClassName(inst, className) {
   }
   classes = classes.replace(/\s/g, ' ');
   return ` ${classes} `.indexOf(` ${className} `) > -1;
+}
+
+function hasClassName(inst, className) {
+  if (!isDOMComponent(inst)) {
+    return false;
+  }
+  return instHasClassName(inst, className);
 }
 
 export function instHasId(inst, id) {
@@ -198,7 +202,7 @@ export function buildInstPredicate(selector) {
 
       switch (selectorType(selector)) {
         case SELECTOR.CLASS_TYPE:
-          return inst => instHasClassName(inst, selector.substr(1));
+          return inst => hasClassName(inst, selector.substr(1));
         case SELECTOR.ID_TYPE:
           return inst => instHasId(inst, selector.substr(1));
         case SELECTOR.PROP_TYPE: {

--- a/test/ReactWrapper-spec.jsx
+++ b/test/ReactWrapper-spec.jsx
@@ -2073,17 +2073,37 @@ describeWithDOM('mount', () => {
   });
 
   describe('.hasClass(className)', () => {
-    it('should return whether or not node has a certain class', () => {
-      const wrapper = mount(
-        <div className="foo bar baz some-long-string FoOo" />,
-      );
+    context('When using a DOM component', () => {
+      it('should return whether or not node has a certain class', () => {
+        const wrapper = mount(
+          <div className="foo bar baz some-long-string FoOo" />,
+        );
 
-      expect(wrapper.hasClass('foo')).to.equal(true);
-      expect(wrapper.hasClass('bar')).to.equal(true);
-      expect(wrapper.hasClass('baz')).to.equal(true);
-      expect(wrapper.hasClass('some-long-string')).to.equal(true);
-      expect(wrapper.hasClass('FoOo')).to.equal(true);
-      expect(wrapper.hasClass('doesnt-exist')).to.equal(false);
+        expect(wrapper.hasClass('foo')).to.equal(true);
+        expect(wrapper.hasClass('bar')).to.equal(true);
+        expect(wrapper.hasClass('baz')).to.equal(true);
+        expect(wrapper.hasClass('some-long-string')).to.equal(true);
+        expect(wrapper.hasClass('FoOo')).to.equal(true);
+        expect(wrapper.hasClass('doesnt-exist')).to.equal(false);
+      });
+    });
+
+    context('When using a Composite component', () => {
+      it('should return whether or not node has a certain class', () => {
+        class Foo extends React.Component {
+          render() {
+            return (<div className="foo bar baz some-long-string FoOo" />);
+          }
+        }
+        const wrapper = mount(<Foo />);
+
+        expect(wrapper.hasClass('foo')).to.equal(true);
+        expect(wrapper.hasClass('bar')).to.equal(true);
+        expect(wrapper.hasClass('baz')).to.equal(true);
+        expect(wrapper.hasClass('some-long-string')).to.equal(true);
+        expect(wrapper.hasClass('FoOo')).to.equal(true);
+        expect(wrapper.hasClass('doesnt-exist')).to.equal(false);
+      });
     });
   });
 


### PR DESCRIPTION
This (hopefully?) address the long running issue #134, where `wrapper.hasClass` always returns false on `mount`ed composite components. The reason for the failure is the following block in `MountedTraversal.js#instHasClassName`:
```js
  if (!isDOMComponent(inst)) {
    return false;
  }
```

Simply removing this block breaks many things, as the method is used internally in `MountedTraversal.js`. My naive solution is to split the method in two, so we retain the exported `instHasClassName` function for use by `ReactWrapper.hasClass`, and extract a private `hasClassName` function for use internally in `MountedTraversal.js`.

From here we can remove the `!isDOMComponent` early exit code from `instHasClassName`, and instead add it to `hasClassName` to maintain existing functionality.
