### PR TITLE
Get outer DOM node from composite component wrapper

### DIFF
--- a/docs/api/ReactWrapper/getDOMNode.md
+++ b/docs/api/ReactWrapper/getDOMNode.md
@@ -1,0 +1,21 @@
+# `.getDOMNode() => DOMComponent`
+
+Returns the outer most DOMComponent of the current wrapper.
+
+Notes:
+- can only be called on a wrapper of a single node.
+- will raise if called on a wrapper of a stateless functional component.
+
+
+#### Returns
+
+`DOMComponent`: The retrieved DOM component.
+
+
+
+#### Examples
+
+```jsx
+const wrapper = mount(<MyComponent />);
+expect(wrapper.getDOMNode()).to.have.property("className");
+```

--- a/docs/api/mount.md
+++ b/docs/api/mount.md
@@ -122,6 +122,9 @@ Returns a static HTML rendering of the current node.
 #### [`.get(index) => ReactElement`](ReactWrapper/get.md)
 Returns the node at the provided index of the current wrapper.
 
+#### [`.getDOMNode() => DOMComponent`](ReactWrapper/getDOMNode.md)
+Returns the outer most DOMComponent of the current wrapper.
+
 #### [`.at(index) => ReactWrapper`](ReactWrapper/at.md)
 Returns a wrapper of the node at the provided index of the current wrapper.
 

--- a/src/ReactWrapper.jsx
+++ b/src/ReactWrapper.jsx
@@ -29,6 +29,7 @@ import {
   typeOfNode,
   displayNameOfNode,
   ITERATOR_SYMBOL,
+  isFunctionalComponent,
 } from './Utils';
 import {
   debugInsts,
@@ -128,6 +129,23 @@ class ReactWrapper {
    */
   getNodes() {
     return this.nodes;
+  }
+
+  /**
+   * Returns the outer most DOMComponent of the current wrapper.
+   *
+   * NOTE: can only be called on a wrapper of a single node.
+   *
+   * @returns {DOMComponent}
+   */
+  getDOMNode() {
+    return this.single('getDOMNode', (n) => {
+      if (isFunctionalComponent(n)) {
+        throw new TypeError('Method “getDOMNode” cannot be used on functional components.');
+      }
+
+      return findDOMNode(n);
+    });
   }
 
   /**

--- a/test/ReactWrapper-spec.jsx
+++ b/test/ReactWrapper-spec.jsx
@@ -3285,6 +3285,45 @@ describeWithDOM('mount', () => {
     });
   });
 
+  describe('.getDOMNode', () => {
+    class Test extends React.Component {
+      render() {
+        return (
+          <div className="outer">
+            <div className="inner">
+              <span />
+              <span />
+            </div>
+          </div>
+        );
+      }
+    }
+
+    it('should return the outer most DOMComponent of the root wrapper', () => {
+      const wrapper = mount(<Test />);
+      expect(wrapper.getDOMNode()).to.have.property('className', 'outer');
+    });
+
+    it('should return the outer most DOMComponent of the inner div wrapper', () => {
+      const wrapper = mount(<Test />);
+      expect(wrapper.find('.inner').getDOMNode()).to.have.property('className', 'inner');
+    });
+
+    it('should throw when wrapping multiple elements', () => {
+      const wrapper = mount(<Test />).find('span');
+      expect(() => wrapper.getDOMNode()).to.throw(Error);
+    });
+
+    describeIf(!REACT013, 'stateless components', () => {
+      const SFC = () => (<div />);
+
+      it('should throw when wrapping an SFC', () => {
+        const wrapper = mount(<SFC />);
+        expect(() => wrapper.getDOMNode()).to.throw(TypeError, 'Method “getDOMNode” cannot be used on functional components.');
+      });
+    });
+  });
+
   describe('#single()', () => {
     it('throws if run on multiple nodes', () => {
       const wrapper = mount(<div><i /><i /></div>).children();


### PR DESCRIPTION
As outlined in #623 and #446, implement `ReactWrapper#getDOMNode` which provides access to the outer most DOMComponent of a mounted composite component.

If you are happy for this to exist, I will add api documentation.