### PR TITLE
Display a useful error when `withDom` fails to find "jsdom".

### DIFF
--- a/withDom.js
+++ b/withDom.js
@@ -15,5 +15,12 @@ if (!global.document) {
     };
   } catch (e) {
     // jsdom is not supported...
+    if (e.message === "Cannot find module 'jsdom'") {
+      console.error('[enzyme/withDom] Error: missing required module "jsdom"');
+      console.error('[enzyme/withDom] To fix this you must run:');
+      console.error('[enzyme/withDom]   npm install jsdom --save-dev');
+    } else {
+      console.error('[enzyme withDom] ' + (e.stack || e.message));
+    }
   }
 }


### PR DESCRIPTION
Lost a bunch of time on this today because I thought it was a compatibility issue around the new `react@15.4.0` release ...

... instead of just my own error of forgetting to install `jsdom` in a new module. 🙀 🙀 🙀 

Hopefully this helps others avoid my mistake. Tried to make the message displayed to users as clear as possible. 💯 ✨ 👍 💪 😼 

<img width="697" alt="screen shot 2016-11-16 at 11 32 42 pm" src="https://cloud.githubusercontent.com/assets/4624/20380133/018faabc-ac55-11e6-8e73-cad3114dce61.png">

_
> _Testability is tricky on this since the `enzyme` module itself depends on `jsdom` so the error will never be produced. I could introduce `proxyquire` and force `require('jsdom')` to throw, but that seemed like overkill. Hopefully the change is obvious and small enough._