### PR TITLE
Update FindWhere.md

### DIFF
--- a/docs/api/ShallowWrapper/findWhere.md
+++ b/docs/api/ShallowWrapper/findWhere.md
@@ -20,7 +20,7 @@ nodes.
 
 ```jsx
 const wrapper = shallow(<MyComponent />);
-const complexComponents = wrapper.findWhere(n => typeof n.type() !== 'string');
+const complexComponents = wrapper.findWhere(n => n.type() !== 'string');
 expect(complexComponents).to.have.length(8);
 ```
 


### PR DESCRIPTION
Changed documentation to fix a broken example:
typeof n.type() !== 'string' fails while n.type() !== 'string' works