### PR TITLE
[Fix] `mount`: ensure that `react-text` comment nodes don’t break `.find`

### DIFF
--- a/src/MountedTraversal.js
+++ b/src/MountedTraversal.js
@@ -126,6 +126,9 @@ export function childrenOfInstInternal(inst) {
       if (!REACT013 && typeof node._currentElement.type === 'function') {
         return node._instance;
       }
+      if (typeof node._stringText === 'string') {
+        return node;
+      }
       return node.getPublicInstance();
     });
   } else if (
@@ -253,9 +256,7 @@ function findAllInRenderedTreeInternal(inst, test) {
       }
       return true;
     }).forEach((node) => {
-      ret = ret.concat(
-        findAllInRenderedTreeInternal(node, test),
-      );
+      ret = ret.concat(findAllInRenderedTreeInternal(node, test));
     });
   } else if (
     !REACT013 &&

--- a/test/ReactWrapper-spec.jsx
+++ b/test/ReactWrapper-spec.jsx
@@ -378,7 +378,25 @@ describeWithDOM('mount', () => {
 
       expect(wrapper.find('span[htmlFor="foo"]')).to.have.length(1);
       expect(wrapper.find('span[htmlFor]')).to.have.length(1);
+    });
 
+    it('works with an adjacent sibling selector', () => {
+      const a = 'some';
+      const b = 'text';
+      const wrapper = mount(
+        <div>
+          <div className="row">
+            {a}
+            {b}
+          </div>
+          <div className="row">
+            {a}
+            {b}
+          </div>
+        </div>,
+      );
+      expect(wrapper.find('.row')).to.have.lengthOf(2);
+      expect(wrapper.find('.row + .row')).to.have.lengthOf(1);
     });
 
     // React 15.2 warns when setting a non valid prop to an DOM element

--- a/test/ShallowWrapper-spec.jsx
+++ b/test/ShallowWrapper-spec.jsx
@@ -483,6 +483,25 @@ describe('shallow', () => {
       expect(wrapper.find('[title]')).to.have.length(1);
     });
 
+    it('works with an adjacent sibling selector', () => {
+      const a = 'some';
+      const b = 'text';
+      const wrapper = shallow(
+        <div>
+          <div className="row">
+            {a}
+            {b}
+          </div>
+          <div className="row">
+            {a}
+            {b}
+          </div>
+        </div>,
+      );
+      expect(wrapper.find('.row')).to.have.lengthOf(2);
+      expect(wrapper.find('.row + .row')).to.have.lengthOf(1);
+    });
+
     it('should error sensibly if prop selector without quotes', () => {
       const wrapper = shallow(
         <div>


### PR DESCRIPTION
Fixes #689.

 - add `shallow` test just in case
 - use `values` over `Object.keys` in MountedTraversal