### PR TITLE
Update jsdom.md to work with react-native

### DIFF
--- a/docs/guides/jsdom.md
+++ b/docs/guides/jsdom.md
@@ -17,7 +17,7 @@ As a result, a standalone script like the one below is generally a good approach
 var jsdom = require('jsdom').jsdom;
 
 global.document = jsdom('');
-global.window = document.defaultView;
+global.window = global;
 Object.keys(document.defaultView).forEach((property) => {
   if (typeof global[property] === 'undefined') {
     global[property] = document.defaultView[property];


### PR DESCRIPTION
The original example does not work with react-native because of (for example) TimerMixin sets a variable `GLOBAL` based on whether or not `window` or `global` exists. If `window` exists, it chooses that to look for `requestAnimationFrame`, `setTimeout` and `setInterval`. I then tries to use `GLOBAL.setTimeout` which doesn't exist.