### PR TITLE
mount: fix broken `.parents()`

### DIFF
--- a/src/ReactWrapper.jsx
+++ b/src/ReactWrapper.jsx
@@ -627,7 +627,7 @@ class ReactWrapper {
    */
   parents(selector) {
     const allParents = this.wrap(
-        this.single('parents', n => parentsOfInst(n, this.root.getNode())),
+      this.single('parents', n => parentsOfInst(n, this.root.getNode())),
     );
     return selector ? allParents.filter(selector) : allParents;
   }

--- a/test/ReactWrapper-spec.jsx
+++ b/test/ReactWrapper-spec.jsx
@@ -1950,13 +1950,16 @@ describeWithDOM('mount', () => {
   });
 
   describe('.parents([selector])', () => {
-    it('should return an array of current nodes ancestors', () => {
+    it('should return an array of current node’s ancestors', () => {
       const wrapper = mount(
         <div className="bax">
           <div className="foo">
             <div className="bar">
               <div className="baz" />
             </div>
+          </div>
+          <div className="qux">
+            <div className="qoo" />
           </div>
         </div>,
       );

--- a/test/ShallowWrapper-spec.jsx
+++ b/test/ShallowWrapper-spec.jsx
@@ -1785,13 +1785,16 @@ describe('shallow', () => {
   });
 
   describe('.parents([selector])', () => {
-    it('should return an array of current nodes ancestors', () => {
+    it('should return an array of current node’s ancestors', () => {
       const wrapper = shallow(
         <div className="bax">
           <div className="foo">
             <div className="bar">
               <div className="baz" />
             </div>
+          </div>
+          <div className="qux">
+            <div className="qoo" />
           </div>
         </div>,
       );
@@ -1802,7 +1805,6 @@ describe('shallow', () => {
       expect(parents.at(0).hasClass('bar')).to.equal(true);
       expect(parents.at(1).hasClass('foo')).to.equal(true);
       expect(parents.at(2).hasClass('bax')).to.equal(true);
-
     });
 
     it('should work for non-leaf nodes as well', () => {


### PR DESCRIPTION
Actually, this is a bug report. Test should pass, but it doesn't.

When elements tree has more than one branch, `.parents()` method returns some nodes, which are not  parent of the element.