### PR TITLE
Add `getClasses()` to mount and shallow API's

### DIFF
--- a/docs/api/ReactWrapper/getClasses.md
+++ b/docs/api/ReactWrapper/getClasses.md
@@ -1,0 +1,18 @@
+# `.getClasses() => Array<String>`
+
+Returns an array containing all the classes for the current node. This can be used in a similar
+fashion as [`.hasClass`](hasClass.md), but can return more interesting information in certain
+test runners on failure, since it will include all class names, and not just a boolean.
+
+
+#### Returns
+
+`Array<String>`: an array containing all the classes for the current node.
+
+
+#### Example
+
+```jsx
+const wrapper = mount(<MyComponent />);
+expect(wrapper.find('.main-navigation-link').getClasses()).to.include('active');
+```

--- a/docs/api/ShallowWrapper/getClasses.md
+++ b/docs/api/ShallowWrapper/getClasses.md
@@ -1,0 +1,18 @@
+# `.getClasses() => Array<String>`
+
+Returns an array containing all the classes for the current node. This can be used in a similar
+fashion as [`.hasClass`](hasClass.md), but can return more interesting information in certain
+test runners on failure, since it will include all class names, and not just a boolean.
+
+
+#### Returns
+
+`Array<String>`: an array containing all the classes for the current node.
+
+
+#### Example
+
+```jsx
+const wrapper = mount(<MyComponent />);
+expect(wrapper.find('.main-navigation-link').getClasses()).to.include('active');
+```

--- a/src/MountedTraversal.js
+++ b/src/MountedTraversal.js
@@ -46,17 +46,22 @@ export function instEqual(a, b, lenComp) {
   return nodeEqual(getNode(a), getNode(b), lenComp);
 }
 
-export function instHasClassName(inst, className) {
-  const node = findDOMNode(inst);
-  if (node.classList) {
-    return node.classList.contains(className);
-  }
+export function instGetClasses(inst, foundNode) {
+  const node = foundNode || findDOMNode(inst);
   let classes = node.className || '';
   if (typeof classes === 'object') {
     classes = classes.baseVal;
   }
   classes = classes.replace(/\s/g, ' ');
-  return ` ${classes} `.indexOf(` ${className} `) > -1;
+  return classes.split(' ');
+}
+
+export function instHasClassName(inst, className) {
+  const node = findDOMNode(inst);
+  if (node.classList) {
+    return node.classList.contains(className);
+  }
+  return instGetClasses(inst, node).indexOf(className) > -1;
 }
 
 function hasClassName(inst, className) {

--- a/src/ReactWrapper.jsx
+++ b/src/ReactWrapper.jsx
@@ -8,6 +8,7 @@ import ComplexSelector from './ComplexSelector';
 import createWrapperComponent from './ReactWrapperComponent';
 import {
   instHasClassName,
+  instGetClasses,
   childrenOfInst,
   parentsOfInst,
   buildInstPredicate,
@@ -707,6 +708,17 @@ class ReactWrapper {
       );
     }
     return this.single('hasClass', n => instHasClassName(n, className));
+  }
+
+  /**
+   * Returns an array of class names.
+   *
+   * NOTE: can only be called on a wrapper of a single node.
+   *
+   * @returns {Array<String>}
+   */
+  getClasses() {
+    return this.single('getClasses', n => instGetClasses(n));
   }
 
   /**

--- a/src/ShallowTraversal.js
+++ b/src/ShallowTraversal.js
@@ -33,7 +33,7 @@ export function getClassesArray(node) {
 }
 
 export function hasClassName(node, className) {
-  let classes = getClassesArray(node);
+  const classes = getClassesArray(node);
   return classes.indexOf(className) > -1;
 }
 

--- a/src/ShallowTraversal.js
+++ b/src/ShallowTraversal.js
@@ -26,10 +26,15 @@ export function childrenOfNode(node) {
   return result;
 }
 
-export function hasClassName(node, className) {
+export function getClassesArray(node) {
   let classes = propsOfNode(node).className || '';
   classes = String(classes).replace(/\s/g, ' ');
-  return ` ${classes} `.indexOf(` ${className} `) > -1;
+  return classes.split(' ');
+}
+
+export function hasClassName(node, className) {
+  let classes = getClassesArray(node);
+  return classes.indexOf(className) > -1;
 }
 
 export function treeForEach(tree, fn) {

--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -22,6 +22,7 @@ import {
   debugNodes,
 } from './Debug';
 import {
+  getClassesArray,
   getTextFromNode,
   hasClassName,
   childrenOfNode,
@@ -744,6 +745,17 @@ class ShallowWrapper {
    */
   name() {
     return this.single('name', displayNameOfNode);
+  }
+
+  /**
+   * Returns an array of class names.
+   *
+   * NOTE: can only be called on a wrapper of a single node.
+   *
+   * @returns {Array<String>}
+   */
+  getClasses() {
+    return this.single('getClasses', n => getClassesArray(n));
   }
 
   /**

--- a/test/ReactWrapper-spec.jsx
+++ b/test/ReactWrapper-spec.jsx
@@ -2125,6 +2125,39 @@ describeWithDOM('mount', () => {
     });
   });
 
+  describe('.getClasses()', () => {
+    context('When using a DOM component', () => {
+      it('should return whether or not node has a certain class', () => {
+        const wrapper = mount(
+          <div className="foo bar baz some-long-string FoOo" />,
+        );
+
+        expect(wrapper.getClasses()).to.include('foo');
+        expect(wrapper.getClasses()).to.include('bar');
+        expect(wrapper.getClasses()).to.include('baz');
+        expect(wrapper.getClasses()).to.include('some-long-string');
+        expect(wrapper.getClasses()).to.include('FoOo');
+      });
+    });
+
+    context('When using a Composite component', () => {
+      it('should return whether or not node has a certain class', () => {
+        class Foo extends React.Component {
+          render() {
+            return (<div className="foo bar baz some-long-string FoOo" />);
+          }
+        }
+        const wrapper = mount(<Foo />);
+
+        expect(wrapper.getClasses()).to.include('foo');
+        expect(wrapper.getClasses()).to.include('bar');
+        expect(wrapper.getClasses()).to.include('baz');
+        expect(wrapper.getClasses()).to.include('some-long-string');
+        expect(wrapper.getClasses()).to.include('FoOo');
+      });
+    });
+  });
+
   describe('.forEach(fn)', () => {
     it('should call a function for each node in the wrapper', () => {
       const wrapper = mount(

--- a/test/ShallowTraversal-spec.jsx
+++ b/test/ShallowTraversal-spec.jsx
@@ -5,6 +5,7 @@ import {
   splitSelector,
 } from '../src/Utils';
 import {
+  getClassesArray,
   hasClassName,
   nodeHasProperty,
   treeForEach,
@@ -65,6 +66,17 @@ describe('ShallowTraversal', () => {
       const node = (<div className={classes} />);
       expect(hasClassName(node, 'foo-bar')).to.equal(true);
     });
+  });
+
+  describe('getClassesArray', () => {
+
+    it('should return an array of classes', () => {
+      const node = (<div className="foo bar baz" />);
+      expect(getClassesArray(node)).to.include('foo');
+      expect(getClassesArray(node)).to.include('bar');
+      expect(getClassesArray(node)).to.include('baz');
+    });
+
   });
 
   describe('nodeHasProperty', () => {

--- a/test/ShallowWrapper-spec.jsx
+++ b/test/ShallowWrapper-spec.jsx
@@ -1943,6 +1943,20 @@ describe('shallow', () => {
     });
   });
 
+  describe('.getClasses()', () => {
+    it('should return an array of class names for the current node', () => {
+      const wrapper = shallow(
+        <div className="foo bar baz some-long-string FoOo" />,
+      );
+
+      expect(wrapper.getClasses()).to.include('foo');
+      expect(wrapper.getClasses()).to.include('bar');
+      expect(wrapper.getClasses()).to.include('baz');
+      expect(wrapper.getClasses()).to.include('some-long-string');
+      expect(wrapper.getClasses()).to.include('FoOo');
+    });
+  });
+
   describe('.hasClass(className)', () => {
     it('should return whether or not node has a certain class', () => {
       const wrapper = shallow(


### PR DESCRIPTION
Returns an array containing all the classes for the current node. This can be used in a similar
fashion as `.hasClass`, but can return more interesting information in certain
test runners on failure, since it will include all class names, and not just a boolean.

I admittedly do not know all the ins and outs of the traversal vs wrapper files, but I think I've got it.

In addition to adding the functions, I have also used the added function inside the `hasClass()` function. That way all the tests for `hasClass()` are also, by proxy, testing `getClasses()`.

Of course, `getClasses()` has its own tests as well.