### PR TITLE
[Dev Deps] move `in-publish` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
   "dependencies": {
     "cheerio": "^0.22.0",
     "function.prototype.name": "^1.0.0",
-    "in-publish": "^2.0.0",
     "is-subset": "^0.1.1",
     "lodash": "^4.17.2",
     "object-is": "^1.0.1",
@@ -83,6 +82,7 @@
     "eslint-plugin-jsx-a11y": "^2.2.3",
     "eslint-plugin-react": "^6.7.1",
     "gitbook-cli": "^1.0.1",
+    "in-publish": "^2.0.0",
     "istanbul": "^1.0.0-alpha.2",
     "jsdom": "^6.1.0",
     "json-loader": "^0.5.4",


### PR DESCRIPTION
It is not necessary to include this module in `dependencies` as the `prepublish` lifecycle is not executed when enzyme is installed as a dependency of another package.

## To Test

```shell
$ mkdir -p /tmp/foo
$ pushd !$
$ npm -v
3.10.10
$ npm init --yes
$ npm i --save react enzyme
$ rm -rf node_modules
$ npm i --loglevel=silly &> install.log
$ cat install.log | grep lifecycle | wc -l
     418
$ cat install.log | grep lifecycle | grep prepublish
npm info lifecycle foo@1.0.0~prepublish: foo@1.0.0
npm sill lifecycle foo@1.0.0~prepublish: no script for prepublish, continuing
```

Identical results with npm `v4.0.3`