### PR TITLE
Add tests on broken .parent() use-case

### DIFF
--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -2422,6 +2422,20 @@ describeWithDOM('mount', () => {
       expect(parents.at(0).hasClass('foo')).to.equal(true);
       expect(parents.at(1).hasClass('bax')).to.equal(true);
     });
+
+    it('should work with components in the tree', () => {
+      const Foo = createClass({
+        render() {
+          return <div className="bar" />;
+        },
+      });
+      const wrapper = mount((
+        <div className="root">
+          <Foo />
+        </div>
+      ));
+      expect(wrapper.find('.bar').parents('.root')).to.have.length(1);
+    });
   });
 
   describe('.parent()', () => {

--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -2434,7 +2434,14 @@ describeWithDOM('mount', () => {
           <Foo />
         </div>
       ));
-      expect(wrapper.find('.bar').parents('.root')).to.have.length(1);
+      const root = wrapper.find('.root');
+      expect(root).to.have.lengthOf(1);
+      expect(root.hasClass('root')).to.equal(true);
+      expect(root.hasClass('bar')).to.equal(false);
+
+      const bar = root.find('.bar');
+      expect(bar).to.have.lengthOf(1);
+      expect(bar.parents('.root')).to.have.lengthOf(1);
     });
   });
 

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -2282,6 +2282,17 @@ describe('shallow', () => {
       expect(parents.at(1).hasClass('bar')).to.equal(true);
       expect(parents.at(2).hasClass('bax')).to.equal(true);
     });
+
+    it('should work with component', () => {
+      const Foo = createClass({
+        render() {
+          return <div className="bar" />;
+        },
+      });
+      const wrapper = shallow(<Foo />);
+      expect(wrapper.find('.bar')).to.have.length(1);
+      expect(wrapper.find('.bar').parent()).to.have.length(0);
+    });
   });
 
   describe('.closest(selector)', () => {


### PR DESCRIPTION
When I traverse through React components in a mounted tree, it can't find parent and fails with the error

```
TypeError: Cannot read property 'reverse' of null
   at parentsOfInst (src/MountedTraversal.js:255:10)
   at ReactWrapper.<anonymous> (src/ReactWrapper.jsx:623:35)
   at ReactWrapper.single (src/ReactWrapper.jsx:916:21)
```

See added test as a reproduction example.

As far as I could track, it happens, because the node can't find itself because component wrapper the wrong children `wrapper.children()` in this test returns an empty array, however we have a node inside.