### PR TITLE
[Fix] `dive` should pass along options from `shallow`

### DIFF
--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -3,6 +3,7 @@ import flatten from 'lodash/flatten';
 import unique from 'lodash/uniq';
 import compact from 'lodash/compact';
 import cheerio from 'cheerio';
+import assign from 'object.assign';
 
 import ComplexSelector from './ComplexSelector';
 import {
@@ -1022,7 +1023,7 @@ class ShallowWrapper {
    * @param options object
    * @returns {ShallowWrapper}
    */
-  dive(options) {
+  dive(options = {}) {
     const name = 'dive';
     return this.single(name, (n) => {
       if (isDOMComponentElement(n)) {
@@ -1031,7 +1032,7 @@ class ShallowWrapper {
       if (!isCustomComponentElement(n)) {
         throw new TypeError(`ShallowWrapper::${name}() can only be called on components`);
       }
-      return new ShallowWrapper(n, null, options);
+      return new ShallowWrapper(n, null, assign({}, this.options, options));
     });
   }
 }

--- a/test/ShallowWrapper-spec.jsx
+++ b/test/ShallowWrapper-spec.jsx
@@ -3842,11 +3842,18 @@ describe('shallow', () => {
         return <RendersDOM />;
       }
     }
+    WrapsRendersDOM.contextTypes = { foo: React.PropTypes.string };
     class DoubleWrapsRendersDOM extends React.Component {
       render() {
         return <WrapsRendersDOM />;
       }
     }
+    class ContextWrapsRendersDOM extends React.Component {
+      render() {
+        return <WrapsRendersDOM />;
+      }
+    }
+    ContextWrapsRendersDOM.contextTypes = { foo: React.PropTypes.string };
 
     it('throws on a DOM node', () => {
       const wrapper = shallow(<RendersDOM />);
@@ -3882,6 +3889,17 @@ describe('shallow', () => {
 
       const underwater = wrapper.dive();
       expect(underwater.is(RendersDOM)).to.equal(true);
+    });
+
+    it('should merge and pass options through', () => {
+      const wrapper = shallow(<ContextWrapsRendersDOM />, { context: { foo: 'hello' } });
+      expect(wrapper.context()).to.deep.equal({ foo: 'hello' });
+
+      let underwater = wrapper.dive();
+      expect(underwater.context()).to.deep.equal({ foo: 'hello' });
+
+      underwater = wrapper.dive({ context: { foo: 'enzyme!' } });
+      expect(underwater.context()).to.deep.equal({ foo: 'enzyme!' });
     });
   });
 


### PR DESCRIPTION
I made it, could you check this source?

I only added a logic that merges options to `dive()`

refs: #770 