### PR TITLE
[Fix] mount/shallow: "match" should not differentiate nullary props

### DIFF
--- a/src/MountedTraversal.js
+++ b/src/MountedTraversal.js
@@ -4,6 +4,7 @@ import isSubset from 'is-subset';
 import {
   internalInstance,
   nodeEqual,
+  nodeMatches,
   propsOfNode,
   isFunctionalComponent,
   splitSelector,
@@ -44,6 +45,10 @@ export function getNode(inst) {
 
 export function instEqual(a, b, lenComp) {
   return nodeEqual(getNode(a), getNode(b), lenComp);
+}
+
+export function instMatches(a, b, lenComp) {
+  return nodeMatches(getNode(a), getNode(b), lenComp);
 }
 
 export function instHasClassName(inst, className) {

--- a/src/ReactWrapper.jsx
+++ b/src/ReactWrapper.jsx
@@ -12,6 +12,7 @@ import {
   parentsOfInst,
   buildInstPredicate,
   instEqual,
+  instMatches,
   treeFilter,
   getNode,
   internalInstanceOrComponent,
@@ -311,7 +312,7 @@ class ReactWrapper {
    * @returns {Boolean}
    */
   matchesElement(node) {
-    return this.single('matchesElement', () => instEqual(node, this.getNode(), (a, b) => a <= b));
+    return this.single('matchesElement', () => instMatches(node, this.getNode(), (a, b) => a <= b));
   }
 
   /**
@@ -350,7 +351,7 @@ class ReactWrapper {
    * @returns {Boolean}
    */
   containsMatchingElement(node) {
-    const predicate = other => instEqual(node, other, (a, b) => a <= b);
+    const predicate = other => instMatches(node, other, (a, b) => a <= b);
     return findWhereUnwrapped(this, predicate).length > 0;
   }
 
@@ -373,7 +374,7 @@ class ReactWrapper {
    * @returns {Boolean}
    */
   containsAllMatchingElements(nodes) {
-    const invertedEquals = (n1, n2) => instEqual(n2, n1, (a, b) => a <= b);
+    const invertedEquals = (n1, n2) => instMatches(n2, n1, (a, b) => a <= b);
     const predicate = other => containsChildrenSubArray(invertedEquals, other, nodes);
     return findWhereUnwrapped(this, predicate).length > 0;
   }

--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -7,6 +7,7 @@ import cheerio from 'cheerio';
 import ComplexSelector from './ComplexSelector';
 import {
   nodeEqual,
+  nodeMatches,
   containsChildrenSubArray,
   propFromEvent,
   withSetStateAllowed,
@@ -354,7 +355,7 @@ class ShallowWrapper {
    * @returns {Boolean}
    */
   containsMatchingElement(node) {
-    const predicate = other => nodeEqual(node, other, (a, b) => a <= b);
+    const predicate = other => nodeMatches(node, other, (a, b) => a <= b);
     return findWhereUnwrapped(this, predicate).length > 0;
   }
 
@@ -378,7 +379,7 @@ class ShallowWrapper {
    * @returns {Boolean}
    */
   containsAllMatchingElements(nodes) {
-    const invertedEquals = (n1, n2) => nodeEqual(n2, n1, (a, b) => a <= b);
+    const invertedEquals = (n1, n2) => nodeMatches(n2, n1, (a, b) => a <= b);
     const predicate = other => containsChildrenSubArray(invertedEquals, other, nodes);
     return findWhereUnwrapped(this, predicate).length > 0;
   }
@@ -440,7 +441,7 @@ class ShallowWrapper {
    * @returns {Boolean}
    */
   matchesElement(node) {
-    return this.single('matchesElement', () => nodeEqual(node, this.getNode(), (a, b) => a <= b));
+    return this.single('matchesElement', () => nodeMatches(node, this.getNode(), (a, b) => a <= b));
   }
 
   /**

--- a/test/ReactWrapper-spec.jsx
+++ b/test/ReactWrapper-spec.jsx
@@ -3040,6 +3040,7 @@ describeWithDOM('mount', () => {
       expect(spy1.callCount).to.equal(0);
       expect(spy2.callCount).to.equal(0);
     });
+
     it('should match on a single node that looks like a rendered one', () => {
       const spy1 = sinon.spy();
       const spy2 = sinon.spy();
@@ -3070,6 +3071,7 @@ describeWithDOM('mount', () => {
       expect(spy1.callCount).to.equal(0);
       expect(spy2.callCount).to.equal(0);
     });
+
     it('should not match on a single node that doesn\'t looks like a rendered one', () => {
       const spy1 = sinon.spy();
       const spy2 = sinon.spy();
@@ -3086,7 +3088,32 @@ describeWithDOM('mount', () => {
         <div onClick={spy2}>Au revoir le monde</div>,
       )).to.equal(false);
     });
+
+    it('should not differentiate between absence, null, or undefined', () => {
+      const wrapper = mount((
+        <div>
+          <div className="a" id={null} />
+          <div className="b" id={undefined} />
+          <div className="c" />
+        </div>
+      ));
+
+      expect(wrapper.containsMatchingElement(<div />)).to.equal(true);
+
+      expect(wrapper.containsMatchingElement(<div className="a" />)).to.equal(true);
+      expect(wrapper.containsMatchingElement(<div className="a" id={null} />)).to.equal(true);
+      expect(wrapper.containsMatchingElement(<div className="a" id={undefined} />)).to.equal(true);
+
+      expect(wrapper.containsMatchingElement(<div className="b" />)).to.equal(true);
+      expect(wrapper.containsMatchingElement(<div className="b" id={null} />)).to.equal(true);
+      expect(wrapper.containsMatchingElement(<div className="b" id={undefined} />)).to.equal(true);
+
+      expect(wrapper.containsMatchingElement(<div className="c" />)).to.equal(true);
+      expect(wrapper.containsMatchingElement(<div className="c" id={null} />)).to.equal(true);
+      expect(wrapper.containsMatchingElement(<div className="c" id={undefined} />)).to.equal(true);
+    });
   });
+
   describe('.containsAllMatchingElements(nodes)', () => {
     it('should match on an array of nodes that all looks like one of rendered nodes', () => {
       const spy1 = sinon.spy();

--- a/test/ShallowWrapper-spec.jsx
+++ b/test/ShallowWrapper-spec.jsx
@@ -3510,6 +3510,7 @@ describe('shallow', () => {
       expect(spy1.callCount).to.equal(0);
       expect(spy2.callCount).to.equal(0);
     });
+
     it('should match on a single node that looks like a rendered one', () => {
       const spy1 = sinon.spy();
       const spy2 = sinon.spy();
@@ -3540,6 +3541,7 @@ describe('shallow', () => {
       expect(spy1.callCount).to.equal(0);
       expect(spy2.callCount).to.equal(0);
     });
+
     it('should not match on a single node that doesn\'t looks like a rendered one', () => {
       const spy1 = sinon.spy();
       const spy2 = sinon.spy();
@@ -3556,18 +3558,42 @@ describe('shallow', () => {
         <div onClick={spy2}>Au revoir le monde</div>,
       )).to.equal(false);
     });
+
+    it('should not differentiate between absence, null, or undefined', () => {
+      const wrapper = shallow((
+        <div>
+          <div className="a" id={null} />
+          <div className="b" id={undefined} />
+          <div className="c" />
+        </div>
+      ));
+
+      expect(wrapper.containsMatchingElement(<div />)).to.equal(true);
+
+      expect(wrapper.containsMatchingElement(<div className="a" />)).to.equal(true);
+      expect(wrapper.containsMatchingElement(<div className="a" id={null} />)).to.equal(true);
+      expect(wrapper.containsMatchingElement(<div className="a" id={undefined} />)).to.equal(true);
+
+      expect(wrapper.containsMatchingElement(<div className="b" />)).to.equal(true);
+      expect(wrapper.containsMatchingElement(<div className="b" id={null} />)).to.equal(true);
+      expect(wrapper.containsMatchingElement(<div className="b" id={undefined} />)).to.equal(true);
+
+      expect(wrapper.containsMatchingElement(<div className="c" />)).to.equal(true);
+      expect(wrapper.containsMatchingElement(<div className="c" id={null} />)).to.equal(true);
+      expect(wrapper.containsMatchingElement(<div className="c" id={undefined} />)).to.equal(true);
+    });
   });
 
   describe('.containsAllMatchingElements(nodes)', () => {
     it('should match on an array of nodes that all looks like one of rendered nodes', () => {
       const spy1 = sinon.spy();
       const spy2 = sinon.spy();
-      const wrapper = shallow(
+      const wrapper = shallow((
         <div>
           <div onClick={spy1} style={{ fontSize: 12, color: 'red' }}>Hello World</div>
           <div onClick={spy2} style={{ fontSize: 13, color: 'blue' }}>Goodbye World</div>
-        </div>,
-      );
+        </div>
+      ));
       expect(wrapper.containsAllMatchingElements([
         <div>Hello World</div>,
         <div>Goodbye World</div>,
@@ -3603,6 +3629,7 @@ describe('shallow', () => {
       expect(spy1.callCount).to.equal(0);
       expect(spy2.callCount).to.equal(0);
     });
+
     it('should not match on nodes that doesn\'t all looks like one of rendered nodes', () => {
       const spy1 = sinon.spy();
       const spy2 = sinon.spy();


### PR DESCRIPTION
This PR fixes the matching APIs.

`<div>` and `<div id={undefined} />` absolutely should match, because React, most of JS, and human intuition does not distinguish between "absent" and "undefined". This is inarguably a bug fix.

This PR also asserts that `<div>` and `<div id={null} />` should match. JS doesn't treat them this way - and React treats them differently only in the case of defaultProps. However, by the time `enzyme` is attempting to match elements, any defaultProps have been applied - and my contention is that absent a defaultProp, `null`, `undefined`, and "absent" should all be treated the same.

This came up specifically because I attempted to add missing defaultProps, set to `null`, on a component, and tests using enzyme's matching APIs began to fail. I don't believe they should have failed.

I consider null-matching expected behavior from these APIs, and I think that this is unlikely to cause any tests to fail, or falsely pass - thus I'm convinced it's a semver-patch.