### PR TITLE
add disableLifecycleMethods for shallow

### DIFF
--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -49,7 +49,7 @@ describe('<MyComponent />', () => {
   - `options.context`: (`Object` [optional]): Context to be passed into the component
   - `options.disableLifecycleMethods`: (`Boolean` [optional]): If set to true, `componentDidMount`
 and `componentDidUpdate` are not called on the component. Allows `shallow` to be
-used when testing components that assume refs or DOM nodes are available during those methods
+used when testing components that assume refs or DOM nodes are available during these methods
 
 #### Returns
 

--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -46,7 +46,10 @@ describe('<MyComponent />', () => {
 
 1. `node` (`ReactElement`): The node to render
 2. `options` (`Object` [optional]):
-- `options.context`: (`Object` [optional]): Context to be passed into the component
+  - `options.context`: (`Object` [optional]): Context to be passed into the component
+  - `options.disableLifecycleMethods`: (`Boolean` [optional]): If set to true, `componentDidMount`
+and `componentDidUpdate` are not called on the component. Allows `shallow` to be
+used when testing components that assume refs or DOM nodes are available during those methods
 
 #### Returns
 

--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -48,8 +48,8 @@ describe('<MyComponent />', () => {
 2. `options` (`Object` [optional]):
   - `options.context`: (`Object` [optional]): Context to be passed into the component
   - `options.disableLifecycleMethods`: (`Boolean` [optional]): If set to true, `componentDidMount`
-and `componentDidUpdate` are not called on the component. Allows `shallow` to be
-used when testing components that assume refs or DOM nodes are available during these methods
+is not called on the component, and `componentDidUpdate` is not called after
+[`setProps`](ShallowWrapper/setProps.md) and [`setContext`](ShallowWrapper/setContext.md).
 
 #### Returns
 

--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -63,12 +63,24 @@ function filterWhereUnwrapped(wrapper, predicate) {
   return wrapper.wrap(compact(wrapper.getNodes().filter(predicate)));
 }
 
+function validateOptions(options) {
+  if (
+    options.lifecycleExperimental != null &&
+    options.lifecycleExperimental === options.disableLifecycleMethods
+  ) {
+    throw new Error(
+      'lifecycleExperimental and disableLifecycleMethods cannot be set to the same value',
+    );
+  }
+}
+
 /**
  * @class ShallowWrapper
  */
 class ShallowWrapper {
 
   constructor(nodes, root, options = {}) {
+    validateOptions(options);
     if (!root) {
       this.root = this;
       this.unrendered = nodes;

--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -63,10 +63,34 @@ function filterWhereUnwrapped(wrapper, predicate) {
   return wrapper.wrap(compact(wrapper.getNodes().filter(predicate)));
 }
 
+/**
+ * Ensure options passed to ShallowWrapper are valid. Throws otherwise.
+ * @param {Object} options
+ */
 function validateOptions(options) {
+  const { lifecycleExperimental, disableLifecycleMethods } = options;
   if (
-    options.lifecycleExperimental != null &&
-    options.lifecycleExperimental === options.disableLifecycleMethods
+    typeof lifecycleExperimental !== 'undefined' &&
+    lifecycleExperimental !== !!lifecycleExperimental
+  ) {
+    throw new Error(
+      'lifecycleExperimental must be either true or false if provided',
+    );
+  }
+
+  if (
+    typeof disableLifecycleMethods !== 'undefined' &&
+    disableLifecycleMethods !== !!disableLifecycleMethods
+  ) {
+    throw new Error(
+      'disableLifecycleMethods must be either true or false if provided',
+    );
+  }
+
+  if (
+    lifecycleExperimental != null &&
+    disableLifecycleMethods != null &&
+    lifecycleExperimental === disableLifecycleMethods
   ) {
     throw new Error(
       'lifecycleExperimental and disableLifecycleMethods cannot be set to the same value',

--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -71,7 +71,7 @@ function validateOptions(options) {
   const { lifecycleExperimental, disableLifecycleMethods } = options;
   if (
     typeof lifecycleExperimental !== 'undefined' &&
-    lifecycleExperimental !== !!lifecycleExperimental
+    typeof lifecycleExperimental !== 'boolean'
   ) {
     throw new Error(
       'lifecycleExperimental must be either true or false if provided',
@@ -80,7 +80,7 @@ function validateOptions(options) {
 
   if (
     typeof disableLifecycleMethods !== 'undefined' &&
-    disableLifecycleMethods !== !!disableLifecycleMethods
+    typeof disableLifecycleMethods !== 'boolean'
   ) {
     throw new Error(
       'disableLifecycleMethods must be either true or false if provided',

--- a/test/ShallowWrapper-spec.jsx
+++ b/test/ShallowWrapper-spec.jsx
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 import { shallow, render, ShallowWrapper } from '../src/';
 import { describeIf, itIf, itWithData, generateEmptyRenderData } from './_helpers';
 import { ITERATOR_SYMBOL, withSetStateAllowed } from '../src/Utils';
-import { REACT013, REACT15 } from '../src/version';
+import { REACT013, REACT014, REACT15 } from '../src/version';
 
 describe('shallow', () => {
   describe('context', () => {
@@ -2777,13 +2777,27 @@ describe('shallow', () => {
         ]);
       });
 
-      it('calls expected methods when receiving new context', () => {
-        wrapper.setContext({ foo: 'foo' });
-        expect(spy.args).to.deep.equal([
-          ['shouldComponentUpdate'],
-          ['componentWillUpdate'],
-          ['render'],
-        ]);
+      describeIf(REACT013 || REACT15, 'setContext', () => {
+        it('calls expected methods when receiving new context', () => {
+          wrapper.setContext({ foo: 'foo' });
+          expect(spy.args).to.deep.equal([
+            ['componentWillReceiveProps'],
+            ['shouldComponentUpdate'],
+            ['componentWillUpdate'],
+            ['render'],
+          ]);
+        });
+      });
+
+      describeIf(REACT014, 'setContext', () => {
+        it('calls expected methods when receiving new context', () => {
+          wrapper.setContext({ foo: 'foo' });
+          expect(spy.args).to.deep.equal([
+            ['shouldComponentUpdate'],
+            ['componentWillUpdate'],
+            ['render'],
+          ]);
+        });
       });
 
       it('calls expected methods for setState', () => {

--- a/test/ShallowWrapper-spec.jsx
+++ b/test/ShallowWrapper-spec.jsx
@@ -2684,6 +2684,18 @@ describe('shallow', () => {
   });
 
   describe('lifecycleExperimental', () => {
+    it('throws when used with disableLifecycleMethods in invalid combinations', () => {
+      expect(() => shallow(<div />, {
+        lifecycleExperimental: true,
+        disableLifecycleMethods: true,
+      })).to.throw(/same value/);
+
+      expect(() => shallow(<div />, {
+        lifecycleExperimental: false,
+        disableLifecycleMethods: false,
+      })).to.throw(/same value/);
+    });
+
     context('mounting phase', () => {
       it('should call componentWillMount and componentDidMount', () => {
         const spy = sinon.spy();

--- a/test/ShallowWrapper-spec.jsx
+++ b/test/ShallowWrapper-spec.jsx
@@ -2747,13 +2747,20 @@ describe('shallow', () => {
         }
       }
 
+      const options = {
+        disableLifecycleMethods: true,
+        context: {
+          foo: 'foo',
+        },
+      };
+
       beforeEach(() => {
-        wrapper = shallow(<Foo />, { disableLifecycleMethods: true });
+        wrapper = shallow(<Foo />, options);
         spy.reset();
       });
 
       it('does not call componentDidMount when mounting', () => {
-        wrapper = shallow(<Foo />, { disableLifecycleMethods: true });
+        wrapper = shallow(<Foo />, options);
         expect(spy.args).to.deep.equal([
           ['componentWillMount'],
           ['render'],
@@ -2764,6 +2771,15 @@ describe('shallow', () => {
         wrapper.setProps({ foo: 'foo' });
         expect(spy.args).to.deep.equal([
           ['componentWillReceiveProps'],
+          ['shouldComponentUpdate'],
+          ['componentWillUpdate'],
+          ['render'],
+        ]);
+      });
+
+      it('calls expected methods when receiving new context', () => {
+        wrapper.setContext({ foo: 'foo' });
+        expect(spy.args).to.deep.equal([
           ['shouldComponentUpdate'],
           ['componentWillUpdate'],
           ['render'],


### PR DESCRIPTION
As part of the plan to switch on all lifecycle methods for `shallow` in the next major, introduce a no-op flag ahead of time that turns that off.

Ref: https://github.com/airbnb/enzyme/issues/678#issuecomment-274949209

~~Since there's no options validation, I'm not sure any code changes are necessary.~~ (added) It may be confusing if someone sets this flag to explicitly false and expects their lifecycle methods to be called. Should we set lifecycleExperimental to true in that case?

I didn't prefix the option with `deprecated` because it seemed this flag is going to be sticking around as the official, inverted version of lifecycleExperimental. I may have misunderstood something though.

The name feels a bit off since it's not disabling *all* the lifecycle methods, just two of them. Should it be something like `disableFullLifecycle`?