### PR TITLE
Fix a bug that doesn't update props with lifecycleExperimental: true and sCU: false

### DIFF
--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -230,6 +230,9 @@ class ShallowWrapper {
               instance.componentDidUpdate(prevProps, state, prevContext);
             }
             this.update();
+          // If it doesn't need to rerender, update only its props.
+          } else if (props) {
+            instance.props = props;
           }
           if (originalComponentWillReceiveProps) {
             instance.componentWillReceiveProps = originalComponentWillReceiveProps;

--- a/test/ShallowWrapper-spec.jsx
+++ b/test/ShallowWrapper-spec.jsx
@@ -2862,8 +2862,11 @@ describe('shallow', () => {
         }
 
         const wrapper = shallow(<Foo foo="bar" />, { lifecycleExperimental: true });
+        expect(wrapper.instance().props.foo).to.equal('bar');
         wrapper.setProps({ foo: 'baz' });
+        expect(wrapper.instance().props.foo).to.equal('baz');
         wrapper.setProps({ foo: 'bax' });
+        expect(wrapper.instance().props.foo).to.equal('bax');
         expect(spy.args).to.deep.equal([
           ['render'],
           ['componentWillReceiveProps'],
@@ -3050,7 +3053,9 @@ describe('shallow', () => {
           }
         }
         const wrapper = shallow(<Foo />, { lifecycleExperimental: true });
+        expect(wrapper.instance().state.foo).to.equal('bar');
         wrapper.setState({ foo: 'baz' });
+        expect(wrapper.instance().state.foo).to.equal('baz');
         expect(spy.args).to.deep.equal([['render'], ['shouldComponentUpdate']]);
       });
 
@@ -3152,7 +3157,9 @@ describe('shallow', () => {
             lifecycleExperimental: true,
           },
         );
+        expect(wrapper.instance().context.foo).to.equal('bar');
         wrapper.setContext({ foo: 'baz' });
+        expect(wrapper.instance().context.foo).to.equal('baz');
         expect(spy.args).to.deep.equal([
           [
             'render',


### PR DESCRIPTION
This PR is to fix #805.
When `lifecycleExperimental` is `true` and `shouldComponentUpdate` returns `false`, ShallowWrapper should update instances's props with passed props.

I've also added some unit tests for to assert updating `props` and `state` and `context` whether `shouldComponentUpdate` returns `true` or not.