### PR TITLE
Add expect-enzyme library to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ should be able to extrapolate to your framework of choice.
 
 If you are interested in using enzyme with custom assertions and convenience functions for
 testing your React components, you can consider using:
+
 * [`chai-enzyme`](https://github.com/producthunt/chai-enzyme) with Mocha/Chai.
 * [`jasmine-enzyme`](https://github.com/blainekasten/enzyme-matchers/tree/master/packages/jasmine-enzyme) with Jasmine.
 * [`jest-enzyme`](https://github.com/blainekasten/enzyme-matchers/tree/master/packages/jest-enzyme) with Jest.
 * [`should-enzyme`](https://github.com/rkotze/should-enzyme) for should.js.
+* [`expect-enzyme`](https://github.com/PsychoLlama/expect-enzyme) for expect.
 
 
 [Using Enzyme with Mocha](/docs/guides/mocha.md)


### PR DESCRIPTION
Briefly mentions `expect-enzyme` with the other assertion libraries on the readme.