### PR TITLE
[Docs] Update AVA example for better use of API

### DIFF
--- a/docs/guides/tape-ava.md
+++ b/docs/guides/tape-ava.md
@@ -40,13 +40,13 @@ import Foo from '../path/to/foo'
 
 test('shallow', t => {
   const wrapper = shallow(<Foo />)
-  t.is(wrapper.contains(<span>Foo</span>), true)
+  t.true(wrapper.contains(<span>Foo</span>))
 })
 
 test('mount', t => {
   const wrapper = mount(<Foo />)
   const fooInner = wrapper.find('.foo-inner')
-  t.is(fooInner.is('.foo-inner'), true)
+  t.true(fooInner.is('.foo-inner'))
 })
 ```
 


### PR DESCRIPTION
AVA has `t.true` and `t.false` for `true`/`false` checking, so you don't need `t.is(..., true)`.

I couldn't see the same in tape's docs (other than `t.ok` and `t.notOk`, but they test for truthy/falsy, not `true` and `false` specifically), so I haven't updated the tape example as I wasn't sure that'd be precise enough for you.