### PR TITLE
[docs] Minor improvements to docs around matchesElement

### DIFF
--- a/docs/api/ReactWrapper/matchesElement.md
+++ b/docs/api/ReactWrapper/matchesElement.md
@@ -1,7 +1,7 @@
 # `.matchesElement(node) => Boolean`
 
 Returns whether or not a given react element matches the current render tree.
-It will determine if the the wrapper root node __looks like__ the expected element by checking if all props of the expected element are present on the wrapper root node and equals to each other.
+It will determine if the the wrapper root node __looks like__ the expected element by checking if all the props supplied in the expected element are present on the wrapper root node and equal to each other. Props present on the wrapper root node but not supplied in the expected element will be ignored.
 
 
 #### Arguments

--- a/docs/api/ShallowWrapper/containsAllMatchingElements.md
+++ b/docs/api/ShallowWrapper/containsAllMatchingElements.md
@@ -1,7 +1,9 @@
 # `.containsAllMatchingElements(nodes) => Boolean`
 
 Returns whether or not one of the given react elements are all matching one element in the shallow render tree.
-It will determine if an element in the wrapper __looks like__ one of the expected element by checking if all props of the expected element are present on the wrappers element and equals to each other.
+It will determine if the wrapper contains elements which __look like__ each of the expected elements by checking if all props of each expected element are present on the wrapper's elements and equal to each other. Props present on the wrapper elements but not supplied in the expected elements will be ignored.
+
+
 
 
 #### Arguments

--- a/docs/api/ShallowWrapper/containsAnyMatchingElements.md
+++ b/docs/api/ShallowWrapper/containsAnyMatchingElements.md
@@ -1,7 +1,7 @@
 # `.containsAnyMatchingElements(nodes) => Boolean`
 
 Returns whether or not one of the given react elements is matching on element in the shallow render tree.
-It will determine if an element in the wrapper __looks like__ one of the expected element by checking if all props of the expected element are present on the wrappers element and equals to each other.
+It will determine if an element in the wrapper __looks like__ one of the expected elements by checking if all props of the expected element are present on the wrappers element and equal to each other. Props present on the wrapper root node but not supplied in the expected element will be ignored.
 
 
 #### Arguments

--- a/docs/api/ShallowWrapper/containsMatchingElement.md
+++ b/docs/api/ShallowWrapper/containsMatchingElement.md
@@ -1,7 +1,7 @@
 # `.containsMatchingElement(node) => Boolean`
 
 Returns whether or not a given react element matches one element in the render tree.
-It will determine if an element in the wrapper matches the expected element by checking if all props of the expected element are present on the wrapper's element and equals to each other.
+It will determine if an element in the wrapper matches the expected element by checking if all props supplied in the expected element are present on the wrapper's element and equal to each other. Props present on the wrapper element but not supplied in the expected element will be ignored.
 
 
 #### Arguments


### PR DESCRIPTION
I overlooked these methods and wasted a lot of time because I didn't read the docs carefully enough until I stumbled across this PR https://github.com/airbnb/enzyme/pull/362. Edits to make it more clear that they do matching with a limited subset of props specified on supplied element and other props will be ignored. 

Minor grammar/language improvements while I was at it.
