### PR TITLE
Fix an issue w/ cleaning up global.document.

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -221,6 +221,9 @@ export function withSetStateAllowed(fn) {
   }
   fn();
   if (cleanup) {
+    // This works around a bug in node/jest in that developers aren't able to
+    // delete things from global when running in a node vm.
+    global.document = undefined;
     delete global.document;
   }
 }


### PR DESCRIPTION
Except in the most recent versions of node, developers are unable to delete
things from global when running code in a node vm.  This means that enzyme is
failing to clean up after itself when temporarily defining global.document for
setState calls.

This papers over the issue by explicitly setting global.document to undefined
if it failed to be deleted.

Relevant jest issue - https://github.com/facebook/jest/issues/3152

Relevant node pr - https://github.com/nodejs/node/pull/11266