### PR TITLE
Update shallow docs with lifecycleExperimental

### DIFF
--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -46,6 +46,7 @@ describe('<MyComponent />', () => {
   - `options.disableLifecycleMethods`: (`Boolean` [optional]): If set to true, `componentDidMount`
 is not called on the component, and `componentDidUpdate` is not called after
 [`setProps`](ShallowWrapper/setProps.md) and [`setContext`](ShallowWrapper/setContext.md).
+  - `options.lifecycleExperimental`: (`Boolean` [optional]): If set to true, the entire lifecycle (`componentDidMount` and `componentDidUpdate`) of the React component is called
 
 #### Returns
 

--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -43,10 +43,12 @@ describe('<MyComponent />', () => {
 1. `node` (`ReactElement`): The node to render
 2. `options` (`Object` [optional]):
   - `options.context`: (`Object` [optional]): Context to be passed into the component
-  - `options.disableLifecycleMethods`: (`Boolean` [optional]): If set to true, `componentDidMount`
-is not called on the component, and `componentDidUpdate` is not called after
-[`setProps`](ShallowWrapper/setProps.md) and [`setContext`](ShallowWrapper/setContext.md).
-  - `options.lifecycleExperimental`: (`Boolean` [optional]): If set to true, the entire lifecycle (`componentDidMount` and `componentDidUpdate`) of the React component is called. The current default value is `false` with enzyme v2, but the next major version will flip the default value to `true`
+  - `options.disableLifecycleMethods`: (`Boolean` [optional]): If set to true, most of the React
+lifecycle methods will never be executed: `componentDidMount`, `componentWillReceiveProps`,
+`shouldComponentUpdate`, `componentWillUpdate` and `componentDidUpdate`. Default to `false`.
+  - `options.lifecycleExperimental`: (`Boolean` [optional]): If set to true, the entire lifecycle
+(`componentDidMount` and `componentDidUpdate`) of the React component is called. The current default value
+is `false` with enzyme v2, but the next major version will flip the default value to `true`.
 
 #### Returns
 

--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -43,9 +43,9 @@ describe('<MyComponent />', () => {
 1. `node` (`ReactElement`): The node to render
 2. `options` (`Object` [optional]):
   - `options.context`: (`Object` [optional]): Context to be passed into the component
-  - `options.disableLifecycleMethods`: (`Boolean` [optional]): If set to true, most of the React
-lifecycle methods will never be executed: `componentDidMount`, `componentWillReceiveProps`,
-`shouldComponentUpdate`, `componentWillUpdate` and `componentDidUpdate`. Default to `false`.
+  - `options.disableLifecycleMethods`: (`Boolean` [optional]): If set to true, `componentDidMount`
+is not called on the component, and `componentDidUpdate` is not called after
+[`setProps`](ShallowWrapper/setProps.md) and [`setContext`](ShallowWrapper/setContext.md). Default to `false`. 
   - `options.lifecycleExperimental`: (`Boolean` [optional]): If set to true, the entire lifecycle
 (`componentDidMount` and `componentDidUpdate`) of the React component is called. The current default value
 is `false` with enzyme v2, but the next major version will flip the default value to `true`.

--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -46,7 +46,7 @@ describe('<MyComponent />', () => {
   - `options.disableLifecycleMethods`: (`Boolean` [optional]): If set to true, `componentDidMount`
 is not called on the component, and `componentDidUpdate` is not called after
 [`setProps`](ShallowWrapper/setProps.md) and [`setContext`](ShallowWrapper/setContext.md).
-  - `options.lifecycleExperimental`: (`Boolean` [optional]): If set to true, the entire lifecycle (`componentDidMount` and `componentDidUpdate`) of the React component is called
+  - `options.lifecycleExperimental`: (`Boolean` [optional]): If set to true, the entire lifecycle (`componentDidMount` and `componentDidUpdate`) of the React component is called. The current default value is `false` with enzyme v2, but the next major version will flip the default value to `true`
 
 #### Returns
 


### PR DESCRIPTION
As far as I know, the `options.lifecycleExperimental` is not documented yet.  
I just found this pull request https://github.com/airbnb/enzyme/pull/318 and that's the only place where we see that option