### PR TITLE
Add beforeInput to simulated event map.

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -412,6 +412,7 @@ export function mapNativeEventNames(event) {
     ratechange: 'rateChange',
     timeupdate: 'timeUpdate',
     volumechange: 'volumeChange',
+    beforeinput: 'beforeInput',
   };
 
   if (!REACT013) {


### PR DESCRIPTION
For the purposes of testing an editor based on https://github.com/facebook/draft-js, I'd like to be able to simulate the `beforeinput` event.

I didn't see tests to make sure that each event is mapped properly, so I didn't add one. If I missed it, please point me the proper place, and I'm happy to add one.

Thanks for enzyme! It's fantastic!