### PR TITLE
Convert React.createClass to React.Component

### DIFF
--- a/docs/api/ReactWrapper/matchesElement.md
+++ b/docs/api/ReactWrapper/matchesElement.md
@@ -21,16 +21,20 @@ render tree.
 
 
 ```jsx
-const MyComponent = React.createClass({
+class MyComponent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleClick = this.handleClick.bind(this);
+  }
   handleClick() {
     ...
-  },
+  }
   render() {
     return (
       <div onClick={this.handleClick} className="foo bar">Hello</div>
     );
   }
-});
+}
 
 const wrapper = mount(<MyComponent />);
 expect(wrapper.matchesElement(

--- a/docs/api/ReactWrapper/setContext.md
+++ b/docs/api/ReactWrapper/setContext.md
@@ -21,14 +21,14 @@ NOTE: can only be called on a wrapper instance that is also the root instance.
 #### Example
 
 ```jsx
-const SimpleComponent = React.createClass({
-  contextTypes: {
-    name: React.PropTypes.string,
-  },
+class SimpleComponent extends React.Component {
   render() {
     return <div>{this.context.name}</div>;
-  },
-});
+  }
+}
+SimpleComponent.contextTypes = {
+  name: React.PropTypes.string,
+};
 ```
 ```jsx
 const context = { name: 'foo' };

--- a/docs/api/ShallowWrapper/matchesElement.md
+++ b/docs/api/ShallowWrapper/matchesElement.md
@@ -21,16 +21,20 @@ render tree.
 
 
 ```jsx
-const MyComponent = React.createClass({
+class MyComponent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleClick = this.handleClick.bind(this);
+  }
   handleClick() {
     ...
-  },
+  }
   render() {
     return (
       <div onClick={this.handleClick} className="foo bar">Hello</div>
     );
   }
-});
+}
 
 const wrapper = shallow(<MyComponent />);
 expect(wrapper.matchesElement(

--- a/docs/api/ShallowWrapper/prop.md
+++ b/docs/api/ShallowWrapper/prop.md
@@ -19,13 +19,13 @@ of the root node of the component.
 
 
 ```jsx
-const MyComponent = React.createClass({
+class MyComponent extends React.Component {
   render() {
     return (
         <div className="foo bar" includedProp={this.props.includedProp}>Hello</div>
     )
   }
-})
+}
 const wrapper = shallow(<MyComponent includedProp="Success!" excludedProp="I'm not included" />);
 expect(wrapper.prop('includedProp')).to.equal("Success!");
 

--- a/docs/api/ShallowWrapper/props.md
+++ b/docs/api/ShallowWrapper/props.md
@@ -13,13 +13,13 @@ See [`.instance() => ReactComponent`](instance.md)
 
 
 ```jsx
-const MyComponent = React.createClass({
+class MyComponent extends React.Component {
   render() {
     return (
         <div className="foo bar" includedProp={this.props.includedProp}>Hello</div>
     )
   }
-})
+}
 const wrapper = shallow(<MyComponent includedProp="Success!" excludedProp="I'm not included" />);
 expect(wrapper.props().includedProp).to.equal("Success!");
 

--- a/docs/api/ShallowWrapper/setContext.md
+++ b/docs/api/ShallowWrapper/setContext.md
@@ -21,14 +21,14 @@ NOTE: can only be called on a wrapper instance that is also the root instance.
 #### Example
 
 ```jsx
-const SimpleComponent = React.createClass({
-  contextTypes: {
-    name: React.PropTypes.string,
-  },
+class SimpleComponent extends React.Component {
   render() {
     return <div>{this.context.name}</div>;
-  },
-});
+  }
+}
+SimpleComponent.contextTypes = {
+  name: React.PropTypes.string,
+};
 ```
 ```jsx
 const context = { name: 'foo' };

--- a/docs/api/render.md
+++ b/docs/api/render.md
@@ -30,14 +30,14 @@ describe('<Foo />', () => {
   });
 
   it('can pass in context', () => {
-    const SimpleComponent = React.createClass({
-      contextTypes: {
-        name: React.PropTypes.string,
-      },
+    class SimpleComponent extends React.Component {
       render() {
         return <div>{this.context.name}</div>;
-      },
-    });
+      }
+    }
+    SimpleComponent.contextTypes = {
+      name: React.PropTypes.string,
+    };
 
     const context = { name: 'foo' };
     const wrapper = render(<SimpleComponent />, { context });


### PR DESCRIPTION
In react@15.5, `React.createClass` is deprecated, So we have to use `create-react-class` instead. #876

In this PR, I've converted `React.createClass` to `React.Component` except some tests for `React.createClass`. 
Should Enzyme support `create-react-class`? If it isn't necessary, I can remove all `React.createClass` from the tests.

* https://github.com/airbnb/enzyme/blob/master/test/ReactWrapper-spec.jsx#L3270
* https://github.com/airbnb/enzyme/blob/master/test/ReactWrapper-spec.jsx#L3306
* https://github.com/airbnb/enzyme/blob/master/test/ShallowWrapper-spec.jsx#L1273
* https://github.com/airbnb/enzyme/blob/master/test/ShallowWrapper-spec.jsx#L3909
* https://github.com/airbnb/enzyme/blob/master/test/ShallowWrapper-spec.jsx#L3955

After this PR is merged, Enzyme can put `create-react-class` in `devDependencies` instead of `dependencies`.