### PR TITLE
Migrating React.PropTypes to prop-types

### DIFF
--- a/docs/api/ReactWrapper/setContext.md
+++ b/docs/api/ReactWrapper/setContext.md
@@ -27,7 +27,7 @@ class SimpleComponent extends React.Component {
   }
 }
 SimpleComponent.contextTypes = {
-  name: React.PropTypes.string,
+  name: PropTypes.string,
 };
 ```
 ```jsx

--- a/docs/api/ShallowWrapper/setContext.md
+++ b/docs/api/ShallowWrapper/setContext.md
@@ -27,7 +27,7 @@ class SimpleComponent extends React.Component {
   }
 }
 SimpleComponent.contextTypes = {
-  name: React.PropTypes.string,
+  name: PropTypes.string,
 };
 ```
 ```jsx

--- a/docs/api/render.md
+++ b/docs/api/render.md
@@ -36,7 +36,7 @@ describe('<Foo />', () => {
       }
     }
     SimpleComponent.contextTypes = {
-      name: React.PropTypes.string,
+      name: PropTypes.string,
     };
 
     const context = { name: 'foo' };

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "object.assign": "^4.0.4",
     "object.entries": "^1.0.3",
     "object.values": "^1.0.3",
+    "prop-types": "^15.5.6",
     "uuid": "^2.0.3"
   },
   "devDependencies": {

--- a/src/ReactWrapperComponent.jsx
+++ b/src/ReactWrapperComponent.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import objectAssign from 'object.assign';
 
 /* eslint react/forbid-prop-types: 0 */

--- a/test/ReactWrapper-spec.jsx
+++ b/test/ReactWrapper-spec.jsx
@@ -1,6 +1,7 @@
 /* globals document */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { batchedUpdates } from '../src/react-compat';
@@ -25,7 +26,7 @@ describeWithDOM('mount', () => {
     it('can pass in context', () => {
       const SimpleComponent = React.createClass({
         contextTypes: {
-          name: React.PropTypes.string,
+          name: PropTypes.string,
         },
         render() {
           return <div>{this.context.name}</div>;
@@ -40,7 +41,7 @@ describeWithDOM('mount', () => {
     it('can pass context to the child of mounted component', () => {
       const SimpleComponent = React.createClass({
         contextTypes: {
-          name: React.PropTypes.string,
+          name: PropTypes.string,
         },
         render() {
           return <div>{this.context.name}</div>;
@@ -53,7 +54,7 @@ describeWithDOM('mount', () => {
       });
 
       const childContextTypes = {
-        name: React.PropTypes.string.isRequired,
+        name: PropTypes.string.isRequired,
       };
       const context = { name: 'foo' };
       const wrapper = mount(<ComplexComponent />, { context, childContextTypes });
@@ -74,7 +75,7 @@ describeWithDOM('mount', () => {
     it('is instrospectable through context API', () => {
       const SimpleComponent = React.createClass({
         contextTypes: {
-          name: React.PropTypes.string,
+          name: PropTypes.string,
         },
         render() {
           return <div>{this.context.name}</div>;
@@ -93,7 +94,7 @@ describeWithDOM('mount', () => {
         const SimpleComponent = (props, context) => (
           <div>{context.name}</div>
         );
-        SimpleComponent.contextTypes = { name: React.PropTypes.string };
+        SimpleComponent.contextTypes = { name: PropTypes.string };
 
         const context = { name: 'foo' };
         const wrapper = mount(<SimpleComponent />, { context });
@@ -104,14 +105,14 @@ describeWithDOM('mount', () => {
         const SimpleComponent = (props, context) => (
           <div>{context.name}</div>
         );
-        SimpleComponent.contextTypes = { name: React.PropTypes.string };
+        SimpleComponent.contextTypes = { name: PropTypes.string };
 
         const ComplexComponent = () => (
           <div><SimpleComponent /></div>
         );
 
         const childContextTypes = {
-          name: React.PropTypes.string.isRequired,
+          name: PropTypes.string.isRequired,
         };
 
         const context = { name: 'foo' };
@@ -132,7 +133,7 @@ describeWithDOM('mount', () => {
         const SimpleComponent = (props, context) => (
           <div>{context.name}</div>
         );
-        SimpleComponent.contextTypes = { name: React.PropTypes.string };
+        SimpleComponent.contextTypes = { name: PropTypes.string };
 
         const context = { name: 'foo' };
         const wrapper = mount(<SimpleComponent />, { context });
@@ -150,7 +151,7 @@ describeWithDOM('mount', () => {
         );
 
         Foo.contextTypes = {
-          _: React.PropTypes.string,
+          _: PropTypes.string,
         };
 
         const wrapper = mount(<Foo foo="qux" />, {
@@ -1098,7 +1099,7 @@ describeWithDOM('mount', () => {
     it('should set context for a component multiple times', () => {
       const SimpleComponent = React.createClass({
         contextTypes: {
-          name: React.PropTypes.string,
+          name: PropTypes.string,
         },
         render() {
           return <div>{this.context.name}</div>;
@@ -1117,7 +1118,7 @@ describeWithDOM('mount', () => {
     it('should throw if it is called when shallow didn’t include context', () => {
       const SimpleComponent = React.createClass({
         contextTypes: {
-          name: React.PropTypes.string,
+          name: PropTypes.string,
         },
         render() {
           return <div>{this.context.name}</div>;
@@ -1136,7 +1137,7 @@ describeWithDOM('mount', () => {
         const SimpleComponent = (props, context) => (
           <div>{context.name}</div>
         );
-        SimpleComponent.contextTypes = { name: React.PropTypes.string };
+        SimpleComponent.contextTypes = { name: PropTypes.string };
 
         const context = { name: 'foo' };
         const wrapper = mount(<SimpleComponent />, { context });
@@ -1151,7 +1152,7 @@ describeWithDOM('mount', () => {
         const SimpleComponent = (props, context) => (
           <div>{context.name}</div>
         );
-        SimpleComponent.contextTypes = { name: React.PropTypes.string };
+        SimpleComponent.contextTypes = { name: PropTypes.string };
 
         const wrapper = mount(<SimpleComponent />);
         expect(() => wrapper.setContext({ name: 'bar' })).to.throw(

--- a/test/ShallowWrapper-spec.jsx
+++ b/test/ShallowWrapper-spec.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
@@ -12,7 +13,7 @@ describe('shallow', () => {
     it('can pass in context', () => {
       const SimpleComponent = React.createClass({
         contextTypes: {
-          name: React.PropTypes.string,
+          name: PropTypes.string,
         },
         render() {
           return <div>{this.context.name}</div>;
@@ -38,7 +39,7 @@ describe('shallow', () => {
     it('is instrospectable through context API', () => {
       const SimpleComponent = React.createClass({
         contextTypes: {
-          name: React.PropTypes.string,
+          name: PropTypes.string,
         },
         render() {
           return <div>{this.context.name}</div>;
@@ -57,7 +58,7 @@ describe('shallow', () => {
         const SimpleComponent = (props, context) => (
           <div>{context.name}</div>
         );
-        SimpleComponent.contextTypes = { name: React.PropTypes.string };
+        SimpleComponent.contextTypes = { name: PropTypes.string };
 
         const context = { name: 'foo' };
         const wrapper = shallow(<SimpleComponent />, { context });
@@ -77,7 +78,7 @@ describe('shallow', () => {
         const SimpleComponent = (props, context) => (
           <div>{context.name}</div>
         );
-        SimpleComponent.contextTypes = { name: React.PropTypes.string };
+        SimpleComponent.contextTypes = { name: PropTypes.string };
 
         const wrapper = shallow(<SimpleComponent />, { context });
 
@@ -892,7 +893,7 @@ describe('shallow', () => {
         }
       }
 
-      Foo.contextTypes = { x: React.PropTypes.string };
+      Foo.contextTypes = { x: PropTypes.string };
 
       const context = { x: 'yolo' };
       const wrapper = shallow(<Foo x={5} />, { context });
@@ -938,7 +939,7 @@ describe('shallow', () => {
         const Foo = (props, context) => (
           <div>{context.x}</div>
         );
-        Foo.contextTypes = { x: React.PropTypes.string };
+        Foo.contextTypes = { x: PropTypes.string };
 
         const context = { x: 'yolo' };
         const wrapper = shallow(<Foo x={5} />, { context });
@@ -953,7 +954,7 @@ describe('shallow', () => {
   describe('.setContext(newContext)', () => {
     const SimpleComponent = React.createClass({
       contextTypes: {
-        name: React.PropTypes.string,
+        name: PropTypes.string,
       },
       render() {
         return <div>{this.context.name}</div>;
@@ -982,7 +983,7 @@ describe('shallow', () => {
       const SFC = (props, context) => (
         <div>{context.name}</div>
       );
-      SFC.contextTypes = { name: React.PropTypes.string };
+      SFC.contextTypes = { name: PropTypes.string };
 
       it('should set context for a component multiple times', () => {
         const context = { name: 'foo' };
@@ -2309,7 +2310,7 @@ describe('shallow', () => {
           }
         }
         Bar.contextTypes = {
-          name: React.PropTypes.string,
+          name: PropTypes.string,
         };
         class Foo extends React.Component {
           render() {
@@ -2355,7 +2356,7 @@ describe('shallow', () => {
           }
         }
         Bar.contextTypes = {
-          name: React.PropTypes.string,
+          name: PropTypes.string,
         };
         class Foo extends React.Component {
           render() {
@@ -2399,7 +2400,7 @@ describe('shallow', () => {
           const Bar = (props, context) => (
             <div>{context.name}</div>
           );
-          Bar.contextTypes = { name: React.PropTypes.string };
+          Bar.contextTypes = { name: PropTypes.string };
           const Foo = () => (
             <div>
               <Bar />
@@ -2430,7 +2431,7 @@ describe('shallow', () => {
           const Bar = (props, context) => (
             <div>{context.name}</div>
           );
-          Bar.contextTypes = { name: React.PropTypes.string };
+          Bar.contextTypes = { name: PropTypes.string };
           const Foo = () => (
             <div>
               <Bar />
@@ -2921,7 +2922,7 @@ describe('shallow', () => {
           }
         }
         Foo.contextTypes = {
-          foo: React.PropTypes.string,
+          foo: PropTypes.string,
         };
 
         const wrapper = shallow(
@@ -3145,7 +3146,7 @@ describe('shallow', () => {
           }
         }
         Foo.contextTypes = {
-          foo: React.PropTypes.string,
+          foo: PropTypes.string,
         };
 
         const wrapper = shallow(
@@ -3304,7 +3305,7 @@ describe('shallow', () => {
           }
         }
         Foo.contextTypes = {
-          foo: React.PropTypes.string,
+          foo: PropTypes.string,
         };
         const wrapper = shallow(
           <Foo foo="props" />,
@@ -3363,7 +3364,7 @@ describe('shallow', () => {
           }
         }
         Foo.contextTypes = {
-          foo: React.PropTypes.string,
+          foo: PropTypes.string,
         };
         const wrapper = shallow(
           <Foo />,
@@ -4005,7 +4006,7 @@ describe('shallow', () => {
         return <RendersDOM />;
       }
     }
-    WrapsRendersDOM.contextTypes = { foo: React.PropTypes.string };
+    WrapsRendersDOM.contextTypes = { foo: PropTypes.string };
     class DoubleWrapsRendersDOM extends React.Component {
       render() {
         return <WrapsRendersDOM />;
@@ -4016,7 +4017,7 @@ describe('shallow', () => {
         return <WrapsRendersDOM />;
       }
     }
-    ContextWrapsRendersDOM.contextTypes = { foo: React.PropTypes.string };
+    ContextWrapsRendersDOM.contextTypes = { foo: PropTypes.string };
 
     it('throws on a DOM node', () => {
       const wrapper = shallow(<RendersDOM />);

--- a/test/staticRender-spec.jsx
+++ b/test/staticRender-spec.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { describeWithDOM, describeIf } from './_helpers';
 import { render } from '../src/';
@@ -9,7 +10,7 @@ describeWithDOM('render', () => {
     it('can pass in context', () => {
       const SimpleComponent = React.createClass({
         contextTypes: {
-          name: React.PropTypes.string,
+          name: PropTypes.string,
         },
         render() {
           return <div>{this.context.name}</div>;
@@ -23,7 +24,7 @@ describeWithDOM('render', () => {
     it('can pass context to the child of mounted component', () => {
       const SimpleComponent = React.createClass({
         contextTypes: {
-          name: React.PropTypes.string,
+          name: PropTypes.string,
         },
         render() {
           return <div>{this.context.name}</div>;
@@ -36,7 +37,7 @@ describeWithDOM('render', () => {
       });
 
       const childContextTypes = {
-        name: React.PropTypes.string.isRequired,
+        name: PropTypes.string.isRequired,
       };
       const context = { name: 'foo' };
       const wrapper = render(<ComplexComponent />, { context, childContextTypes });


### PR DESCRIPTION
Using React.PropTypes is raising warnings, migrating `React.PropTypes` to `PropTypes` removed those warnings. https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes