### PR TITLE
Update docs to use the prop-types package #890

### DIFF
--- a/docs/api/ReactWrapper/setContext.md
+++ b/docs/api/ReactWrapper/setContext.md
@@ -21,13 +21,16 @@ NOTE: can only be called on a wrapper instance that is also the root instance.
 #### Example
 
 ```jsx
+import React from 'react';
+import PropTypes from 'prop-types';
+
 class SimpleComponent extends React.Component {
   render() {
     return <div>{this.context.name}</div>;
   }
 }
 SimpleComponent.contextTypes = {
-  name: React.PropTypes.string,
+  name: PropTypes.string,
 };
 ```
 ```jsx

--- a/docs/api/ShallowWrapper/setContext.md
+++ b/docs/api/ShallowWrapper/setContext.md
@@ -21,13 +21,16 @@ NOTE: can only be called on a wrapper instance that is also the root instance.
 #### Example
 
 ```jsx
+import React from 'react';
+import PropTypes from 'prop-types';
+
 class SimpleComponent extends React.Component {
   render() {
     return <div>{this.context.name}</div>;
   }
 }
 SimpleComponent.contextTypes = {
-  name: React.PropTypes.string,
+  name: PropTypes.string,
 };
 ```
 ```jsx

--- a/docs/api/render.md
+++ b/docs/api/render.md
@@ -16,7 +16,9 @@ constructors.
 ### Example Usage
 
 ```jsx
+import React from 'react';
 import { render } from 'enzyme';
+import PropTypes from 'prop-types';
 
 describe('<Foo />', () => {
   it('renders three `.foo-bar`s', () => {
@@ -36,7 +38,7 @@ describe('<Foo />', () => {
       }
     }
     SimpleComponent.contextTypes = {
-      name: React.PropTypes.string,
+      name: PropTypes.string,
     };
 
     const context = { name: 'foo' };


### PR DESCRIPTION
Not sure if I should also include explicit imports in the `setContext` examples.