### PR TITLE
Add enzyme/webpack entrypoint with getPluginsForInstalledReact function

### DIFF
--- a/docs/guides/karma.md
+++ b/docs/guides/karma.md
@@ -14,8 +14,8 @@ See the [webpack guide](webpack.md).
 ```js
 /* karma.conf.js */
 
-webpack: { //kind of a copy of your webpack config
-  devtool: 'inline-source-map', //just do inline source maps instead of the default
+webpack: { // kind of a copy of your webpack config
+  devtool: 'inline-source-map', // just do inline source maps instead of the default
   module: {
     loaders: [
       {
@@ -25,15 +25,14 @@ webpack: { //kind of a copy of your webpack config
         query: {
           presets: ['airbnb']
         }
+      },
+      {
+        test: /\.json$/,
+        loader: 'json-loader',
       }
     ]
   },
-  externals: {
-    'cheerio': 'window',
-    'react/addons': true,
-    'react/lib/ExecutionEnvironment': true,
-    'react/lib/ReactContext': true
-  }
+  plugins: require('enzyme/webpack').getPluginsForInstalledReact(),
 },
 ```
 

--- a/docs/guides/webpack.md
+++ b/docs/guides/webpack.md
@@ -5,75 +5,42 @@ If you are using a test runner that runs code in a browser-based environment, yo
 
 Webpack uses static analysis to create a dependency graph at build-time of your source code to
 build a bundle. Enzyme has a handful of conditional `require()` calls in it in order to remain
-compatible with React 0.13 and React 0.14.
+compatible with React 0.13 and React 0.14 and React 15.
 
 Unfortunately, these conditional requires mean there is a bit of extra setup with bundlers like
 webpack.
 
-In your webpack configuration, you simply need to make sure that the following files are
-labeled as "external", which means they will be ignored:
+In your webpack configuration, you simply need to make sure that you include `IgnorePlugin`s for
+the conditional dependencies not needed for your version of `react`.
 
-```
-cheerio
-react/addons
-react/lib/ReactContext
-react/lib/ExecutionEnvironment
-```
+Enzyme exports a function returning the `IgnorePlugin`s needed for the version of `react` you have installed.
 
-Depending on if you are using Webpack 1 or Webpack 2 you will need different configurations.
+Depending on if you are using Webpack 1 or Webpack 2 you will need different additions to your configuration.
 
 ### Webpack 1
 
 ```js
 /* webpack.config.js */
-// ...
-externals: {
-  'cheerio': 'window',
-  'react/addons': true,
-  'react/lib/ExecutionEnvironment': true,
-  'react/lib/ReactContext': true
+{
+  plugins: require('enzyme/webpack').getPluginsForInstalledReact(),
+  loaders: {
+    {
+      test: /\.json$/,
+      loader: 'json-loader',
+    },
+  }
 }
-// ...
 ```
 
 ### Webpack 2
 
 ```js
-externals: {
-  'cheerio': 'window',
-  'react/addons': 'react',
-  'react/lib/ExecutionEnvironment': 'react',
-  'react/lib/ReactContext': 'react',
-},
-```
-
-
-## React 0.14 Compatibility
-
-If you are using React 0.14, the instructions above will be the same but with a different list of
-externals:
-
-```
-cheerio
-react-dom
-react-dom/server
-react-addons-test-utils
-```
-
-## React 15 Compatibility
-
-If you are using React 15, your config should include these externals:
-
-```js
 /* webpack.config.js */
-// ...
-externals: {
-  'react/addons': true,
-  'react/lib/ExecutionEnvironment': true,
-  'react/lib/ReactContext': true
+{
+  plugins: require('enzyme/webpack').getPluginsForInstalledReact(),
 }
-// ...
 ```
+
 
 ## Example Projects
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,39 +2,6 @@
 
 require('babel-register');
 
-var IgnorePlugin = require('webpack').IgnorePlugin;
-var REACT013 = require('./src/version').REACT013;
-var REACT155 = require('./src/version').REACT155;
-
-function getPlugins() {
-  var plugins = [];
-
-  /*
-  this list of conditional IgnorePlugins mirrors the conditional
-  requires in src/react-compat.js and exists to avoid error
-  output from the webpack compilation
-  */
-
-  if (!REACT013) {
-    plugins.push(new IgnorePlugin(/react\/lib\/ExecutionEnvironment/));
-    plugins.push(new IgnorePlugin(/react\/lib\/ReactContext/));
-    plugins.push(new IgnorePlugin(/react\/addons/));
-  }
-  if (REACT013) {
-    plugins.push(new IgnorePlugin(/react-dom/));
-  }
-  if (REACT013 || REACT155) {
-    plugins.push(new IgnorePlugin(/react-addons-test-utils/));
-  }
-  if (!REACT155) {
-    plugins.push(new IgnorePlugin(/react-test-renderer/));
-    plugins.push(new IgnorePlugin(/react-dom\/test-utils/));
-    plugins.push(new IgnorePlugin(/create-react-class/));
-  }
-
-  return plugins;
-}
-
 module.exports = function karma(config) {
   config.set({
     basePath: '.',
@@ -101,7 +68,7 @@ module.exports = function karma(config) {
           },
         ],
       },
-      plugins: getPlugins(),
+      plugins: require('./src/webpack').getPluginsForInstalledReact(),
     },
 
     webpackServer: {

--- a/src/webpack.js
+++ b/src/webpack.js
@@ -1,0 +1,32 @@
+import { IgnorePlugin } from 'webpack';
+
+import { REACT013, REACT155 } from './version';
+
+export function getPluginsForInstalledReact() {
+  var plugins = [];
+
+  /*
+  this list of conditional IgnorePlugins mirrors the conditional
+  requires in src/react-compat.js and exists to avoid error
+  output from the webpack compilation
+  */
+
+  if (!REACT013) {
+    plugins.push(new IgnorePlugin(/react\/lib\/ExecutionEnvironment/));
+    plugins.push(new IgnorePlugin(/react\/lib\/ReactContext/));
+    plugins.push(new IgnorePlugin(/react\/addons/));
+  }
+  if (REACT013) {
+    plugins.push(new IgnorePlugin(/react-dom/));
+  }
+  if (REACT013 || REACT155) {
+    plugins.push(new IgnorePlugin(/react-addons-test-utils/));
+  }
+  if (!REACT155) {
+    plugins.push(new IgnorePlugin(/react-test-renderer/));
+    plugins.push(new IgnorePlugin(/react-dom\/test-utils/));
+    plugins.push(new IgnorePlugin(/create-react-class/));
+  }
+
+  return plugins;
+}

--- a/src/webpack.js
+++ b/src/webpack.js
@@ -1,9 +1,11 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { IgnorePlugin } from 'webpack';
 
 import { REACT013, REACT155 } from './version';
 
+// eslint-disable-next-line import/prefer-default-export
 export function getPluginsForInstalledReact() {
-  var plugins = [];
+  const plugins = [];
 
   /*
   this list of conditional IgnorePlugins mirrors the conditional

--- a/src/webpack.js
+++ b/src/webpack.js
@@ -7,8 +7,7 @@ export function getPluginsForInstalledReact() {
 
   /*
   this list of conditional IgnorePlugins mirrors the conditional
-  requires in src/react-compat.js and exists to avoid error
-  output from the webpack compilation
+  requires in src/react-compat.js
   */
 
   if (!REACT013) {

--- a/webpack.js
+++ b/webpack.js
@@ -1,0 +1,1 @@
+module.exports = require('./build/webpack');


### PR DESCRIPTION
Motivation
- make using enzyme with webpack easier
- make sure the documentation in the webpack guide doesn't go out of date

Changes
- export getPluginsForInstalledReact function
- update our karma config to use it
- update documentation guides to use it

`getPluginsForInstalledReact` is currently tested with webpack 1 and all supported versions of react because it is used in our karma tests

closes #881 #740 #744 #847 #309 #791