### PR TITLE
Make enzyme work for react ^15.4.x.

### DIFF
--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -102,7 +102,7 @@ function validateOptions(options) {
 
 function performBatchedUpdates(wrapper, fn) {
   const renderer = wrapper.root.renderer;
-  if (REACT155) {
+  if (REACT155 && renderer.unstable_batchedUpdates) {
     // React 15.5+ exposes batching on shallow renderer itself
     return renderer.unstable_batchedUpdates(fn);
   }

--- a/src/react-compat.js
+++ b/src/react-compat.js
@@ -96,19 +96,30 @@ if (REACT013) {
   // to list this as a dependency in package.json and have 0.13 work properly.
   // As a result, right now this is basically an implicit dependency.
   try {
-    if (REACT155) {
+    try {
+      // This is for react v15.5 and up...
+
       // eslint-disable-next-line import/no-extraneous-dependencies
       TestUtils = require('react-dom/test-utils');
-    } else {
+      // eslint-disable-next-line import/no-extraneous-dependencies
+      shallowRendererFactory = require('react-test-renderer/shallow').createRenderer;
+    } catch (e) {
+      // This is for react < v15.5.  Note that users who have `react^15.4.x` in their package.json
+      // will arrive here, too.  They need to upgrade.  React will print a nice warning letting
+      // them know they need to upgrade, though, so we're good.  Also note we explicitly do not
+      // use TestUtils from react-dom/test-utils here, mainly so the user still gets a warning for
+      // requiring 'react-addons-test-utils', which lets them know there's action required.
+
       // eslint-disable-next-line import/no-extraneous-dependencies
       TestUtils = require('react-addons-test-utils');
+      shallowRendererFactory = TestUtils.createRenderer;
     }
   } catch (e) {
     if (REACT155) {
       console.error( // eslint-disable-line no-console
-        'react-dom@15.5+ is an implicit dependency when using react@15.5+ with enzyme. ' +
-        'Please add the appropriate version to your devDependencies. ' +
-        'See https://github.com/airbnb/enzyme#installation',
+        'react-dom@15.5+ and react-test-renderer are implicit dependencies when using' +
+        'react@15.5+ with enzyme. Please add the appropriate version to your' +
+        'devDependencies. See https://github.com/airbnb/enzyme#installation',
       );
     } else {
       console.error( // eslint-disable-line no-console
@@ -117,26 +128,6 @@ if (REACT013) {
         'See https://github.com/airbnb/enzyme#installation',
       );
     }
-    throw e;
-  }
-
-  // Shallow renderer is accessible via the react-test-renderer package for React 15.5+.
-  // This is a separate package though and may not be installed.
-  try {
-    if (REACT155) {
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      shallowRendererFactory = require('react-test-renderer/shallow').createRenderer;
-    } else {
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      shallowRendererFactory = TestUtils.createRenderer;
-    }
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error(
-      'react-test-renderer is an implicit dependency in order to support react@15.5+. ' +
-      'Please add the appropriate version to your devDependencies. ' +
-      'See https://github.com/airbnb/enzyme#installation',
-    );
     throw e;
   }
 


### PR DESCRIPTION
Users with package.json files that include:

```
    "react": "^15.4.0",
    "react-dom": "^15.4.0",
    "enzyme": "^2.8.0",
```

will have their tests break after https://github.com/airbnb/enzyme/pull/876.  This PR fixes it so enzyme "does the right thing" in the case where the user is running react 15.4, running react 15.5 but hasn't done any of the "upgrade work" yet, and in the case where they are actually running 15.5.

Verified by running [this test script](https://gist.github.com/jwalton/efda0a6d2b966fb8e6431f3fb864295b#file-test-sh).  If you want to run this, you need a folder called ~/Development/enzyme which has a built copy of this branch, and you need to run it in some other directory.  (Need the built copy instead of just `npm link`ing because we need to pick up the right versions from the test project.)  The output of this script on my machine is [here](https://gist.github.com/jwalton/efda0a6d2b966fb8e6431f3fb864295b#file-output).

Closes #892.