### PR TITLE
Fix #925 - indentation is broken for debug() on shallow wrapper

### DIFF
--- a/src/Debug.js
+++ b/src/Debug.js
@@ -57,26 +57,30 @@ function propsString(node) {
   return keys.map(key => `${key}=${propString(props[key])}`).join(' ');
 }
 
+function indentChildren(childrenStrs, indentLength) {
+  return childrenStrs.length
+    ? `\n${childrenStrs.map(x => indent(indentLength, x)).join('\n')}\n`
+    : '';
+}
+
 export function debugNode(node, indentLength = 2) {
   if (typeof node === 'string' || typeof node === 'number') return escape(node);
   if (!node) return '';
 
-  const children = compact(childrenOfNode(node).map(n => debugNode(n, indentLength)));
+  const childrenStrs = compact(childrenOfNode(node).map(n => debugNode(n, indentLength)));
   const type = typeName(node);
   const props = propsString(node);
   const beforeProps = props ? ' ' : '';
-  const nodeClose = children.length ? `</${type}>` : '/>';
-  const afterProps = children.length
+  const nodeClose = childrenStrs.length ? `</${type}>` : '/>';
+  const afterProps = childrenStrs.length
     ? '>'
     : ' ';
-  const childrenIndented = children.length
-    ? `\n${children.map(x => indent(indentLength, x)).join('\n')}\n`
-    : '';
+  const childrenIndented = indentChildren(childrenStrs, indentLength);
   return `<${type}${beforeProps}${props}${afterProps}${childrenIndented}${nodeClose}`;
 }
 
 export function debugNodes(nodes) {
-  return nodes.map(debugNode).join('\n\n\n');
+  return nodes.map(node => debugNode(node)).join('\n\n\n');
 }
 
 export function debugInst(inst, indentLength = 2) {
@@ -128,12 +132,10 @@ export function debugInst(inst, indentLength = 2) {
   const afterProps = childrenStrs.length
     ? '>'
     : ' ';
-  const childrenIndented = childrenStrs.length
-    ? `\n${childrenStrs.map(x => indent(indentLength + 2, x)).join('\n')}\n`
-    : '';
+  const childrenIndented = indentChildren(childrenStrs, indentLength);
   return `<${type}${beforeProps}${props}${afterProps}${childrenIndented}${nodeClose}`;
 }
 
 export function debugInsts(insts) {
-  return insts.map(debugInst).join('\n\n\n');
+  return insts.map(inst => debugInst(inst)).join('\n\n\n');
 }

--- a/test/Debug-spec.jsx
+++ b/test/Debug-spec.jsx
@@ -4,8 +4,9 @@ import {
   spaces,
   indent,
   debugNode,
+  debugNodes,
 } from '../src/Debug';
-import { mount } from '../src/';
+import { mount, shallow } from '../src/';
 import {
   describeWithDOM,
   describeIf,
@@ -447,9 +448,127 @@ describe('debug', () => {
     </Foo>
   </div>
 </Bar>`);
-
       });
 
+    });
+
+  });
+
+  describe('shallow', () => {
+    it('renders shallow wrapper properly', () => {
+      class Foo extends React.Component {
+        render() {
+          return (
+            <div className="foo">
+              <span>From Foo</span>
+              {this.props.children}
+            </div>
+          );
+        }
+      }
+      class Bar extends React.Component {
+        render() {
+          return (
+            <div className="bar">
+              <Foo baz="bax">
+                <span>From Bar</span>
+              </Foo>
+            </div>
+          );
+        }
+      }
+
+      expect(shallow(<Bar id="2" />).debug()).to.eql(
+`<div className="bar">
+  <Foo baz="bax">
+    <span>
+      From Bar
+    </span>
+  </Foo>
+</div>`);
+    });
+  });
+
+  describe('debugNodes', () => {
+    it('can render a single node', () => {
+      class Foo extends React.Component {
+        render() {
+          return (
+            <div className="foo">
+              <span>inside Foo</span>
+            </div>
+          );
+        }
+      }
+
+      expect(debugNodes(shallow(<Foo />).getNodes())).to.eql(
+`<div className="foo">
+  <span>
+    inside Foo
+  </span>
+</div>`);
+    });
+
+    it('can render multiple nodes', () => {
+      class Foo extends React.Component {
+        render() {
+          return (
+            <div className="foo">
+              <span>inside Foo</span>
+            </div>
+          );
+        }
+      }
+
+      class Bar extends React.Component {
+        render() {
+          return (
+            <div className="bar">
+              <Foo key="foo1" />
+              <Foo key="foo2" />
+              <Foo key="foo3" />
+            </div>
+          );
+        }
+      }
+
+      expect(debugNodes(shallow(<Bar />).children().getNodes())).to.eql(
+`<Foo />
+
+
+<Foo />
+
+
+<Foo />`);
+    });
+
+    it('can render multiple nodes with indent', () => {
+      class Foo extends React.Component {
+        render() {
+          return (
+            <div className="bar">
+              <span>span1 text</span>
+              <span>span2 text</span>
+              <span>span3 text</span>
+            </div>
+          );
+        }
+      }
+
+      expect(debugNodes(shallow(<Foo />).children().getNodes())).to.eql(
+`<span>
+  span1 text
+</span>
+
+
+<span>
+  span2 text
+</span>
+
+
+<span>
+  span3 text
+</span>`);
     });
   });
 });


### PR DESCRIPTION
### SUMMARY
- Fixes #925, the issue where .debug() on a shallow wrapper does not indent child nodes

### DETAILS
The problem is with the use of `.map()`:
```
export function debugNodes(nodes) {
  return nodes.map(debugNode).join('\n\n\n');
 }
```

[Array.map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map?v=example) passes 3 args to the callback, the second of which is the current index (0 in this case since there's only one top-level node), which overrides the default arg value `indentLength = 2` in debugNode.

The fix here adds a callback that explicitly only takes one parameter and then calls debugNode explicitly with that single parameter: `nodes.map(node => debugNode(node))`