### PR TITLE
Make sure dependency error reporting always works

### DIFF
--- a/src/react-compat.js
+++ b/src/react-compat.js
@@ -76,13 +76,11 @@ if (REACT013) {
     // eslint-disable-next-line import/no-extraneous-dependencies
     ReactDOM = require('react-dom');
   } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error(
+    throw new Error(
       'react-dom is an implicit dependency in order to support react@0.13-14. ' +
       'Please add the appropriate version to your devDependencies. ' +
       'See https://github.com/airbnb/enzyme#installation',
     );
-    throw e;
   }
 
   // eslint-disable-next-line import/no-extraneous-dependencies
@@ -116,19 +114,18 @@ if (REACT013) {
     }
   } catch (e) {
     if (REACT155) {
-      console.error( // eslint-disable-line no-console
+      throw new Error(
         'react-dom@15.5+ and react-test-renderer are implicit dependencies when using ' +
         'react@15.5+ with enzyme. Please add the appropriate version to your ' +
         'devDependencies. See https://github.com/airbnb/enzyme#installation',
       );
     } else {
-      console.error( // eslint-disable-line no-console
+      throw new Error(
         'react-addons-test-utils is an implicit dependency in order to support react@0.13-14. ' +
         'Please add the appropriate version to your devDependencies. ' +
         'See https://github.com/airbnb/enzyme#installation',
       );
     }
-    throw e;
   }
 
   // Shallow rendering changed from 0.13 => 0.14 in such a way that


### PR DESCRIPTION
In some cases, the logging from console.error is swallowed (e.g. when
using create-react-app and having multiple test files). By placing the
message in the error instead, it is shown.

Before this change and without having `react-test-renderer` as a dependency, this message would be shown:

```
    Cannot find module 'react-addons-test-utils' from 'react-compat.js'
      
      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:151:17)
      at node_modules/enzyme/build/react-compat.js:143:21
      at Object.<anonymous> (node_modules/enzyme/build/react-compat.js:214:5)
```

After this change, this is shown instead:

```
    react-dom@15.5+ and react-test-renderer are implicit dependencies when using react@15.5+ with enzyme. Please add the appropriate version to your devDependencies. See https://github.com/airbnb/enzyme#installation
      
      at Object.<anonymous> (node_modules/enzyme/build/react-compat.js:143:13)
      at Object.<anonymous> (node_modules/enzyme/build/Utils.js:65:20)
      at Object.<anonymous> (node_modules/enzyme/build/MountedTraversal.js:36:14)
      at Object.<anonymous> (node_modules/enzyme/build/ReactWrapper.js:35:25)
      at Object.<anonymous> (node_modules/enzyme/build/index.js:6:21)
      at Object.<anonymous> (src/App.test.js:2:41)
      at handle (node_modules/worker-farm/lib/child/index.js:41:8)
      at process.<anonymous> (node_modules/worker-farm/lib/child/index.js:47:3)
      at emitTwo (events.js:106:13)
      at process.emit (events.js:194:7)
      at process.nextTick (internal/child_process.js:766:12)
      at _combinedTickCallback (internal/process/next_tick.js:73:7)
      at process._tickCallback (internal/process/next_tick.js:104:9)
```

Is there any specific reason `console.error` was used in the first place?