### PR TITLE
Change componentDidMount to componentWillMount in shallow options api doc

### DIFF
--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -47,7 +47,7 @@ describe('<MyComponent />', () => {
 1. `node` (`ReactElement`): The node to render
 2. `options` (`Object` [optional]):
   - `options.context`: (`Object` [optional]): Context to be passed into the component
-  - `options.disableLifecycleMethods`: (`Boolean` [optional]): If set to true, `componentDidMount`
+  - `options.disableLifecycleMethods`: (`Boolean` [optional]): If set to true, `componentWillMount`
 is not called on the component, and `componentDidUpdate` is not called after
 [`setProps`](ShallowWrapper/setProps.md) and [`setContext`](ShallowWrapper/setContext.md).
 


### PR DESCRIPTION
In shallow rendering we do not call `componentDidMount`, this fixes the docs to reflect that.