### PR TITLE
Updated example: expect().toEqual

### DIFF
--- a/docs/api/ShallowWrapper/is.md
+++ b/docs/api/ShallowWrapper/is.md
@@ -20,6 +20,6 @@ Returns whether or not the current node matches a provided selector.
 
 ```jsx
 const wrapper = shallow(<div className="some-class other-class" />);
-expect(wrapper.is('.some-class')).to.equal(true);
+expect(wrapper.is('.some-class')).toEqual(true);
 ```
 


### PR DESCRIPTION
The example at https://github.com/vjwilson/enzyme-example-jest/blob/master/src/__tests__/Foo-test.js#L20 shows usage of the method "toEqual", and "is.equal" doesn't work for me, locally. So I thought I'd update it here.