### PR TITLE
Problem with simulating a "change" with a mock event object

### DIFF
--- a/test/ReactWrapper-spec.jsx
+++ b/test/ReactWrapper-spec.jsx
@@ -1273,6 +1273,23 @@ describeWithDOM('mount', () => {
       expect(spy.args[0][0].someSpecialData).to.equal('foo');
     });
 
+    it('should let us override the event object', () => {
+      const spy = sinon.spy();
+      class Foo extends React.Component {
+        render() {
+          return (
+            <input type="text" onChange={spy} value="foo" />
+          );
+        }
+      }
+
+      const wrapper = mount(<Foo />);
+
+      wrapper.simulate('change', { target: { value: 'bar' } });
+      expect(spy.calledOnce).to.equal(true);
+      expect(spy.args[0][0].target.value).to.equal('bar');
+    });
+
     it('should throw a descriptive error for invalid events', () => {
       const wrapper = mount(<div>foo</div>);
       expect(wrapper.simulate.bind(wrapper, 'invalidEvent'))


### PR DESCRIPTION
Based on enzyme's doc we should be able to use simulate()'s second
argument this way:

simulate(event [, mock])
- mock (Object [optional]): A mock event object that will be merged with
the event object passed to the handlers.

This test demonstrates a problem trying to simulate a change event on
an input field: we are unable to override the `target` property.

The same goes for the `currentTarget` property (not demonstrated in this test case).

This PR adds a failing tests case which demonstrates the issue.

Thanks in advance for your great work! 👍 