### PR TITLE
Require uuid at least 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "object.entries": "^1.0.4",
     "object.values": "^1.0.4",
     "prop-types": "^15.5.10",
-    "uuid": "^3.0.0"
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
In #998 I bumped uuid 2.x -> 3.x and converted the import to
import from `uuid/v4`, but this didn't exist until 3.0.1.