### PR TITLE
Support npm@5 scripts behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "homepage": "http://airbnb.io/enzyme/",
   "main": "build",
   "scripts": {
-    "prepublish": "not-in-publish || (npm run clean && npm run build && safe-publish-latest)",
+    "prepare": "not-in-publish || (npm run clean && npm run build && safe-publish-latest)",
+    "prepublish": "npm run prepare",
     "preversion": "npm run clean && npm run check",
     "postversion": "git push && git push --tags && npm run clean && npm run docs:publish",
     "version": "npm run build",


### PR DESCRIPTION
enzyme isn't currently working npm@5 because `prepublish` no longers runs after local `npm install` like it does in previous versions. However the new `prepare` hook reproduces this behavior. My thinking is that aliasing these 2 commands should enable enzyme to work in any npm version. On publish via npm@5 both will run but this seems tolerable because one will replace the other.

- [npm scripts documentation](https://docs.npmjs.com/misc/scripts)
- [prepublish transition strategy](https://github.com/npm/npm/issues/10074)