### PR TITLE
update shallow.md to describe disableLifecycleMethods option correctly

### DIFF
--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -43,7 +43,7 @@ describe('<MyComponent />', () => {
 1. `node` (`ReactElement`): The node to render
 2. `options` (`Object` [optional]):
   - `options.context`: (`Object` [optional]): Context to be passed into the component
-  - `options.disableLifecycleMethods`: (`Boolean` [optional]): If set to true, `componentWillMount`
+  - `options.disableLifecycleMethods`: (`Boolean` [optional]): If set to true, `componentDidMount`
 is not called on the component, and `componentDidUpdate` is not called after
 [`setProps`](ShallowWrapper/setProps.md) and [`setContext`](ShallowWrapper/setContext.md).
 


### PR DESCRIPTION
In ShallowWrapper-spec.jsx line 2766 for testing disableLifecycleMethods option, when disableLifecycleMethods is set to true, componentWillMount is expected to be called, componentDidMount was the one not getting called. This contradict what's in shallow.md. I found this issue when I was using disableLifecycleMethods option and componentWillMount() always fires.