### PR TITLE
Remove unused isCompositeComponentElement re-export

### DIFF
--- a/src/react-compat.js
+++ b/src/react-compat.js
@@ -181,7 +181,6 @@ const {
   isDOMComponent,
   isCompositeComponent,
   isCompositeComponentWithType,
-  isCompositeComponentElement,
   Simulate,
   findAllInRenderedTree,
 } = TestUtils;
@@ -197,7 +196,6 @@ export {
   isDOMComponentElement,
   isCompositeComponent,
   isCompositeComponentWithType,
-  isCompositeComponentElement,
   Simulate,
   findDOMNode,
   findAllInRenderedTree,


### PR DESCRIPTION
This method is being deprecated soon https://github.com/facebook/react/pull/10096

We don't actually use it at all internally, so this change just removes the unused import/export.

The rewrite doesn't include this import/export so this may be a moot PR, but I'm not sure if we intend to make any more minor releases before it's accepted.