### PR TITLE
[Docs] Update Common Gotchas for ShallowWrapper setProps

### DIFF
--- a/docs/api/ShallowWrapper/setProps.md
+++ b/docs/api/ShallowWrapper/setProps.md
@@ -59,7 +59,11 @@ expect(spy.calledOnce).to.equal(true);
 
 #### Common Gotchas
 
+`setProps()` will not trigger the lifecycle method `componentDidUpdate` when using `shallow()` unless you set `lifecycleExperimental` to true.
 
+```jsx
+const wrapper = shallow(<MyComponent />, { lifecycleExperimental: true })
+```
 
 #### Related Methods
 


### PR DESCRIPTION
As discussed here: https://github.com/airbnb/enzyme/issues/34 `setProps` does not trigger the `componentDidUpdate` lifecycle method by default.

I've updated the Common Gotchas section of the `setProps` documentation with the solution to set `lifecycleExperimental` to true.