### PR TITLE
WIP: upgrade GitBook to 3.x + required config changes

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,10 +1,11 @@
 {
-  "gitbook": "2.4.3",
+  "gitbook": "3.x",
   "title": "Enzyme",
   "description": "React Testing",
+  "root": "docs/",
   "structure": {
-    "summary": "docs/README.md",
-    "glossary": "docs/GLOSSARY.md"
+    "summary": "README.md",
+    "glossary": "GLOSSARY.md"
   },
   "plugins": [
     "edit-link",


### PR DESCRIPTION
See discussion in #944 for context - the long and short of it is that upgrading GitBook to the 3.x version seems like the path of least resistance to allowing folks to run the docs locally in newer versions of node (7.x and 8.x).

**NB:** The docs will *break* if this PR is merged as is! I wanted to throw it up for others like @samit4me to try, and if this looks like the best path forward than I (or anyone else) can work on making the remaining required changes, which I believe will largely be link/path renamings, since all links are current relative to the root of the repo (e.g., docs/guides/browserify.md) but need to be relative to the "root" of the docs themselves (which is docs/) under the requirements of GitBook 3.x (e.g., guides/browserify.md).