### PR TITLE
Adds Sinon imports to API docs.

### DIFF
--- a/docs/api/ReactWrapper/mount.md
+++ b/docs/api/ReactWrapper/mount.md
@@ -13,6 +13,7 @@ an unmount/mount lifecycle.
 
 ```jsx
 import PropTypes from 'prop-types';
+import sinon from 'sinon';
 
 const willMount = sinon.spy();
 const didMount = sinon.spy();

--- a/docs/api/ReactWrapper/setProps.md
+++ b/docs/api/ReactWrapper/setProps.md
@@ -46,6 +46,8 @@ expect(wrapper.find('.bar')).to.have.length(1);
 ```
 
 ```jsx
+import sinon from 'sinon';
+
 const spy = sinon.spy(MyComponent.prototype, 'componentWillReceiveProps');
 
 const wrapper = mount(<MyComponent foo="bar" />);

--- a/docs/api/ReactWrapper/unmount.md
+++ b/docs/api/ReactWrapper/unmount.md
@@ -13,6 +13,7 @@ an unmount/mount lifecycle.
 
 ```jsx
 import PropTypes from 'prop-types';
+import sinon from 'sinon';
 
 const willMount = sinon.spy();
 const didMount = sinon.spy();

--- a/docs/api/ShallowWrapper/setProps.md
+++ b/docs/api/ShallowWrapper/setProps.md
@@ -46,6 +46,8 @@ expect(wrapper.find('.bar')).to.have.length(1);
 ```
 
 ```jsx
+import sinon from 'sinon';
+
 const spy = sinon.spy(MyComponent.prototype, 'componentWillReceiveProps');
 
 const wrapper = shallow(<MyComponent foo="bar" />);

--- a/docs/api/ShallowWrapper/unmount.md
+++ b/docs/api/ShallowWrapper/unmount.md
@@ -13,6 +13,7 @@ an unmount/mount lifecycle.
 
 ```jsx
 import PropTypes from 'prop-types';
+import sinon from 'sinon';
 
 const spy = sinon.spy();
 

--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -5,6 +5,7 @@ that your tests aren't indirectly asserting on behavior of child components.
 
 ```jsx
 import { shallow } from 'enzyme';
+import sinon from 'sinon';
 
 describe('<MyComponent />', () => {
   it('should render three <Foo /> components', () => {


### PR DESCRIPTION
**GOAL:**
I was reading through the API documentation and noticed that there were a few inconsistencies with imports of `sinon` and usage. I have added the explicit imports of `sinon` to the relevant places in the documentation. I believe this is a valuable addition because it will remove any ambiguity from the code examples.

**CURRENT:**
Currently, there are a couple of API docs where code examples are using `sinon` without an explicit import. The main docs page explicitly imports `sinon` and this change will make it consistent throughout all the docs.

**IMPACT:**
This will remove ambiguity from the docs and explicitly mention other dependencies for the code samples.