### PR TITLE
Update setProps.md: misleading "state" -> "props"

### DIFF
--- a/docs/api/ShallowWrapper/setProps.md
+++ b/docs/api/ShallowWrapper/setProps.md
@@ -12,7 +12,7 @@ NOTE: can only be called on a wrapper instance that is also the root instance.
 
 #### Arguments
 
-1. `nextProps` (`Object`): An object containing new props to merge in with the current state
+1. `nextProps` (`Object`): An object containing new props to merge in with the current props
 
 
 


### PR DESCRIPTION
Super minor wording change - I was just referencing these docs, and the use of "state" here confused me for a second.