### PR TITLE
Remove isFunctionalComponent, use nodeType instead

### DIFF
--- a/src/ShallowWrapper.js
+++ b/src/ShallowWrapper.js
@@ -13,7 +13,6 @@ import {
   typeOfNode,
   isReactElementAlike,
   displayNameOfNode,
-  isFunctionalComponent,
   isCustomComponentElement,
   ITERATOR_SYMBOL,
   getAdapter,
@@ -346,7 +345,7 @@ class ShallowWrapper {
     if (this.root !== this) {
       throw new Error('ShallowWrapper::setState() can only be called on the root');
     }
-    if (this.instance() === null || isFunctionalComponent(this.instance())) {
+    if (this.instance() === null || this.renderer.getNode().nodeType === 'function') {
       throw new Error('ShallowWrapper::setState() can only be called on class components');
     }
     this.single('setState', () => {
@@ -677,7 +676,7 @@ class ShallowWrapper {
     if (this.root !== this) {
       throw new Error('ShallowWrapper::state() can only be called on the root');
     }
-    if (this.instance() === null || isFunctionalComponent(this.instance())) {
+    if (this.instance() === null || this.renderer.getNode().nodeType === 'function') {
       throw new Error('ShallowWrapper::state() can only be called on class components');
     }
     const _state = this.single('state', () => this.instance().state);

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -19,12 +19,6 @@ export function getAdapter(options = {}) {
   return adapter;
 }
 
-// TODO(lmr): we shouldn't need this
-export function isFunctionalComponent(inst) {
-  return !!inst && !!inst.constructor && typeof inst.constructor === 'function' &&
-    functionName(inst.constructor) === 'StatelessComponent';
-}
-
 export function isCustomComponentElement(inst, adapter) {
   return !!inst && adapter.isValidElement(inst) && typeof inst.type === 'function';
 }

--- a/src/adapters/ReactFifteenAdapter.js
+++ b/src/adapters/ReactFifteenAdapter.js
@@ -136,7 +136,7 @@ class ReactFifteenAdapter extends EnzymeAdapter {
         }
         const output = renderer.getRenderOutput();
         return {
-          nodeType: 'class',
+          nodeType: compositeTypeToNodeType(renderer._instance._compositeType),
           type: cachedNode.type,
           props: cachedNode.props,
           key: cachedNode.key,

--- a/src/adapters/ReactFifteenFourAdapter.js
+++ b/src/adapters/ReactFifteenFourAdapter.js
@@ -136,7 +136,7 @@ class ReactFifteenFourAdapter extends EnzymeAdapter {
         }
         const output = renderer.getRenderOutput();
         return {
-          nodeType: 'class',
+          nodeType: compositeTypeToNodeType(renderer._instance._compositeType),
           type: cachedNode.type,
           props: cachedNode.props,
           key: cachedNode.key,

--- a/src/adapters/ReactFourteenAdapter.js
+++ b/src/adapters/ReactFourteenAdapter.js
@@ -128,7 +128,7 @@ class ReactFifteenAdapter extends EnzymeAdapter {
         }
         const output = renderer.getRenderOutput();
         return {
-          nodeType: 'class',
+          nodeType: typeToNodeType(cachedNode.type),
           type: cachedNode.type,
           props: cachedNode.props,
           key: cachedNode.key,

--- a/src/adapters/ReactSixteenAdapter.js
+++ b/src/adapters/ReactSixteenAdapter.js
@@ -6,7 +6,7 @@ import ShallowRenderer from 'react-test-renderer/shallow';
 import TestUtils from 'react-dom/test-utils';
 import PropTypes from 'prop-types';
 import EnzymeAdapter from './EnzymeAdapter';
-import elementToTree from './elementToTree';
+import elementToTree, { nodeTypeFromType } from './elementToTree';
 import {
   mapNativeEventNames,
   propFromEvent,
@@ -205,7 +205,7 @@ class ReactSixteenAdapter extends EnzymeAdapter {
         }
         const output = renderer.getRenderOutput();
         return {
-          nodeType: 'class',
+          nodeType: nodeTypeFromType(cachedNode.type),
           type: cachedNode.type,
           props: cachedNode.props,
           key: cachedNode.key,

--- a/src/adapters/elementToTree.js
+++ b/src/adapters/elementToTree.js
@@ -1,6 +1,6 @@
 import flatten from 'lodash/flatten';
 
-function nodeTypeFromType(type) {
+export function nodeTypeFromType(type) {
   if (typeof type === 'string') {
     return 'host';
   }


### PR DESCRIPTION
* Removes usage of `isFunctionalComponent` which caused some problems when running tests with the production React bundles (see #1041)

* Fixes an issue where the shallow renderers were returning an incorrect `nodeType` for the root node. It was always returning `'class'` even when the component was functional.

