### PR TITLE
Make private properties more private and harder to use

### DIFF
--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -18,7 +18,7 @@ import {
   render,
   ReactWrapper,
 } from 'enzyme';
-import { ITERATOR_SYMBOL } from 'enzyme/build/Utils';
+import { ITERATOR_SYMBOL, sym } from 'enzyme/build/Utils';
 import { REACT013, REACT014, REACT16, is } from './_helpers/version';
 
 describeWithDOM('mount', () => {
@@ -1037,6 +1037,7 @@ describeWithDOM('mount', () => {
       expect(setInvalidProps).to.throw(TypeError, similarException.message);
     });
 
+
     itIf(!REACT16, 'should call the callback when setProps has completed', () => {
       class Foo extends React.Component {
         render() {
@@ -1050,7 +1051,7 @@ describeWithDOM('mount', () => {
       const wrapper = mount(<Foo id="foo" />);
       expect(wrapper.find('.foo').length).to.equal(1);
 
-      wrapper.renderer.batchedUpdates(() => {
+      wrapper[sym('__renderer__')].batchedUpdates(() => {
         wrapper.setProps({ id: 'bar', foo: 'bla' }, () => {
           expect(wrapper.find('.bar').length).to.equal(1);
         });

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -7,7 +7,7 @@ import sinon from 'sinon';
 import { createClass } from './_helpers/react-compat';
 import { shallow, render, ShallowWrapper } from 'enzyme';
 import { describeIf, itIf, itWithData, generateEmptyRenderData } from './_helpers';
-import { ITERATOR_SYMBOL, withSetStateAllowed } from 'enzyme/build/Utils';
+import { ITERATOR_SYMBOL, withSetStateAllowed, sym } from 'enzyme/build/Utils';
 import { REACT013, REACT014, REACT16, is } from './_helpers/version';
 
 // The shallow renderer in react 16 does not yet support batched updates. When it does,
@@ -4300,14 +4300,14 @@ describe('shallow', () => {
     it('works with a name', () => {
       const wrapper = shallow(<div />);
       wrapper.single('foo', (node) => {
-        expect(node).to.equal(wrapper.node);
+        expect(node).to.equal(wrapper[sym('__node__')]);
       });
     });
 
     it('works without a name', () => {
       const wrapper = shallow(<div />);
       wrapper.single((node) => {
-        expect(node).to.equal(wrapper.node);
+        expect(node).to.equal(wrapper[sym('__node__')]);
       });
     });
   });

--- a/packages/enzyme/src/Utils.js
+++ b/packages/enzyme/src/Utils.js
@@ -362,3 +362,15 @@ export function displayNameOfNode(node) {
 
   return type.displayName || (typeof type === 'function' ? functionName(type) : type.name || type);
 }
+
+export function sym(s) {
+  return typeof Symbol === 'function' ? Symbol.for(`enzyme.${s}`) : s;
+}
+
+export function privateSet(obj, prop, value) {
+  Object.defineProperty(obj, prop, {
+    value,
+    enumerable: false,
+    writable: true,
+  });
+}


### PR DESCRIPTION
to: @ljharb @aweary 

This is in preparation for Enzyme v3.0. We are moving properties that are considered private and implementation details to use symbols and harder to rely on property names in an effort to make future migrations easier.