### PR TITLE
Remove all React dependencies from enzyme

### DIFF
--- a/env.js
+++ b/env.js
@@ -56,13 +56,12 @@ const additionalDirsToRemove = [
   'node_modules/.bin/npm.cmd',
 ];
 
-const rmrfArgs = []
+const rmrfs = []
   .concat(packagesToRemove)
-  .concat(additionalDirsToRemove)
-  .join(' ');
+  .concat(additionalDirsToRemove);
 
 Promise.resolve()
-  .then(() => primraf(rmrfArgs))
+  .then(() => Promise.all(rmrfs.map(s => primraf(s))))
   .then(() => run('npm i'))
   .then(() => Promise.all([
     getJSON(adapterPackageJsonPath),

--- a/packages/enzyme-adapter-react-13/package.json
+++ b/packages/enzyme-adapter-react-13/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "enzyme-adapter-utils": "2.9.1",
     "lodash": "^4.17.4",
+    "object.assign": "^4.0.4",
     "object.values": "^1.0.4",
     "prop-types": "^15.5.10"
   },

--- a/packages/enzyme-adapter-react-14/package.json
+++ b/packages/enzyme-adapter-react-14/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "enzyme-adapter-utils": "2.9.1",
     "lodash": "^4.17.4",
+    "object.assign": "^4.0.4",
     "object.values": "^1.0.4",
     "prop-types": "^15.5.10"
   },

--- a/packages/enzyme-adapter-react-14/src/ReactFourteenAdapter.js
+++ b/packages/enzyme-adapter-react-14/src/ReactFourteenAdapter.js
@@ -4,7 +4,6 @@ import ReactDOM from 'react-dom';
 import ReactDOMServer from 'react-dom/server';
 // eslint-disable-next-line import/no-unresolved, import/extensions
 import TestUtils from 'react-addons-test-utils';
-import PropTypes from 'prop-types';
 import values from 'object.values';
 import { EnzymeAdapter } from 'enzyme';
 import {
@@ -13,6 +12,8 @@ import {
   propFromEvent,
   withSetStateAllowed,
   assertDomAvailable,
+  createRenderWrapper,
+  createMountWrapper,
 } from 'enzyme-adapter-utils';
 
 function typeToNodeType(type) {
@@ -65,31 +66,34 @@ function instanceToTree(inst) {
   throw new Error('Enzyme Internal Error: unknown instance encountered');
 }
 
-class SimpleWrapper extends React.Component {
-  render() {
-    return this.props.node || null;
-  }
-}
-
-SimpleWrapper.propTypes = { node: PropTypes.node.isRequired };
-
 class ReactFifteenAdapter extends EnzymeAdapter {
   createMountRenderer(options) {
     assertDomAvailable('mount');
     const domNode = options.attachTo || global.document.createElement('div');
     let instance = null;
     return {
-      render(el/* , context */) {
-        const wrappedEl = React.createElement(SimpleWrapper, {
-          node: el,
-        });
-        instance = ReactDOM.render(wrappedEl, domNode);
+      render(el, context, callback) {
+        if (instance === null) {
+          const ReactWrapperComponent = createMountWrapper(el, options);
+          const wrappedEl = React.createElement(ReactWrapperComponent, {
+            Component: el.type,
+            props: el.props,
+            context,
+          });
+          instance = ReactDOM.render(wrappedEl, domNode);
+          if (typeof callback === 'function') {
+            callback();
+          }
+        } else {
+          instance.setChildProps(el.props, context, callback);
+        }
       },
       unmount() {
         ReactDOM.unmountComponentAtNode(domNode);
+        instance = null;
       },
       getNode() {
-        return instanceToTree(instance._reactInternalInstance._renderedComponent);
+        return instance ? instanceToTree(instance._reactInternalInstance).rendered : null;
       },
       simulateEvent(node, event, mock) {
         const mappedEvent = mapNativeEventNames(event);
@@ -157,9 +161,17 @@ class ReactFifteenAdapter extends EnzymeAdapter {
     };
   }
 
-  createStringRenderer(/* options */) {
+  createStringRenderer(options) {
     return {
-      render(el /* , context */) {
+      render(el, context) {
+        if (options.context && (el.type.contextTypes || options.childContextTypes)) {
+          const childContextTypes = {
+            ...(el.type.contextTypes || {}),
+            ...options.childContextTypes,
+          };
+          const ContextWrapper = createRenderWrapper(el, context, childContextTypes);
+          return ReactDOMServer.renderToStaticMarkup(React.createElement(ContextWrapper));
+        }
         return ReactDOMServer.renderToStaticMarkup(el);
       },
     };

--- a/packages/enzyme-adapter-react-15.4/package.json
+++ b/packages/enzyme-adapter-react-15.4/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "enzyme-adapter-utils": "2.9.1",
     "lodash": "^4.17.4",
+    "object.assign": "^4.0.4",
     "object.values": "^1.0.4",
     "prop-types": "^15.5.10"
   },

--- a/packages/enzyme-adapter-react-15.4/src/ReactFifteenFourAdapter.js
+++ b/packages/enzyme-adapter-react-15.4/src/ReactFifteenFourAdapter.js
@@ -4,7 +4,6 @@ import ReactDOM from 'react-dom';
 import ReactDOMServer from 'react-dom/server';
 // eslint-disable-next-line import/no-unresolved, import/extensions
 import TestUtils from 'react-addons-test-utils';
-import PropTypes from 'prop-types';
 import values from 'object.values';
 import { EnzymeAdapter } from 'enzyme';
 import {
@@ -13,6 +12,8 @@ import {
   propFromEvent,
   withSetStateAllowed,
   assertDomAvailable,
+  createRenderWrapper,
+  createMountWrapper,
 } from 'enzyme-adapter-utils';
 
 function compositeTypeToNodeType(type) {
@@ -73,31 +74,34 @@ function instanceToTree(inst) {
   throw new Error('Enzyme Internal Error: unknown instance encountered');
 }
 
-class SimpleWrapper extends React.Component {
-  render() {
-    return this.props.node || null;
-  }
-}
-
-SimpleWrapper.propTypes = { node: PropTypes.node.isRequired };
-
 class ReactFifteenFourAdapter extends EnzymeAdapter {
   createMountRenderer(options) {
     assertDomAvailable('mount');
     const domNode = options.attachTo || global.document.createElement('div');
     let instance = null;
     return {
-      render(el/* , context */) {
-        const wrappedEl = React.createElement(SimpleWrapper, {
-          node: el,
-        });
-        instance = ReactDOM.render(wrappedEl, domNode);
+      render(el, context, callback) {
+        if (instance === null) {
+          const ReactWrapperComponent = createMountWrapper(el, options);
+          const wrappedEl = React.createElement(ReactWrapperComponent, {
+            Component: el.type,
+            props: el.props,
+            context,
+          });
+          instance = ReactDOM.render(wrappedEl, domNode);
+          if (typeof callback === 'function') {
+            callback();
+          }
+        } else {
+          instance.setChildProps(el.props, context, callback);
+        }
       },
       unmount() {
         ReactDOM.unmountComponentAtNode(domNode);
+        instance = null;
       },
       getNode() {
-        return instanceToTree(instance._reactInternalInstance._renderedComponent);
+        return instance ? instanceToTree(instance._reactInternalInstance).rendered : null;
       },
       simulateEvent(node, event, mock) {
         const mappedEvent = mapNativeEventNames(event);
@@ -165,9 +169,17 @@ class ReactFifteenFourAdapter extends EnzymeAdapter {
     };
   }
 
-  createStringRenderer(/* options */) {
+  createStringRenderer(options) {
     return {
-      render(el /* , context */) {
+      render(el, context) {
+        if (options.context && (el.type.contextTypes || options.childContextTypes)) {
+          const childContextTypes = {
+            ...(el.type.contextTypes || {}),
+            ...options.childContextTypes,
+          };
+          const ContextWrapper = createRenderWrapper(el, context, childContextTypes);
+          return ReactDOMServer.renderToStaticMarkup(React.createElement(ContextWrapper));
+        }
         return ReactDOMServer.renderToStaticMarkup(el);
       },
     };

--- a/packages/enzyme-adapter-react-15/package.json
+++ b/packages/enzyme-adapter-react-15/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "enzyme-adapter-utils": "2.9.1",
     "lodash": "^4.17.4",
+    "object.assign": "^4.0.4",
     "object.values": "^1.0.4",
     "prop-types": "^15.5.10"
   },

--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -7,7 +7,6 @@ import ReactDOMServer from 'react-dom/server';
 import ShallowRenderer from 'react-test-renderer/shallow';
 // eslint-disable-next-line import/no-unresolved, import/extensions
 import TestUtils from 'react-dom/test-utils';
-import PropTypes from 'prop-types';
 import { EnzymeAdapter } from 'enzyme';
 import {
   elementToTree,
@@ -16,6 +15,8 @@ import {
   propFromEvent,
   assertDomAvailable,
   withSetStateAllowed,
+  createRenderWrapper,
+  createMountWrapper,
 } from 'enzyme-adapter-utils';
 
 const HostRoot = 3;
@@ -143,31 +144,34 @@ function nodeToHostNode(_node) {
   return ReactDOM.findDOMNode(node.instance);
 }
 
-class SimpleWrapper extends React.Component {
-  render() {
-    return this.props.node || null;
-  }
-}
-
-SimpleWrapper.propTypes = { node: PropTypes.node.isRequired };
-
 class ReactSixteenAdapter extends EnzymeAdapter {
   createMountRenderer(options) {
     assertDomAvailable('mount');
     const domNode = options.attachTo || global.document.createElement('div');
     let instance = null;
     return {
-      render(el/* , context */) {
-        const wrappedEl = React.createElement(SimpleWrapper, {
-          node: el,
-        });
-        instance = ReactDOM.render(wrappedEl, domNode);
+      render(el, context, callback) {
+        if (instance === null) {
+          const ReactWrapperComponent = createMountWrapper(el, options);
+          const wrappedEl = React.createElement(ReactWrapperComponent, {
+            Component: el.type,
+            props: el.props,
+            context,
+          });
+          instance = ReactDOM.render(wrappedEl, domNode);
+          if (typeof callback === 'function') {
+            callback();
+          }
+        } else {
+          instance.setChildProps(el.props, context, callback);
+        }
       },
       unmount() {
         ReactDOM.unmountComponentAtNode(domNode);
+        instance = null;
       },
       getNode() {
-        return toTree(instance._reactInternalInstance.child);
+        return instance ? toTree(instance._reactInternalInstance).rendered : null;
       },
       simulateEvent(node, event, mock) {
         const mappedEvent = mapNativeEventNames(event);
@@ -237,9 +241,17 @@ class ReactSixteenAdapter extends EnzymeAdapter {
     };
   }
 
-  createStringRenderer(/* options */) {
+  createStringRenderer(options) {
     return {
-      render(el /* , context */) {
+      render(el, context) {
+        if (options.context && (el.type.contextTypes || options.childContextTypes)) {
+          const childContextTypes = {
+            ...(el.type.contextTypes || {}),
+            ...options.childContextTypes,
+          };
+          const ContextWrapper = createRenderWrapper(el, context, childContextTypes);
+          return ReactDOMServer.renderToStaticMarkup(React.createElement(ContextWrapper));
+        }
         return ReactDOMServer.renderToStaticMarkup(el);
       },
     };

--- a/packages/enzyme-adapter-utils/package.json
+++ b/packages/enzyme-adapter-utils/package.json
@@ -31,7 +31,12 @@
   "author": "Leland Richardson <leland.richardson@airbnb.com>",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "object.assign": "^4.0.4",
+    "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "react": "0.13.x || 0.14.x || ^15.0.0-0 || ^16.0.0-0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/packages/enzyme-adapter-utils/src/Utils.js
+++ b/packages/enzyme-adapter-utils/src/Utils.js
@@ -1,4 +1,8 @@
 import flatten from 'lodash/flatten';
+import createMountWrapper from './createMountWrapper';
+import createRenderWrapper from './createRenderWrapper';
+
+export { createMountWrapper, createRenderWrapper };
 
 export function mapNativeEventNames(event) {
   const nativeToReactEventMap = {

--- a/packages/enzyme-adapter-utils/src/createMountWrapper.jsx
+++ b/packages/enzyme-adapter-utils/src/createMountWrapper.jsx
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
  * the DOM node it rendered to, so we can't really "re-render" to
  * pass new props in.
  */
-export default function createWrapperComponent(node, options = {}) {
+export default function createMountWrapper(node, options = {}) {
   class WrapperComponent extends React.Component {
     constructor(...args) {
       super(...args);
@@ -21,9 +21,10 @@ export default function createWrapperComponent(node, options = {}) {
         context: this.props.context,
       };
     }
-    setChildProps(newProps, callback = undefined) {
+    setChildProps(newProps, newContext, callback = undefined) {
       const props = { ...this.state.props, ...newProps };
-      this.setState({ props }, callback);
+      const context = { ...this.state.context, ...newContext };
+      this.setState({ props, context }, callback);
     }
     getInstance() {
       const component = this._reactInternalInstance._renderedComponent;

--- a/packages/enzyme-adapter-utils/src/createRenderWrapper.jsx
+++ b/packages/enzyme-adapter-utils/src/createRenderWrapper.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function createRenderWrapper(node, context, childContextTypes) {
+  class ContextWrapper extends React.Component {
+    getChildContext() {
+      return context;
+    }
+    render() {
+      return node;
+    }
+  }
+  ContextWrapper.childContextTypes = childContextTypes;
+  return ContextWrapper;
+}

--- a/packages/enzyme/package.json
+++ b/packages/enzyme/package.json
@@ -38,12 +38,8 @@
     "object-is": "^1.0.1",
     "object.assign": "^4.0.4",
     "object.entries": "^1.0.4",
-    "prop-types": "^15.5.10",
     "raf": "^3.3.2",
     "uuid": "^3.1.0"
-  },
-  "peerDependencies": {
-    "react": "0.13.x || 0.14.x || ^15.0.0-0 || ^16.0.0-0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import flatten from 'lodash/flatten';
 import unique from 'lodash/uniq';
 import compact from 'lodash/compact';
@@ -18,6 +17,7 @@ import {
   getAdapter,
   sym,
   privateSet,
+  cloneElement,
 } from './Utils';
 import {
   debugNodes,
@@ -252,6 +252,7 @@ class ShallowWrapper {
    * @returns {ShallowWrapper}
    */
   rerender(props, context) {
+    const adapter = getAdapter(this[OPTIONS]);
     this.single('rerender', () => {
       withSetStateAllowed(() => {
         // NOTE(lmr): In react 16, instances will be null for SFCs, but
@@ -291,7 +292,7 @@ class ShallowWrapper {
             originalShouldComponentUpdate = instance.shouldComponentUpdate;
           }
           if (shouldRender) {
-            if (props) this[UNRENDERED] = React.cloneElement(this[UNRENDERED], props);
+            if (props) this[UNRENDERED] = cloneElement(adapter, this[UNRENDERED], props);
             if (originalShouldComponentUpdate) {
               instance.shouldComponentUpdate = () => true;
             }

--- a/packages/enzyme/src/Utils.js
+++ b/packages/enzyme/src/Utils.js
@@ -374,3 +374,10 @@ export function privateSet(obj, prop, value) {
     writable: true,
   });
 }
+
+export function cloneElement(adapter, el, props) {
+  return adapter.createElement(
+    el.type,
+    { ...el.props, ...props },
+  );
+}

--- a/packages/enzyme/src/render.js
+++ b/packages/enzyme/src/render.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import cheerio from 'cheerio';
 import { getAdapter } from './Utils';
 
@@ -16,31 +15,9 @@ import { getAdapter } from './Utils';
  * @returns {Cheerio}
  */
 
-function createContextWrapperForNode(node, context, childContextTypes) {
-  class ContextWrapper extends React.Component {
-    getChildContext() {
-      return context;
-    }
-    render() {
-      return node;
-    }
-  }
-  ContextWrapper.childContextTypes = childContextTypes;
-  return ContextWrapper;
-}
-
 export default function render(node, options = {}) {
   const adapter = getAdapter(options);
   const renderer = adapter.createRenderer({ mode: 'string', ...options });
-  if (options.context && (node.type.contextTypes || options.childContextTypes)) {
-    const childContextTypes = {
-      ...(node.type.contextTypes || {}),
-      ...options.childContextTypes,
-    };
-    const ContextWrapper = createContextWrapperForNode(node, options.context, childContextTypes);
-    const html = renderer.render(<ContextWrapper />);
-    return cheerio.load(html).root();
-  }
-  const html = renderer.render(node);
+  const html = renderer.render(node, options.context);
   return cheerio.load(html).root();
 }


### PR DESCRIPTION
to: @ljharb @aweary 

This PR removes all react dependencies from the core enzyme library. In order to do this, the component "wrappers" were moved from enzyme into the adapters. This ends up cleaning up a number of things, and I think worked out rather nicely.