### PR TITLE
props not merged when shallow rendering in lifecycleExperimental

### DIFF
--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -958,6 +958,50 @@ describe('shallow', () => {
       expect(wrapper.first('div').text()).to.equal('yolo');
     });
 
+    it('should call componentWillReceiveProps, shouldComponentUpdate and componentWillUpdate with merged newProps', () => {
+      const spy = sinon.spy();
+
+      class Foo extends React.Component {
+        componentWillReceiveProps(nextProps) {
+          spy('componentWillReceiveProps', this.props, nextProps);
+        }
+        shouldComponentUpdate(nextProps) {
+          spy('shouldComponentUpdate', this.props, nextProps);
+          return true;
+        }
+        componentWillUpdate(nextProps) {
+          spy('componentWillUpdate', this.props, nextProps);
+        }
+        render() {
+          return (
+            <div />
+          );
+        }
+      }
+
+      const wrapper = shallow(<Foo a="a" b="b" />);
+
+      wrapper.setProps({ b: 'c', d: 'e' });
+
+      expect(spy.args).to.deep.equal([
+        [
+          'componentWillReceiveProps',
+          { a: 'a', b: 'b' },
+          { a: 'a', b: 'c', d: 'e' },
+        ],
+        [
+          'shouldComponentUpdate',
+          { a: 'a', b: 'b' },
+          { a: 'a', b: 'c', d: 'e' },
+        ],
+        [
+          'componentWillUpdate',
+          { a: 'a', b: 'b' },
+          { a: 'a', b: 'c', d: 'e' },
+        ],
+      ]);
+    });
+
     describeIf(!REACT013, 'stateless function components', () => {
       it('should set props for a component multiple times', () => {
         const Foo = props => (
@@ -3092,6 +3136,58 @@ describe('shallow', () => {
             ],
           ],
         );
+      });
+
+      it('should componentWillReceiveProps, shouldComponentUpdate, componentWillUpdate and componentDidUpdate with merged props', () => {
+        const spy = sinon.spy();
+
+        class Foo extends React.Component {
+          componentWillReceiveProps(nextProps) {
+            spy('componentWillReceiveProps', this.props, nextProps);
+          }
+          shouldComponentUpdate(nextProps) {
+            spy('shouldComponentUpdate', this.props, nextProps);
+            return true;
+          }
+          componentWillUpdate(nextProps) {
+            spy('componentWillUpdate', this.props, nextProps);
+          }
+          componentDidUpdate(prevProps) {
+            spy('componentDidUpdate', prevProps, this.props);
+          }
+          render() {
+            return (
+              <div />
+            );
+          }
+        }
+
+        const wrapper = shallow(<Foo a="a" b="b" />, { lifecycleExperimental: true });
+
+        wrapper.setProps({ b: 'c', d: 'e' });
+
+        expect(spy.args).to.deep.equal([
+          [
+            'componentWillReceiveProps',
+            { a: 'a', b: 'b' },
+            { a: 'a', b: 'c', d: 'e' },
+          ],
+          [
+            'shouldComponentUpdate',
+            { a: 'a', b: 'b' },
+            { a: 'a', b: 'c', d: 'e' },
+          ],
+          [
+            'componentWillUpdate',
+            { a: 'a', b: 'b' },
+            { a: 'a', b: 'c', d: 'e' },
+          ],
+          [
+            'componentDidUpdate',
+            { a: 'a', b: 'b' },
+            { a: 'a', b: 'c', d: 'e' },
+          ],
+        ]);
       });
 
       it('should cancel rendering when Component returns false in shouldComponentUpdate', () => {

--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -262,7 +262,7 @@ class ShallowWrapper {
         const state = instance.state;
         const prevProps = instance.props || this[UNRENDERED].props;
         const prevContext = instance.context || this[OPTIONS].context;
-        const nextProps = props || prevProps;
+        const nextProps = { ...prevProps, ...props };
         const nextContext = context || prevContext;
         if (context) {
           this[OPTIONS] = { ...this[OPTIONS], context: nextContext };


### PR DESCRIPTION
When shallow rendering a component with `lifecycleExperimental: true` the lifecyle methods `componentWillReceiveProps` and `shouldComponentUpdate` will only be called with the value given to `setProps`, but not with old and new props merged.

It works for shallow rendering without lifecycleExperimental.

Due to the "[dirty hacks](https://github.com/airbnb/enzyme/blob/da9140713a946ef3bef23952e693bc917166a0b3/packages/enzyme/src/ShallowWrapper.js#L272-L293)" i'm not sure if there is a better way to do this, but this at least fixes the dirty hacks.