### PR TITLE
[Fix] `mount`: do not mutate `Component.contextTypes`

### DIFF
--- a/packages/enzyme-adapter-utils/src/createMountWrapper.jsx
+++ b/packages/enzyme-adapter-utils/src/createMountWrapper.jsx
@@ -69,10 +69,11 @@ export default function createMountWrapper(node, options = {}) {
     // OR the merged context types for all children (the node component or deeper children) are
     // specified in options parameter under childContextTypes.
     // In that case, we define both a `getChildContext()` function and a `childContextTypes` prop.
-    const childContextTypes = node.type.contextTypes || {};
-    if (options.childContextTypes) {
-      Object.assign(childContextTypes, options.childContextTypes);
-    }
+    const childContextTypes = {
+      ...node.type.contextTypes,
+      ...options.childContextTypes,
+    };
+
     WrapperComponent.prototype.getChildContext = function getChildContext() {
       return this.state.context;
     };

--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -94,6 +94,46 @@ describeWithDOM('mount', () => {
       expect(wrapper.find(SimpleComponent)).to.have.length(1);
     });
 
+    describe('does not attempt to mutate Component.childContextTypes', () => {
+      const SimpleComponent = createClass({
+        displayName: 'Simple',
+        render() {
+          return <div />;
+        },
+      });
+
+      class ClassComponent extends React.Component {
+        render() {
+          return (
+            <div>
+              {this.context.a}
+              <SimpleComponent />
+            </div>
+          );
+        }
+      }
+      ClassComponent.contextTypes = Object.freeze({ a: PropTypes.string });
+
+      const CreateClassComponent = createClass({
+        contextTypes: ClassComponent.contextTypes,
+        render: ClassComponent.prototype.render,
+      });
+
+      it('works without options', () => {
+        expect(() => mount(<ClassComponent />)).not.to.throw();
+        expect(() => mount(<CreateClassComponent />)).not.to.throw();
+      });
+
+      it('works with a childContextTypes option', () => {
+        const options = {
+          childContextTypes: { b: PropTypes.string },
+          context: { a: 'hello', b: 'world' },
+        };
+        expect(() => mount(<ClassComponent />, options)).not.to.throw();
+        expect(() => mount(<CreateClassComponent />, options)).not.to.throw();
+      });
+    });
+
     it('should not throw if context is passed in but contextTypes is missing', () => {
       const SimpleComponent = createClass({
         render() {
@@ -102,7 +142,7 @@ describeWithDOM('mount', () => {
       });
 
       const context = { name: 'foo' };
-      expect(() => mount(<SimpleComponent />, { context })).to.not.throw();
+      expect(() => mount(<SimpleComponent />, { context })).not.to.throw();
     });
 
     it('is introspectable through context API', () => {


### PR DESCRIPTION
Fixes #1091.

Turns out that this was only an issue on class-based components (possibly SFCs as well), presumably because createClass clones `contextTypes` for us.