### PR TITLE
[BREAKING] Add .root() and make shallow() and mount() semantics consistent

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "check": "lerna run lint && npm run test:all",
     "prebuild": "npm run clean",
     "build": "lerna run build",
-    "build:watch": "lerna run watch",
+    "build:watch": "lerna run --parallel watch",
     "pretest": "lerna run lint",
     "test": "npm run test:only",
     "pretest:only": "npm run build",

--- a/packages/enzyme-test-suite/test/Debug-spec.jsx
+++ b/packages/enzyme-test-suite/test/Debug-spec.jsx
@@ -218,7 +218,7 @@ describe('debug', () => {
           );
         }
       }
-      expect(mount(<Foo id="2" />).debug()).to.eql(
+      expect(mount(<Foo id="2" />).root().debug()).to.eql(
         `<Foo id="2">
   <div className="foo">
     <span>
@@ -237,7 +237,7 @@ describe('debug', () => {
           );
         }
       }
-      expect(mount(<Foo id="2" />).debug()).to.eql(
+      expect(mount(<Foo id="2" />).root().debug()).to.eql(
         `<Foo id="2">
   <div>
     hello
@@ -267,7 +267,7 @@ describe('debug', () => {
           );
         }
       }
-      expect(mount(<Bar id="2" />).debug()).to.eql(
+      expect(mount(<Bar id="2" />).root().debug()).to.eql(
         `<Bar id="2">
   <div className="bar">
     <span>
@@ -337,7 +337,7 @@ describe('debug', () => {
         }
       }
 
-      expect(mount(<Bar id="2" />).debug()).to.eql(
+      expect(mount(<Bar id="2" />).root().debug()).to.eql(
         `<Bar id="2">
   <div className="bar">
     <Foo baz="bax">
@@ -362,7 +362,7 @@ describe('debug', () => {
             <span>Foo</span>
           </div>
         );
-        expect(mount(<Foo id="2" />).debug()).to.eql(
+        expect(mount(<Foo id="2" />).root().debug()).to.eql(
           `<Foo id="2">
   <div className="foo">
     <span>
@@ -385,7 +385,7 @@ describe('debug', () => {
             <Foo baz="bax" />
           </div>
         );
-        expect(mount(<Bar id="2" />).debug()).to.eql(
+        expect(mount(<Bar id="2" />).root().debug()).to.eql(
           `<Bar id="2">
   <div className="bar">
     <span>
@@ -415,7 +415,7 @@ describe('debug', () => {
             <Foo baz="bax" />
           </div>
         );
-        expect(mount(<Bar id="2" />).find(Foo).debug()).to.eql(
+        expect(mount(<Bar id="2" />).root().find(Foo).debug()).to.eql(
           `<Foo baz="bax">
   <div className="foo">
     <span>
@@ -442,7 +442,7 @@ describe('debug', () => {
           </div>
         );
 
-        expect(mount(<Bar id="2" />).debug()).to.eql(
+        expect(mount(<Bar id="2" />).root().debug()).to.eql(
           `<Bar id="2">
   <div className="bar">
     <Foo baz="bax">
@@ -650,7 +650,7 @@ describe('debug', () => {
         }
       }
 
-      expect(mount(<Bar />).debug({ ignoreProps: false })).to.eql(
+      expect(mount(<Bar />).root().debug({ ignoreProps: false })).to.eql(
         `<Bar>
   <div className="class1">
     <Foo fooVal="baz">
@@ -665,7 +665,7 @@ describe('debug', () => {
 </Bar>`,
       );
 
-      expect(mount(<Bar />).debug({ ignoreProps: true })).to.eql(
+      expect(mount(<Bar />).root().debug({ ignoreProps: true })).to.eql(
         `<Bar>
   <div>
     <Foo>

--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -44,17 +44,17 @@ describeWithDOM('mount', () => {
 
       const wrapper = mount(<Foo bar />);
 
-      expect(wrapper.type()).to.equal(Foo);
-      expect(wrapper.props()).to.deep.equal({ bar: true });
-      expect(wrapper.instance()).to.be.instanceOf(Foo);
-      expect(wrapper.children().at(0).type()).to.equal(Box);
+      expect(wrapper.root().type()).to.equal(Foo);
+      expect(wrapper.root().props()).to.deep.equal({ bar: true });
+      expect(wrapper.root().instance()).to.be.instanceOf(Foo);
+      expect(wrapper.type()).to.equal(Box);
       expect(wrapper.find(Box).children().props().className).to.equal('box');
       expect(wrapper.find(Box).instance()).to.be.instanceOf(Box);
       expect(wrapper.find(Box).children().at(0).props().className).to.equal('box');
       expect(wrapper.find(Box).children().props().className).to.equal('box');
-      expect(wrapper.children().type()).to.equal(Box);
-      expect(wrapper.children().instance()).to.be.instanceOf(Box);
-      expect(wrapper.children().props().bam).to.equal(true);
+      expect(wrapper.type()).to.equal(Box);
+      expect(wrapper.instance()).to.be.instanceOf(Box);
+      expect(wrapper.props().bam).to.equal(true);
     });
   });
 
@@ -161,8 +161,8 @@ describeWithDOM('mount', () => {
       const context = { name: 'foo' };
       const wrapper = mount(<SimpleComponent />, { context });
 
-      expect(wrapper.context().name).to.equal(context.name);
-      expect(wrapper.context('name')).to.equal(context.name);
+      expect(wrapper.root().context().name).to.equal(context.name);
+      expect(wrapper.root().context('name')).to.equal(context.name);
     });
 
     describeIf(!REACT013, 'stateless components', () => {
@@ -214,8 +214,8 @@ describeWithDOM('mount', () => {
         const context = { name: 'foo' };
         const wrapper = mount(<SimpleComponent />, { context });
 
-        expect(wrapper.context().name).to.equal(context.name);
-        expect(wrapper.context('name')).to.equal(context.name);
+        expect(wrapper.root().context().name).to.equal(context.name);
+        expect(wrapper.root().context('name')).to.equal(context.name);
       });
 
       itIf(!REACT16, 'works with stateless components', () => {
@@ -235,7 +235,7 @@ describeWithDOM('mount', () => {
             _: 'foo',
           },
         });
-        expect(wrapper.context('_')).to.equal('foo');
+        expect(wrapper.root().context('_')).to.equal('foo');
       });
     });
   });
@@ -249,7 +249,7 @@ describeWithDOM('mount', () => {
         </div>
       );
       const wrapper = mount(<Foo foo="qux" />);
-      expect(wrapper.type()).to.equal(Foo);
+      expect(wrapper.root().type()).to.equal(Foo);
       expect(wrapper.find('.bar')).to.have.length(1);
       expect(wrapper.find('.qoo').text()).to.equal('qux');
     });
@@ -859,7 +859,7 @@ describeWithDOM('mount', () => {
 
       const content = 'blah';
       const wrapper = mount(<Foo data={content} />);
-      expect(wrapper.props()).to.deep.equal({ data: content });
+      expect(wrapper.root().props()).to.deep.equal({ data: content });
     });
 
     it('should return shallow rendered string when debug() is called', () => {
@@ -873,7 +873,7 @@ describeWithDOM('mount', () => {
 
       const content = 'blah';
       const wrapper = mount(<Foo data={content} />);
-      expect(wrapper.debug()).to.equal(
+      expect(wrapper.root().debug()).to.equal(
         `<Foo data="${content}">
   <div data-foo="${content}">
     Test Component
@@ -938,7 +938,7 @@ describeWithDOM('mount', () => {
 
         const content = 'blah';
         const wrapper = mount(<SFC data={content} />);
-        expect(wrapper.props()).to.deep.equal({ data: content });
+        expect(wrapper.root().props()).to.deep.equal({ data: content });
       });
 
       it('should return shallow rendered string when debug() is called', () => {
@@ -950,7 +950,7 @@ describeWithDOM('mount', () => {
 
         const content = 'blah';
         const wrapper = mount(<SFC data={content} />);
-        expect(wrapper.debug()).to.equal(
+        expect(wrapper.root().debug()).to.equal(
           `<SFC data="${content}">
   <div data-foo="${content}">
     Test SFC
@@ -990,7 +990,7 @@ describeWithDOM('mount', () => {
       }
       const wrapper = mount(<Foo id="foo" />);
       expect(wrapper.find('.foo').length).to.equal(1);
-      wrapper.setProps({ id: 'bar', foo: 'bla' });
+      wrapper.root().setProps({ id: 'bar', foo: 'bla' });
       expect(wrapper.find('.bar').length).to.equal(1);
     });
 
@@ -1013,7 +1013,7 @@ describeWithDOM('mount', () => {
       const nextProps = { id: 'bar', foo: 'bla' };
       const wrapper = mount(<Foo id="foo" />);
       expect(spy.calledOnce).to.equal(false);
-      wrapper.setProps(nextProps);
+      wrapper.root().setProps(nextProps);
       expect(spy.calledOnce).to.equal(true);
       expect(spy.calledWith(nextProps)).to.equal(true);
     });
@@ -1033,13 +1033,13 @@ describeWithDOM('mount', () => {
       }
 
       const wrapper = mount(<Foo a="a" b="b" />);
-      expect(wrapper.props().a).to.equal('a');
-      expect(wrapper.props().b).to.equal('b');
+      expect(wrapper.root().props().a).to.equal('a');
+      expect(wrapper.root().props().b).to.equal('b');
 
-      wrapper.setProps({ b: 'c', d: 'e' });
-      expect(wrapper.props().a).to.equal('a');
-      expect(wrapper.props().b).to.equal('c');
-      expect(wrapper.props().d).to.equal('e');
+      wrapper.root().setProps({ b: 'c', d: 'e' });
+      expect(wrapper.root().props().a).to.equal('a');
+      expect(wrapper.root().props().b).to.equal('c');
+      expect(wrapper.root().props().d).to.equal('e');
     });
 
     itIf(!REACT16, 'should throw if an exception occurs during render', () => {
@@ -1072,7 +1072,7 @@ describeWithDOM('mount', () => {
       const wrapper = mount(<Trainwreck user={validUser} />);
 
       const setInvalidProps = () => {
-        wrapper.setProps({
+        wrapper.root().setProps({
           user: {},
         });
       };
@@ -1095,7 +1095,7 @@ describeWithDOM('mount', () => {
       expect(wrapper.find('.foo').length).to.equal(1);
 
       wrapper[sym('__renderer__')].batchedUpdates(() => {
-        wrapper.setProps({ id: 'bar', foo: 'bla' }, () => {
+        wrapper.root().setProps({ id: 'bar', foo: 'bla' }, () => {
           expect(wrapper.find('.bar').length).to.equal(1);
         });
         expect(wrapper.find('.bar').length).to.equal(0);
@@ -1112,7 +1112,7 @@ describeWithDOM('mount', () => {
 
         const wrapper = mount(<Foo id="foo" />);
         expect(wrapper.find('.foo').length).to.equal(1);
-        wrapper.setProps({ id: 'bar', foo: 'bla' });
+        wrapper.root().setProps({ id: 'bar', foo: 'bla' });
         expect(wrapper.find('.bar').length).to.equal(1);
       });
 
@@ -1125,13 +1125,13 @@ describeWithDOM('mount', () => {
         );
 
         const wrapper = mount(<Foo a="a" b="b" />);
-        expect(wrapper.props().a).to.equal('a');
-        expect(wrapper.props().b).to.equal('b');
+        expect(wrapper.root().props().a).to.equal('a');
+        expect(wrapper.root().props().b).to.equal('b');
 
-        wrapper.setProps({ b: 'c', d: 'e' });
-        expect(wrapper.props().a).to.equal('a');
-        expect(wrapper.props().b).to.equal('c');
-        expect(wrapper.props().d).to.equal('e');
+        wrapper.root().setProps({ b: 'c', d: 'e' });
+        expect(wrapper.root().props().a).to.equal('a');
+        expect(wrapper.root().props().b).to.equal('c');
+        expect(wrapper.root().props().d).to.equal('e');
       });
 
       itIf(!REACT16, 'should throw if an exception occurs during render', () => {
@@ -1159,7 +1159,7 @@ describeWithDOM('mount', () => {
         const wrapper = mount(<Trainwreck user={validUser} />);
 
         const setInvalidProps = () => {
-          wrapper.setProps({
+          wrapper.root().setProps({
             user: {},
           });
         };
@@ -1186,9 +1186,9 @@ describeWithDOM('mount', () => {
       const context = { name: 'foo' };
       const wrapper = mount(<SimpleComponent />, { context });
       expect(wrapper.text()).to.equal('foo');
-      wrapper.setContext({ name: 'bar' });
+      wrapper.root().setContext({ name: 'bar' });
       expect(wrapper.text()).to.equal('bar');
-      wrapper.setContext({ name: 'baz' });
+      wrapper.root().setContext({ name: 'baz' });
       expect(wrapper.text()).to.equal('baz');
     });
 
@@ -1203,7 +1203,7 @@ describeWithDOM('mount', () => {
       });
 
       const wrapper = mount(<SimpleComponent />);
-      expect(() => wrapper.setContext({ name: 'bar' })).to.throw(
+      expect(() => wrapper.root().setContext({ name: 'bar' })).to.throw(
         Error,
         'ShallowWrapper::setContext() can only be called on a wrapper that was originally passed a context option', // eslint-disable-line max-len
       );
@@ -1219,9 +1219,9 @@ describeWithDOM('mount', () => {
         const context = { name: 'foo' };
         const wrapper = mount(<SimpleComponent />, { context });
         expect(wrapper.text()).to.equal('foo');
-        wrapper.setContext({ name: 'bar' });
+        wrapper.root().setContext({ name: 'bar' });
         expect(wrapper.text()).to.equal('bar');
-        wrapper.setContext({ name: 'baz' });
+        wrapper.root().setContext({ name: 'baz' });
         expect(wrapper.text()).to.equal('baz');
       });
 
@@ -1232,7 +1232,7 @@ describeWithDOM('mount', () => {
         SimpleComponent.contextTypes = { name: PropTypes.string };
 
         const wrapper = mount(<SimpleComponent />);
-        expect(() => wrapper.setContext({ name: 'bar' })).to.throw(
+        expect(() => wrapper.root().setContext({ name: 'bar' })).to.throw(
           Error,
           'ShallowWrapper::setContext() can only be called on a wrapper that was originally passed a context option', // eslint-disable-line max-len
         );
@@ -1265,11 +1265,11 @@ describeWithDOM('mount', () => {
       expect(willMount.callCount).to.equal(1);
       expect(didMount.callCount).to.equal(1);
       expect(willUnmount.callCount).to.equal(0);
-      wrapper.unmount();
+      wrapper.root().unmount();
       expect(willMount.callCount).to.equal(1);
       expect(didMount.callCount).to.equal(1);
       expect(willUnmount.callCount).to.equal(1);
-      wrapper.mount();
+      wrapper.root().mount();
       expect(willMount.callCount).to.equal(2);
       expect(didMount.callCount).to.equal(2);
       expect(willUnmount.callCount).to.equal(1);
@@ -1295,7 +1295,7 @@ describeWithDOM('mount', () => {
       }
       const wrapper = mount(<Foo id="foo" />);
       expect(spy.calledOnce).to.equal(false);
-      wrapper.unmount();
+      wrapper.root().unmount();
       expect(spy.calledOnce).to.equal(true);
     });
   });
@@ -1425,7 +1425,7 @@ describeWithDOM('mount', () => {
       }
       const wrapper = mount(<Foo />);
       expect(wrapper.find('.foo').length).to.equal(1);
-      wrapper.setState({ id: 'bar' });
+      wrapper.root().setState({ id: 'bar' });
       expect(wrapper.find('.bar').length).to.equal(1);
     });
 
@@ -1461,9 +1461,9 @@ describeWithDOM('mount', () => {
         }
       }
       const wrapper = mount(<Foo />);
-      expect(wrapper.state()).to.eql({ id: 'foo' });
-      wrapper.setState({ id: 'bar' }, () => {
-        expect(wrapper.state()).to.eql({ id: 'bar' });
+      expect(wrapper.root().state()).to.eql({ id: 'foo' });
+      wrapper.root().setState({ id: 'bar' }, () => {
+        expect(wrapper.root().state()).to.eql({ id: 'bar' });
       });
     });
 
@@ -1480,8 +1480,8 @@ describeWithDOM('mount', () => {
         }
       }
       const wrapper = mount(<Foo />);
-      expect(wrapper.state()).to.eql({ id: 'foo' });
-      expect(() => wrapper.setState({ id: 'bar' }, 1)).to.throw(Error);
+      expect(wrapper.root().state()).to.eql({ id: 'foo' });
+      expect(() => wrapper.root().setState({ id: 'bar' }, 1)).to.throw(Error);
     });
 
     itIf(is('>=15 || ^16.0.0-alpha'), 'should throw error when cb is not a function', () => {
@@ -1497,8 +1497,8 @@ describeWithDOM('mount', () => {
         }
       }
       const wrapper = mount(<Foo />);
-      expect(wrapper.state()).to.eql({ id: 'foo' });
-      expect(() => wrapper.setState({ id: 'bar' }, 1)).to.throw(Error);
+      expect(wrapper.root().state()).to.eql({ id: 'foo' });
+      expect(() => wrapper.root().setState({ id: 'bar' }, 1)).to.throw(Error);
     });
   });
 
@@ -1546,7 +1546,7 @@ describeWithDOM('mount', () => {
         },
       });
       const wrapper = mount(<Foo />);
-      expect(wrapper.isEmptyRender()).to.equal(data.expectResponse);
+      expect(wrapper.root().isEmptyRender()).to.equal(data.expectResponse);
     });
 
     itWithData(emptyRenderValues, 'when an ES2015 class component returns: ', (data) => {
@@ -1556,12 +1556,12 @@ describeWithDOM('mount', () => {
         }
       }
       const wrapper = mount(<Foo />);
-      expect(wrapper.isEmptyRender()).to.equal(data.expectResponse);
+      expect(wrapper.root().isEmptyRender()).to.equal(data.expectResponse);
     });
 
     it('should not return true for HTML elements', () => {
       const wrapper = mount(<div className="bar baz" />);
-      expect(wrapper.isEmptyRender()).to.equal(false);
+      expect(wrapper.root().isEmptyRender()).to.equal(false);
     });
 
     describeIf(is('>=15 || ^16.0.0-alpha'), 'stateless function components', () => {
@@ -1570,7 +1570,7 @@ describeWithDOM('mount', () => {
           return data.value;
         }
         const wrapper = mount(<Foo />);
-        expect(wrapper.isEmptyRender()).to.equal(data.expectResponse);
+        expect(wrapper.root().isEmptyRender()).to.equal(data.expectResponse);
       });
     });
   });
@@ -1795,7 +1795,7 @@ describeWithDOM('mount', () => {
 
       const wrapper = mount(<Foo foo="hi" bar="bye" />);
 
-      expect(wrapper.props()).to.eql({ bar: 'bye', foo: 'hi' });
+      expect(wrapper.root().props()).to.eql({ bar: 'bye', foo: 'hi' });
     });
 
     describeIf(!REACT013, 'stateless function components', () => {
@@ -1806,7 +1806,7 @@ describeWithDOM('mount', () => {
 
         const wrapper = mount(<Foo foo="hi" bar="bye" />);
 
-        expect(wrapper.props()).to.eql({ bar: 'bye', foo: 'hi' });
+        expect(wrapper.root().props()).to.eql({ bar: 'bye', foo: 'hi' });
       });
     });
   });
@@ -1850,10 +1850,10 @@ describeWithDOM('mount', () => {
 
       const wrapper = mount(<Foo foo="hi" bar="bye" />);
 
-      expect(wrapper.prop('className')).to.equal(undefined);
-      expect(wrapper.prop('id')).to.equal(undefined);
-      expect(wrapper.prop('foo')).to.equal('hi');
-      expect(wrapper.prop('bar')).to.equal('bye');
+      expect(wrapper.root().prop('className')).to.equal(undefined);
+      expect(wrapper.root().prop('id')).to.equal(undefined);
+      expect(wrapper.root().prop('foo')).to.equal('hi');
+      expect(wrapper.root().prop('bar')).to.equal('bye');
     });
 
     describeIf(!REACT013, 'stateless function components', () => {
@@ -1864,10 +1864,10 @@ describeWithDOM('mount', () => {
 
         const wrapper = mount(<Foo foo="hi" bar="bye" />);
 
-        expect(wrapper.prop('className')).to.equal(undefined);
-        expect(wrapper.prop('id')).to.equal(undefined);
-        expect(wrapper.prop('foo')).to.equal('hi');
-        expect(wrapper.prop('bar')).to.equal('bye');
+        expect(wrapper.root().prop('className')).to.equal(undefined);
+        expect(wrapper.root().prop('id')).to.equal(undefined);
+        expect(wrapper.root().prop('foo')).to.equal('hi');
+        expect(wrapper.root().prop('bar')).to.equal('bye');
       });
     });
   });
@@ -1882,7 +1882,7 @@ describeWithDOM('mount', () => {
         render() { return <div />; }
       }
       const wrapper = mount(<Foo />);
-      expect(wrapper.state()).to.eql({ foo: 'foo' });
+      expect(wrapper.root().state()).to.eql({ foo: 'foo' });
     });
 
     it('should return the current state after state transitions', () => {
@@ -1894,8 +1894,8 @@ describeWithDOM('mount', () => {
         render() { return <div />; }
       }
       const wrapper = mount(<Foo />);
-      wrapper.setState({ foo: 'bar' });
-      expect(wrapper.state()).to.eql({ foo: 'bar' });
+      wrapper.root().setState({ foo: 'bar' });
+      expect(wrapper.root().state()).to.eql({ foo: 'bar' });
     });
 
     it('should allow a state property name be passed in as an argument', () => {
@@ -1907,7 +1907,7 @@ describeWithDOM('mount', () => {
         render() { return <div />; }
       }
       const wrapper = mount(<Foo />);
-      expect(wrapper.state('foo')).to.equal('foo');
+      expect(wrapper.root().state('foo')).to.equal('foo');
     });
   });
 
@@ -1964,10 +1964,10 @@ describeWithDOM('mount', () => {
           ]}
         />,
       );
-      expect(wrapper.children().children().length).to.equal(3);
-      expect(wrapper.children().children().at(0).hasClass('foo')).to.equal(true);
-      expect(wrapper.children().children().at(1).hasClass('bar')).to.equal(true);
-      expect(wrapper.children().children().at(2).hasClass('baz')).to.equal(true);
+      expect(wrapper.children().length).to.equal(3);
+      expect(wrapper.children().at(0).hasClass('foo')).to.equal(true);
+      expect(wrapper.children().at(1).hasClass('bar')).to.equal(true);
+      expect(wrapper.children().at(2).hasClass('baz')).to.equal(true);
     });
 
     it('should optionally allow a selector to filter by', () => {
@@ -2007,10 +2007,10 @@ describeWithDOM('mount', () => {
             ]}
           />,
         );
-        expect(wrapper.children().children().length).to.equal(3);
-        expect(wrapper.children().children().at(0).hasClass('foo')).to.equal(true);
-        expect(wrapper.children().children().at(1).hasClass('bar')).to.equal(true);
-        expect(wrapper.children().children().at(2).hasClass('baz')).to.equal(true);
+        expect(wrapper.children().length).to.equal(3);
+        expect(wrapper.children().at(0).hasClass('foo')).to.equal(true);
+        expect(wrapper.children().at(1).hasClass('bar')).to.equal(true);
+        expect(wrapper.children().at(2).hasClass('baz')).to.equal(true);
       });
     });
   });
@@ -2194,19 +2194,19 @@ describeWithDOM('mount', () => {
         const Foo = () => <div className="foo bar baz some-long-string FoOo" />;
         const wrapper = mount(<Foo />);
 
-        expect(wrapper.hasClass('foo')).to.equal(false);
-        expect(wrapper.hasClass('bar')).to.equal(false);
-        expect(wrapper.hasClass('baz')).to.equal(false);
-        expect(wrapper.hasClass('some-long-string')).to.equal(false);
-        expect(wrapper.hasClass('FoOo')).to.equal(false);
-        expect(wrapper.hasClass('doesnt-exist')).to.equal(false);
+        expect(wrapper.root().hasClass('foo')).to.equal(false);
+        expect(wrapper.root().hasClass('bar')).to.equal(false);
+        expect(wrapper.root().hasClass('baz')).to.equal(false);
+        expect(wrapper.root().hasClass('some-long-string')).to.equal(false);
+        expect(wrapper.root().hasClass('FoOo')).to.equal(false);
+        expect(wrapper.root().hasClass('doesnt-exist')).to.equal(false);
 
-        expect(wrapper.children().hasClass('foo')).to.equal(true);
-        expect(wrapper.children().hasClass('bar')).to.equal(true);
-        expect(wrapper.children().hasClass('baz')).to.equal(true);
-        expect(wrapper.children().hasClass('some-long-string')).to.equal(true);
-        expect(wrapper.children().hasClass('FoOo')).to.equal(true);
-        expect(wrapper.children().hasClass('doesnt-exist')).to.equal(false);
+        expect(wrapper.hasClass('foo')).to.equal(true);
+        expect(wrapper.hasClass('bar')).to.equal(true);
+        expect(wrapper.hasClass('baz')).to.equal(true);
+        expect(wrapper.hasClass('some-long-string')).to.equal(true);
+        expect(wrapper.hasClass('FoOo')).to.equal(true);
+        expect(wrapper.hasClass('doesnt-exist')).to.equal(false);
       });
     });
 
@@ -2219,19 +2219,19 @@ describeWithDOM('mount', () => {
         }
         const wrapper = mount(<Foo />);
 
-        expect(wrapper.hasClass('foo')).to.equal(false);
-        expect(wrapper.hasClass('bar')).to.equal(false);
-        expect(wrapper.hasClass('baz')).to.equal(false);
-        expect(wrapper.hasClass('some-long-string')).to.equal(false);
-        expect(wrapper.hasClass('FoOo')).to.equal(false);
-        expect(wrapper.hasClass('doesnt-exist')).to.equal(false);
+        expect(wrapper.root().hasClass('foo')).to.equal(false);
+        expect(wrapper.root().hasClass('bar')).to.equal(false);
+        expect(wrapper.root().hasClass('baz')).to.equal(false);
+        expect(wrapper.root().hasClass('some-long-string')).to.equal(false);
+        expect(wrapper.root().hasClass('FoOo')).to.equal(false);
+        expect(wrapper.root().hasClass('doesnt-exist')).to.equal(false);
 
-        expect(wrapper.children().hasClass('foo')).to.equal(true);
-        expect(wrapper.children().hasClass('bar')).to.equal(true);
-        expect(wrapper.children().hasClass('baz')).to.equal(true);
-        expect(wrapper.children().hasClass('some-long-string')).to.equal(true);
-        expect(wrapper.children().hasClass('FoOo')).to.equal(true);
-        expect(wrapper.children().hasClass('doesnt-exist')).to.equal(false);
+        expect(wrapper.hasClass('foo')).to.equal(true);
+        expect(wrapper.hasClass('bar')).to.equal(true);
+        expect(wrapper.hasClass('baz')).to.equal(true);
+        expect(wrapper.hasClass('some-long-string')).to.equal(true);
+        expect(wrapper.hasClass('FoOo')).to.equal(true);
+        expect(wrapper.hasClass('doesnt-exist')).to.equal(false);
       });
     });
 
@@ -2249,21 +2249,21 @@ describeWithDOM('mount', () => {
         }
         const wrapper = mount(<Bar />);
 
+        expect(wrapper.root().hasClass('foo')).to.equal(false);
+        expect(wrapper.root().hasClass('bar')).to.equal(false);
+        expect(wrapper.root().hasClass('baz')).to.equal(false);
+        expect(wrapper.root().hasClass('some-long-string')).to.equal(false);
+        expect(wrapper.root().hasClass('FoOo')).to.equal(false);
+        expect(wrapper.root().hasClass('doesnt-exist')).to.equal(false);
+
+        // NOTE(lmr): the fact that this no longer works is a semantically
+        // meaningfull deviation in behavior. But this will be remedied with the ".root()" change
         expect(wrapper.hasClass('foo')).to.equal(false);
         expect(wrapper.hasClass('bar')).to.equal(false);
         expect(wrapper.hasClass('baz')).to.equal(false);
         expect(wrapper.hasClass('some-long-string')).to.equal(false);
         expect(wrapper.hasClass('FoOo')).to.equal(false);
         expect(wrapper.hasClass('doesnt-exist')).to.equal(false);
-
-        // NOTE(lmr): the fact that this no longer works is a semantically
-        // meaningfull deviation in behavior. But this will be remedied with the ".root()" change
-        expect(wrapper.children().hasClass('foo')).to.equal(false);
-        expect(wrapper.children().hasClass('bar')).to.equal(false);
-        expect(wrapper.children().hasClass('baz')).to.equal(false);
-        expect(wrapper.children().hasClass('some-long-string')).to.equal(false);
-        expect(wrapper.children().hasClass('FoOo')).to.equal(false);
-        expect(wrapper.children().hasClass('doesnt-exist')).to.equal(false);
       });
     });
 
@@ -2554,7 +2554,7 @@ describeWithDOM('mount', () => {
           <div className="foo" />
         </div>,
       );
-      expect(() => wrapper.some('.foo')).to.throw(
+      expect(() => wrapper.root().some('.foo')).to.throw(
         Error,
         'ReactWrapper::some() can not be called on the root',
       );
@@ -2763,11 +2763,11 @@ describeWithDOM('mount', () => {
       // the public API of enzyme is to just return what `this.refs[refName]` would be expected
       // to return for the version of react you're using.
       if (REACT013 || REACT014) {
-        expect(wrapper.ref('secondRef').getDOMNode().getAttribute('data-amount')).to.equal('4');
-        expect(wrapper.ref('secondRef').getDOMNode().textContent).to.equal('Second');
+        expect(wrapper.root().ref('secondRef').getDOMNode().getAttribute('data-amount')).to.equal('4');
+        expect(wrapper.root().ref('secondRef').getDOMNode().textContent).to.equal('Second');
       } else {
-        expect(wrapper.ref('secondRef').getAttribute('data-amount')).to.equal('4');
-        expect(wrapper.ref('secondRef').textContent).to.equal('Second');
+        expect(wrapper.root().ref('secondRef').getAttribute('data-amount')).to.equal('4');
+        expect(wrapper.root().ref('secondRef').textContent).to.equal('Second');
       }
     });
   });
@@ -2899,7 +2899,7 @@ describeWithDOM('mount', () => {
       expect(document.body.childNodes).to.have.length(initialBodyChildren + 1);
       expect(div.childNodes).to.have.length(1);
 
-      wrapper.detach();
+      wrapper.root().detach();
 
       expect(document.body.childNodes).to.have.length(initialBodyChildren + 1);
       expect(div.childNodes).to.have.length(0);
@@ -2936,7 +2936,7 @@ describeWithDOM('mount', () => {
       expect(document.body.childNodes).to.have.length(initialBodyChildren + 1);
       expect(div.childNodes).to.have.length(1);
 
-      wrapper.detach();
+      wrapper.root().detach();
 
       wrapper = mount(<Bar />, { attachTo: div });
 
@@ -2944,7 +2944,7 @@ describeWithDOM('mount', () => {
       expect(document.body.childNodes).to.have.length(initialBodyChildren + 1);
       expect(div.childNodes).to.have.length(1);
 
-      wrapper.detach();
+      wrapper.root().detach();
 
       expect(document.body.childNodes).to.have.length(initialBodyChildren + 1);
       expect(div.childNodes).to.have.length(0);
@@ -2966,7 +2966,7 @@ describeWithDOM('mount', () => {
       expect(wrapper.find('.in-bar')).to.have.length(1);
       expect(document.body.childNodes).to.have.length(1);
 
-      wrapper.detach();
+      wrapper.root().detach();
 
       expect(document.body.childNodes).to.have.length(0);
     });
@@ -2980,7 +2980,7 @@ describeWithDOM('mount', () => {
     }
     const wrapper = mount(<Foo />);
     expect(wrapper).to.have.length(1);
-    expect(wrapper.type()).to.equal(Foo);
+    expect(wrapper.root().type()).to.equal(Foo);
     expect(wrapper.html()).to.equal(null);
     const rendered = wrapper.render();
     expect(rendered.length).to.equal(0);
@@ -2992,7 +2992,7 @@ describeWithDOM('mount', () => {
 
     const wrapper = mount(<Foo />);
     expect(wrapper).to.have.length(1);
-    expect(wrapper.type()).to.equal(Foo);
+    expect(wrapper.root().type()).to.equal(Foo);
     expect(wrapper.html()).to.equal(null);
     const rendered = wrapper.render();
     expect(rendered.length).to.equal(0);
@@ -3082,7 +3082,7 @@ describeWithDOM('mount', () => {
         expect(document.body.childNodes).to.have.length(initialBodyChildren + 1);
         expect(div.childNodes).to.have.length(1);
 
-        wrapper.detach();
+        wrapper.root().detach();
 
         expect(document.body.childNodes).to.have.length(initialBodyChildren + 1);
         expect(div.childNodes).to.have.length(0);
@@ -3111,7 +3111,7 @@ describeWithDOM('mount', () => {
         expect(document.body.childNodes).to.have.length(initialBodyChildren + 1);
         expect(div.childNodes).to.have.length(1);
 
-        wrapper.detach();
+        wrapper.root().detach();
 
         wrapper = mount(<Bar />, { attachTo: div });
 
@@ -3119,7 +3119,7 @@ describeWithDOM('mount', () => {
         expect(document.body.childNodes).to.have.length(initialBodyChildren + 1);
         expect(div.childNodes).to.have.length(1);
 
-        wrapper.detach();
+        wrapper.root().detach();
 
         expect(document.body.childNodes).to.have.length(initialBodyChildren + 1);
         expect(div.childNodes).to.have.length(0);
@@ -3138,7 +3138,7 @@ describeWithDOM('mount', () => {
         expect(wrapper.find('.in-bar')).to.have.length(1);
         expect(document.body.childNodes).to.have.length(1);
 
-        wrapper.detach();
+        wrapper.root().detach();
 
         expect(document.body.childNodes).to.have.length(0);
       });
@@ -3437,7 +3437,7 @@ describeWithDOM('mount', () => {
         Foo.displayName = 'CustomWrapper';
 
         const wrapper = mount(<Foo />);
-        expect(wrapper.name()).to.equal('CustomWrapper');
+        expect(wrapper.root().name()).to.equal('CustomWrapper');
       });
 
       describeIf(!REACT013, 'stateless function components', () => {
@@ -3449,7 +3449,7 @@ describeWithDOM('mount', () => {
           SFC.displayName = 'CustomWrapper';
 
           const wrapper = mount(<SFC />);
-          expect(wrapper.name()).to.equal('CustomWrapper');
+          expect(wrapper.root().name()).to.equal('CustomWrapper');
         });
       });
 
@@ -3463,7 +3463,7 @@ describeWithDOM('mount', () => {
           });
 
           const wrapper = mount(<Foo />);
-          expect(wrapper.name()).to.equal('CustomWrapper');
+          expect(wrapper.root().name()).to.equal('CustomWrapper');
         });
       });
     });
@@ -3475,7 +3475,7 @@ describeWithDOM('mount', () => {
         }
 
         const wrapper = mount(<Foo />);
-        expect(wrapper.name()).to.equal('Foo');
+        expect(wrapper.root().name()).to.equal('Foo');
       });
 
       describeIf(!REACT013, 'stateless function components', () => {
@@ -3485,7 +3485,7 @@ describeWithDOM('mount', () => {
           }
 
           const wrapper = mount(<SFC />);
-          expect(wrapper.name()).to.equal('SFC');
+          expect(wrapper.root().name()).to.equal('SFC');
         });
       });
     });
@@ -3493,7 +3493,7 @@ describeWithDOM('mount', () => {
     describe('DOM node', () => {
       it('should return the name of the node', () => {
         const wrapper = mount(<div />);
-        expect(wrapper.name()).to.equal('div');
+        expect(wrapper.root().name()).to.equal('div');
       });
     });
 
@@ -3503,7 +3503,7 @@ describeWithDOM('mount', () => {
           render() { return <div />; }
         }
         const wrapper = mount(<WithoutRef />);
-        const ref = wrapper.ref('not-a-ref');
+        const ref = wrapper.root().ref('not-a-ref');
 
         expect(ref).to.equal(undefined);
       });
@@ -3551,7 +3551,7 @@ describeWithDOM('mount', () => {
 
     it('should return the wrapped component instance', () => {
       const wrapper = mount(<Test />);
-      expect(wrapper.instance()).to.be.an.instanceof(Test);
+      expect(wrapper.root().instance()).to.be.an.instanceof(Test);
     });
 
     it('should throw when wrapping multiple elements', () => {

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -39,7 +39,7 @@ describe('shallow', () => {
 
       expect(wrapper.type()).to.equal(Box);
       expect(wrapper.props().bam).to.equal(true);
-      expect(wrapper.instance()).to.be.instanceOf(Foo);
+      expect(wrapper.root().instance()).to.be.instanceOf(Foo);
       expect(wrapper.children().at(0).type()).to.equal('div');
       expect(wrapper.find(Box).children().props().className).to.equal('div');
       expect(wrapper.find(Box).children().at(0).props().className).to.equal('div');
@@ -89,8 +89,8 @@ describe('shallow', () => {
       const context = { name: 'foo' };
       const wrapper = shallow(<SimpleComponent />, { context });
 
-      expect(wrapper.context().name).to.equal(context.name);
-      expect(wrapper.context('name')).to.equal(context.name);
+      expect(wrapper.root().context().name).to.equal(context.name);
+      expect(wrapper.root().context('name')).to.equal(context.name);
     });
 
     describeIf(!REACT013, 'stateless function components', () => {
@@ -122,8 +122,8 @@ describe('shallow', () => {
 
         const wrapper = shallow(<SimpleComponent />, { context });
 
-        expect(wrapper.context().name).to.equal(context.name);
-        expect(wrapper.context('name')).to.equal(context.name);
+        expect(wrapper.root().context().name).to.equal(context.name);
+        expect(wrapper.root().context('name')).to.equal(context.name);
       });
 
       itIf(REACT16, 'is not introspectable through context API', () => {
@@ -134,11 +134,11 @@ describe('shallow', () => {
 
         const wrapper = shallow(<SimpleComponent />, { context });
 
-        expect(() => wrapper.context()).to.throw(
+        expect(() => wrapper.root().context()).to.throw(
           Error,
           'ShallowWrapper::context() can only be called on wrapped nodes that have a non-null instance',
         );
-        expect(() => wrapper.context('name')).to.throw(
+        expect(() => wrapper.root().context('name')).to.throw(
           Error,
           'ShallowWrapper::context() can only be called on wrapped nodes that have a non-null instance',
         );
@@ -168,8 +168,8 @@ describe('shallow', () => {
       }
 
       const wrapper = shallow(<Foo />);
-      expect(wrapper.instance()).to.be.instanceof(Foo);
-      expect(wrapper.instance().render).to.equal(Foo.prototype.render);
+      expect(wrapper.root().instance()).to.be.instanceof(Foo);
+      expect(wrapper.root().instance().render).to.equal(Foo.prototype.render);
     });
 
     it('should throw if called on something other than the root node', () => {
@@ -887,7 +887,7 @@ describe('shallow', () => {
       }
       const wrapper = shallow(<Foo id="foo" />);
       expect(wrapper.find('.foo').length).to.equal(1);
-      wrapper.setProps({ id: 'bar', foo: 'bla' });
+      wrapper.root().setProps({ id: 'bar', foo: 'bla' });
       expect(wrapper.find('.bar').length).to.equal(1);
     });
 
@@ -911,7 +911,7 @@ describe('shallow', () => {
       const nextProps = { id: 'bar', foo: 'bla' };
       const wrapper = shallow(<Foo id="foo" />);
       expect(spy.calledOnce).to.equal(false);
-      wrapper.setProps(nextProps);
+      wrapper.root().setProps(nextProps);
       expect(spy.calledOnce).to.equal(true);
       expect(spy.calledWith(nextProps)).to.equal(true);
     });
@@ -936,7 +936,7 @@ describe('shallow', () => {
       expect(wrapper.props().a).to.equal('a');
       expect(wrapper.props().b).to.equal('b');
 
-      wrapper.setProps({ b: 'c', d: 'e' });
+      wrapper.root().setProps({ b: 'c', d: 'e' });
       expect(wrapper.props().a).to.equal('a');
       expect(wrapper.props().b).to.equal('c');
       expect(wrapper.props().d).to.equal('e');
@@ -957,7 +957,7 @@ describe('shallow', () => {
       const wrapper = shallow(<Foo x={5} />, { context });
       expect(wrapper.first('div').text()).to.equal('yolo');
 
-      wrapper.setProps({ x: 5 }); // Just force a re-render
+      wrapper.root().setProps({ x: 5 }); // Just force a re-render
       expect(wrapper.first('div').text()).to.equal('yolo');
     });
 
@@ -984,7 +984,7 @@ describe('shallow', () => {
 
       const wrapper = shallow(<Foo a="a" b="b" />);
 
-      wrapper.setProps({ b: 'c', d: 'e' });
+      wrapper.root().setProps({ b: 'c', d: 'e' });
 
       expect(spy.args).to.deep.equal([
         [
@@ -1015,7 +1015,7 @@ describe('shallow', () => {
 
         const wrapper = shallow(<Foo id="foo" />);
         expect(wrapper.find('.foo').length).to.equal(1);
-        wrapper.setProps({ id: 'bar', foo: 'bla' });
+        wrapper.root().setProps({ id: 'bar', foo: 'bla' });
         expect(wrapper.find('.bar').length).to.equal(1);
       });
 
@@ -1031,7 +1031,7 @@ describe('shallow', () => {
         expect(wrapper.props().a).to.equal('a');
         expect(wrapper.props().b).to.equal('b');
 
-        wrapper.setProps({ b: 'c', d: 'e' });
+        wrapper.root().setProps({ b: 'c', d: 'e' });
         expect(wrapper.props().a).to.equal('a');
         expect(wrapper.props().b).to.equal('c');
         expect(wrapper.props().d).to.equal('e');
@@ -1047,7 +1047,7 @@ describe('shallow', () => {
         const wrapper = shallow(<Foo x={5} />, { context });
         expect(wrapper.first('div').text()).to.equal('yolo');
 
-        wrapper.setProps({ x: 5 }); // Just force a re-render
+        wrapper.root().setProps({ x: 5 }); // Just force a re-render
         expect(wrapper.first('div').text()).to.equal('yolo');
       });
     });
@@ -1067,15 +1067,15 @@ describe('shallow', () => {
       const context = { name: 'foo' };
       const wrapper = shallow(<SimpleComponent />, { context });
       expect(wrapper.text()).to.equal('foo');
-      wrapper.setContext({ name: 'bar' });
+      wrapper.root().setContext({ name: 'bar' });
       expect(wrapper.text()).to.equal('bar');
-      wrapper.setContext({ name: 'baz' });
+      wrapper.root().setContext({ name: 'baz' });
       expect(wrapper.text()).to.equal('baz');
     });
 
     it('should throw if it is called when shallow didn’t include context', () => {
       const wrapper = shallow(<SimpleComponent />);
-      expect(() => wrapper.setContext({ name: 'bar' })).to.throw(
+      expect(() => wrapper.root().setContext({ name: 'bar' })).to.throw(
         Error,
         'ShallowWrapper::setContext() can only be called on a wrapper that was originally passed a context option', // eslint-disable-line max-len
       );
@@ -1091,15 +1091,15 @@ describe('shallow', () => {
         const context = { name: 'foo' };
         const wrapper = shallow(<SFC />, { context });
         expect(wrapper.text()).to.equal('foo');
-        wrapper.setContext({ name: 'bar' });
+        wrapper.root().setContext({ name: 'bar' });
         expect(wrapper.text()).to.equal('bar');
-        wrapper.setContext({ name: 'baz' });
+        wrapper.root().setContext({ name: 'baz' });
         expect(wrapper.text()).to.equal('baz');
       });
 
       it('should throw if it is called when shallow didn’t include context', () => {
         const wrapper = shallow(<SFC />);
-        expect(() => wrapper.setContext({ name: 'bar' })).to.throw(
+        expect(() => wrapper.root().setContext({ name: 'bar' })).to.throw(
           Error,
           'ShallowWrapper::setContext() can only be called on a wrapper that was originally passed a context option', // eslint-disable-line max-len
         );
@@ -1285,7 +1285,7 @@ describe('shallow', () => {
       }
       const wrapper = shallow(<Foo />);
       expect(wrapper.find('.foo').length).to.equal(1);
-      wrapper.setState({ id: 'bar' });
+      wrapper.root().setState({ id: 'bar' });
       expect(wrapper.find('.bar').length).to.equal(1);
     });
 
@@ -1302,9 +1302,9 @@ describe('shallow', () => {
         }
       }
       const wrapper = shallow(<Foo />);
-      expect(wrapper.state()).to.eql({ id: 'foo' });
-      wrapper.setState({ id: 'bar' }, () => {
-        expect(wrapper.state()).to.eql({ id: 'bar' });
+      expect(wrapper.root().state()).to.eql({ id: 'foo' });
+      wrapper.root().setState({ id: 'bar' }, () => {
+        expect(wrapper.root().state()).to.eql({ id: 'bar' });
       });
     });
 
@@ -1316,7 +1316,7 @@ describe('shallow', () => {
 
         const wrapper = shallow(<Foo />);
 
-        expect(() => wrapper.state()).to.throw(
+        expect(() => wrapper.root().state()).to.throw(
           Error,
           'ShallowWrapper::state() can only be called on class components',
         );
@@ -1329,7 +1329,7 @@ describe('shallow', () => {
 
         const wrapper = shallow(<Foo />);
 
-        expect(() => wrapper.setState({ a: 1 })).to.throw(
+        expect(() => wrapper.root().setState({ a: 1 })).to.throw(
           Error,
           'ShallowWrapper::setState() can only be called on class components',
         );
@@ -1722,7 +1722,7 @@ describe('shallow', () => {
         render() { return <div />; }
       }
       const wrapper = shallow(<Foo />);
-      expect(wrapper.state()).to.eql({ foo: 'foo' });
+      expect(wrapper.root().state()).to.eql({ foo: 'foo' });
     });
 
     it('should return the current state after state transitions', () => {
@@ -1734,8 +1734,8 @@ describe('shallow', () => {
         render() { return <div />; }
       }
       const wrapper = shallow(<Foo />);
-      wrapper.setState({ foo: 'bar' });
-      expect(wrapper.state()).to.eql({ foo: 'bar' });
+      wrapper.root().setState({ foo: 'bar' });
+      expect(wrapper.root().state()).to.eql({ foo: 'bar' });
     });
 
     it('should allow a state property name be passed in as an argument', () => {
@@ -1747,7 +1747,7 @@ describe('shallow', () => {
         render() { return <div />; }
       }
       const wrapper = shallow(<Foo />);
-      expect(wrapper.state('foo')).to.equal('foo');
+      expect(wrapper.root().state('foo')).to.equal('foo');
     });
   });
 
@@ -2342,7 +2342,7 @@ describe('shallow', () => {
           <div className="foo" />
         </div>,
       );
-      expect(() => wrapper.some('.foo')).to.throw(
+      expect(() => wrapper.root().some('.foo')).to.throw(
         Error,
         'ShallowWrapper::some() can not be called on the root',
       );
@@ -2520,8 +2520,8 @@ describe('shallow', () => {
         const context = { name: 'foo' };
         const wrapper = shallow(<Foo />).find(Bar).shallow({ context });
 
-        expect(wrapper.context().name).to.equal(context.name);
-        expect(wrapper.context('name')).to.equal(context.name);
+        expect(wrapper.root().context().name).to.equal(context.name);
+        expect(wrapper.root().context('name')).to.equal(context.name);
       });
     });
 
@@ -2590,8 +2590,8 @@ describe('shallow', () => {
           const context = { name: 'foo' };
           const wrapper = shallow(<Foo />).find(Bar).shallow({ context });
 
-          expect(wrapper.context().name).to.equal(context.name);
-          expect(wrapper.context('name')).to.equal(context.name);
+          expect(wrapper.root().context().name).to.equal(context.name);
+          expect(wrapper.root().context('name')).to.equal(context.name);
         });
 
         itIf(REACT16, 'will throw when trying to inspect context', () => {
@@ -2608,11 +2608,11 @@ describe('shallow', () => {
           const context = { name: 'foo' };
           const wrapper = shallow(<Foo />).find(Bar).shallow({ context });
 
-          expect(() => wrapper.context()).to.throw(
+          expect(() => wrapper.root().context()).to.throw(
             Error,
             'ShallowWrapper::context() can only be called on wrapped nodes that have a non-null instance',
           );
-          expect(() => wrapper.context('name')).to.throw(
+          expect(() => wrapper.root().context('name')).to.throw(
             Error,
             'ShallowWrapper::context() can only be called on wrapped nodes that have a non-null instance',
           );
@@ -2952,7 +2952,7 @@ describe('shallow', () => {
       });
 
       it('calls expected methods when receiving new props', () => {
-        wrapper.setProps({ foo: 'foo' });
+        wrapper.root().setProps({ foo: 'foo' });
         expect(spy.args).to.deep.equal([
           ['componentWillReceiveProps'],
           ['shouldComponentUpdate'],
@@ -2963,7 +2963,7 @@ describe('shallow', () => {
 
       describeIf(!REACT014 && !REACT16, 'setContext', () => {
         it('calls expected methods when receiving new context', () => {
-          wrapper.setContext({ foo: 'foo' });
+          wrapper.root().setContext({ foo: 'foo' });
           expect(spy.args).to.deep.equal([
             ['componentWillReceiveProps'],
             ['shouldComponentUpdate'],
@@ -2975,7 +2975,7 @@ describe('shallow', () => {
 
       describeIf(REACT16, 'setContext', () => {
         it('calls expected methods when receiving new context', () => {
-          wrapper.setContext({ foo: 'foo' });
+          wrapper.root().setContext({ foo: 'foo' });
           expect(spy.args).to.deep.equal([
             ['shouldComponentUpdate'],
             ['componentWillUpdate'],
@@ -2986,7 +2986,7 @@ describe('shallow', () => {
 
       describeIf(REACT014, 'setContext', () => {
         it('calls expected methods when receiving new context', () => {
-          wrapper.setContext({ foo: 'foo' });
+          wrapper.root().setContext({ foo: 'foo' });
           expect(spy.args).to.deep.equal([
             ['shouldComponentUpdate'],
             ['componentWillUpdate'],
@@ -2996,7 +2996,7 @@ describe('shallow', () => {
       });
 
       itIf(!REACT16, 'calls expected methods for setState', () => {
-        wrapper.setState({ bar: 'bar' });
+        wrapper.root().setState({ bar: 'bar' });
         expect(spy.args).to.deep.equal([
           ['shouldComponentUpdate'],
           ['componentWillUpdate'],
@@ -3007,7 +3007,7 @@ describe('shallow', () => {
 
       // componentDidUpdate does not seem to get called in react 16 beta.
       itIf(REACT16, 'calls expected methods for setState', () => {
-        wrapper.setState({ bar: 'bar' });
+        wrapper.root().setState({ bar: 'bar' });
         expect(spy.args).to.deep.equal([
           ['shouldComponentUpdate'],
           ['componentWillUpdate'],
@@ -3134,8 +3134,8 @@ describe('shallow', () => {
             lifecycleExperimental: true,
           },
         );
-        wrapper.setProps({ foo: 'baz' });
-        wrapper.setProps({ foo: 'bax' });
+        wrapper.root().setProps({ foo: 'baz' });
+        wrapper.root().setProps({ foo: 'bax' });
         expect(spy.args).to.deep.equal(
           [
             [
@@ -3223,7 +3223,7 @@ describe('shallow', () => {
 
         const wrapper = shallow(<Foo a="a" b="b" />, { lifecycleExperimental: true });
 
-        wrapper.setProps({ b: 'c', d: 'e' });
+        wrapper.root().setProps({ b: 'c', d: 'e' });
 
         expect(spy.args).to.deep.equal([
           [
@@ -3273,11 +3273,11 @@ describe('shallow', () => {
         }
 
         const wrapper = shallow(<Foo foo="bar" />, { lifecycleExperimental: true });
-        expect(wrapper.instance().props.foo).to.equal('bar');
-        wrapper.setProps({ foo: 'baz' });
-        expect(wrapper.instance().props.foo).to.equal('baz');
-        wrapper.setProps({ foo: 'bax' });
-        expect(wrapper.instance().props.foo).to.equal('bax');
+        expect(wrapper.root().instance().props.foo).to.equal('bar');
+        wrapper.root().setProps({ foo: 'baz' });
+        expect(wrapper.root().instance().props.foo).to.equal('baz');
+        wrapper.root().setProps({ foo: 'bax' });
+        expect(wrapper.root().instance().props.foo).to.equal('bax');
         expect(spy.args).to.deep.equal([
           ['render'],
           ['componentWillReceiveProps'],
@@ -3412,7 +3412,7 @@ describe('shallow', () => {
             lifecycleExperimental: true,
           },
         );
-        wrapper.setState({ foo: 'baz' });
+        wrapper.root().setState({ foo: 'baz' });
         expect(spy.args).to.deep.equal([
           [
             'render',
@@ -3466,9 +3466,9 @@ describe('shallow', () => {
           }
         }
         const wrapper = shallow(<Foo />, { lifecycleExperimental: true });
-        expect(wrapper.instance().state.foo).to.equal('bar');
-        wrapper.setState({ foo: 'baz' });
-        expect(wrapper.instance().state.foo).to.equal('baz');
+        expect(wrapper.root().instance().state.foo).to.equal('bar');
+        wrapper.root().setState({ foo: 'baz' });
+        expect(wrapper.root().instance().state.foo).to.equal('baz');
         expect(spy.args).to.deep.equal([['render'], ['shouldComponentUpdate']]);
       });
 
@@ -3570,9 +3570,9 @@ describe('shallow', () => {
             lifecycleExperimental: true,
           },
         );
-        expect(wrapper.instance().context.foo).to.equal('bar');
-        wrapper.setContext({ foo: 'baz' });
-        expect(wrapper.instance().context.foo).to.equal('baz');
+        expect(wrapper.root().instance().context.foo).to.equal('bar');
+        wrapper.root().setContext({ foo: 'baz' });
+        expect(wrapper.root().instance().context.foo).to.equal('baz');
         expect(spy.args).to.deep.equal([
           [
             'render',
@@ -3629,7 +3629,7 @@ describe('shallow', () => {
             lifecycleExperimental: true,
           },
         );
-        wrapper.setContext({ foo: 'baz' });
+        wrapper.root().setContext({ foo: 'baz' });
         expect(spy.args).to.deep.equal([['render'], ['shouldComponentUpdate']]);
       });
 
@@ -3663,7 +3663,7 @@ describe('shallow', () => {
           },
         );
         expect(spy).to.have.property('callCount', 1);
-        result.setContext({ foo: 'baz' });
+        result.root().setContext({ foo: 'baz' });
         expect(spy).to.have.property('callCount', 3);
         expect(result.state('count')).to.equal(1);
       });
@@ -3700,7 +3700,7 @@ describe('shallow', () => {
           },
         );
         expect(spy).to.have.property('callCount', 1);
-        result.setContext({ foo: 'baz' });
+        result.root().setContext({ foo: 'baz' });
         expect(spy).to.have.property('callCount', 3);
         expect(result.state('count')).to.equal(1);
       });
@@ -3762,11 +3762,11 @@ describe('shallow', () => {
         },
       );
       expect(spy).to.have.property('callCount', 0);
-      wrapper.setProps({ foo: 'bar' });
+      wrapper.root().setProps({ foo: 'bar' });
       expect(spy).to.have.property('callCount', 1);
-      wrapper.setState({ foo: 'bar' });
+      wrapper.root().setState({ foo: 'bar' });
       expect(spy).to.have.property('callCount', 2);
-      wrapper.setContext({ foo: 'bar' });
+      wrapper.root().setContext({ foo: 'bar' });
       expect(spy).to.have.property('callCount', 3);
     });
   });
@@ -4327,13 +4327,13 @@ describe('shallow', () => {
 
     it('should merge and pass options through', () => {
       const wrapper = shallow(<ContextWrapsRendersDOM />, { context: { foo: 'hello' } });
-      expect(wrapper.context()).to.deep.equal({ foo: 'hello' });
+      expect(wrapper.root().context()).to.deep.equal({ foo: 'hello' });
 
       let underwater = wrapper.dive();
-      expect(underwater.context()).to.deep.equal({ foo: 'hello' });
+      expect(underwater.root().context()).to.deep.equal({ foo: 'hello' });
 
       underwater = wrapper.dive({ context: { foo: 'enzyme!' } });
-      expect(underwater.context()).to.deep.equal({ foo: 'enzyme!' });
+      expect(underwater.root().context()).to.deep.equal({ foo: 'enzyme!' });
     });
   });
 
@@ -4428,7 +4428,7 @@ describe('shallow', () => {
       const wrapper = shallow(<Test />);
       wrapper.find('.async-btn').simulate('click');
       setImmediate(() => {
-        wrapper.update();
+        wrapper.root().update();
         expect(wrapper.find('.show-me').length).to.equal(1);
         done();
       });
@@ -4437,7 +4437,7 @@ describe('shallow', () => {
     it('should have updated output after child prop callback invokes setState', () => {
       const wrapper = shallow(<Test />);
       wrapper.find(Child).props().callback();
-      wrapper.update();
+      wrapper.root().update();
       expect(wrapper.find('.show-me').length).to.equal(1);
     });
   });

--- a/packages/enzyme/src/ReactWrapper.js
+++ b/packages/enzyme/src/ReactWrapper.js
@@ -99,10 +99,6 @@ class ReactWrapper {
       const renderer = getAdapter(options).createRenderer({ mode: 'mount', ...options });
       privateSet(this, RENDERER, renderer);
       renderer.render(nodes, options.context);
-      // privateSet(this, ROOT, this);
-      // const node = this[RENDERER].getNode();
-      // privateSet(this, NODE, node);
-      // privateSet(this, NODES, [node]);
       privateSet(this, OPTIONS, options);
       privateSet(this, ROOT, new ReactWrapper(null, this, options, true));
       this.length = 1;
@@ -1109,7 +1105,6 @@ function privateWarning(prop, extraMessage) {
 privateWarning('node', 'Consider using the getElement() method instead.');
 privateWarning('nodes', 'Consider using the getElements() method instead.');
 privateWarning('renderer', '');
-// privateWarning('root', '');
 privateWarning('options', '');
 privateWarning('complexSelector', '');
 

--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -140,8 +140,8 @@ class ShallowWrapper {
           instance.componentDidMount();
         });
       }
-      privateSet(this, NODE, getRootNode(this[RENDERER].getNode()));
-      privateSet(this, NODES, [this[NODE]]);
+      // privateSet(this, NODE, getRootNode(this[RENDERER].getNode()));
+      // privateSet(this, NODES, [this[NODE]]);
       privateSet(this, OPTIONS, options);
       privateSet(this, ROOT, new ShallowWrapper(null, this, options, true));
       this.length = 1;

--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -140,8 +140,6 @@ class ShallowWrapper {
           instance.componentDidMount();
         });
       }
-      // privateSet(this, NODE, getRootNode(this[RENDERER].getNode()));
-      // privateSet(this, NODES, [this[NODE]]);
       privateSet(this, OPTIONS, options);
       privateSet(this, ROOT, new ShallowWrapper(null, this, options, true));
       this.length = 1;
@@ -1212,7 +1210,6 @@ function privateWarning(prop, extraMessage) {
 privateWarning('node', 'Consider using the getElement() method instead.');
 privateWarning('nodes', 'Consider using the getElements() method instead.');
 privateWarning('renderer', '');
-// privateWarning('root', '');
 privateWarning('options', '');
 privateWarning('complexSelector', '');
 


### PR DESCRIPTION
to: @ljharb 

This PR updates both `mount()` and `shallow()` to have similar semantics with respect to what the wrapper that is returned by them.

The idea is that `mount(<Foo />)` and `shallow(<Foo />)` both return a wrapper that's around the *node that Foo rendered*, and not `<Foo />` itself. This means that calling `.type()` and `.instance()` on the resulting wrapper will not return `Foo` and an instance of `Foo`, but the type and instance of the root node returned by it's render function.

Additionally, calling `.root()` on the wrapper will return a new wrapper that *is around the node of `<Foo />`*. Calling `.type()` on this wrapper will return `Foo` and `.instance()` will return the `Foo` component instance.

This is a huge breaking change, and i'm not convinced that this is the right API. But putting up this PR for comments.