### PR TITLE
Fixed #762: Improved shallow options documentation

### DIFF
--- a/docs/api/ShallowWrapper/shallow.md
+++ b/docs/api/ShallowWrapper/shallow.md
@@ -8,7 +8,10 @@ NOTE: can only be called on wrapper of a single node.
 #### Arguments
 
 1. `options` (`Object` [optional]):
-- `options.context`: (`Object` [optional]): Context to be passed into the component
+  - `options.context`: (`Object` [optional]): Context to be passed into the component
+  - `options.disableLifecycleMethods`: (`Boolean` [optional]): If set to true, `componentDidMount`
+is not called on the component, and `componentDidUpdate` is not called after
+[`setProps`](ShallowWrapper/setProps.md) and [`setContext`](ShallowWrapper/setContext.md). Default to `false`.
 
 
 


### PR DESCRIPTION
Fixes #762:

Added details of the following `options` parameters for `shallow` API:

- `disableLifecycleMethods`
- `lifecycleExperimental`

This should update the GitBook html documentation to include all available options:
http://airbnb.io/enzyme/docs/api/ShallowWrapper/shallow.html