### PR TITLE
Move adapter 15 to react-test-renderer

### DIFF
--- a/packages/enzyme-adapter-react-15/package.json
+++ b/packages/enzyme-adapter-react-15/package.json
@@ -40,7 +40,8 @@
   "peerDependencies": {
     "enzyme": "^3.0.0-beta.2",
     "react": "^15.5.0",
-    "react-dom": "^15.5.0"
+    "react-dom": "^15.5.0",
+    "react-test-renderer": "^15.5.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/packages/enzyme-adapter-react-15/src/ReactFifteenAdapter.js
+++ b/packages/enzyme-adapter-react-15/src/ReactFifteenAdapter.js
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom';
 import ReactDOMServer from 'react-dom/server';
 // eslint-disable-next-line import/no-unresolved, import/extensions
 import TestUtils from 'react-dom/test-utils';
+import ShallowRenderer from 'react-test-renderer/shallow';
 import values from 'object.values';
 import { EnzymeAdapter } from 'enzyme';
 import {
@@ -119,7 +120,7 @@ class ReactFifteenAdapter extends EnzymeAdapter {
   }
 
   createShallowRenderer(/* options */) {
-    const renderer = TestUtils.createRenderer();
+    const renderer = new ShallowRenderer();
     let isDOM = false;
     let cachedNode = null;
     return {


### PR DESCRIPTION
This PR moves the enzyme-adapter-react-15 package from the "test utils" shallow renderer to the "react-test-renderer" shallow renderer. I believe this is running essentially the same exact code, but will not trigger a console.error when used.  I'm not sure how I missed this earlier.