### PR TITLE
Remove Karma flakiness by providing browser shims

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,6 @@ matrix:
      env: KARMA=true REACT=15
    - node_js: "6"
      env: KARMA=true REACT=16
-  allow_failures:
-    - node_js: "6"
-      env: KARMA=true REACT=16
 env:
   - REACT=0.13
   - REACT=0.14

--- a/packages/enzyme-test-suite/package.json
+++ b/packages/enzyme-test-suite/package.json
@@ -33,7 +33,8 @@
     "enzyme-adapter-utils": "^1.0.0-beta.2",
     "prop-types": "^15.5.10",
     "semver": "^5.4.1",
-    "sinon": "^2.4.1"
+    "sinon": "^2.4.1",
+    "airbnb-browser-shims": "^1.12.0"
   },
   "peerDependencies": {
     "react": "^15.5.0"

--- a/packages/enzyme-test-suite/test/Adapter-spec.jsx
+++ b/packages/enzyme-test-suite/test/Adapter-spec.jsx
@@ -1,4 +1,4 @@
-import './_helpers/setupAdapters';
+import './_helpers/setup';
 import React from 'react';
 import { expect } from 'chai';
 

--- a/packages/enzyme-test-suite/test/Debug-spec.jsx
+++ b/packages/enzyme-test-suite/test/Debug-spec.jsx
@@ -1,4 +1,4 @@
-import './_helpers/setupAdapters';
+import './_helpers/setup';
 import { expect } from 'chai';
 import React from 'react';
 import {

--- a/packages/enzyme-test-suite/test/RSTTraversal-spec.jsx
+++ b/packages/enzyme-test-suite/test/RSTTraversal-spec.jsx
@@ -1,4 +1,4 @@
-import './_helpers/setupAdapters';
+import './_helpers/setup';
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';

--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -1,5 +1,5 @@
 /* globals document */
-import './_helpers/setupAdapters';
+import './_helpers/setup';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -1,4 +1,4 @@
-import './_helpers/setupAdapters';
+import './_helpers/setup';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';

--- a/packages/enzyme-test-suite/test/Utils-spec.jsx
+++ b/packages/enzyme-test-suite/test/Utils-spec.jsx
@@ -1,4 +1,4 @@
-import './_helpers/setupAdapters';
+import './_helpers/setup';
 import React from 'react';
 import { expect } from 'chai';
 

--- a/packages/enzyme-test-suite/test/_helpers/setup.js
+++ b/packages/enzyme-test-suite/test/_helpers/setup.js
@@ -1,0 +1,2 @@
+import './setupShims';
+import './setupAdapters';

--- a/packages/enzyme-test-suite/test/_helpers/setupShims.js
+++ b/packages/enzyme-test-suite/test/_helpers/setupShims.js
@@ -1,0 +1,15 @@
+/* eslint no-undef: 0, global-require: 0 */
+/**
+ * This file is needed only when karma runs the test suite. We can't guarantee
+ * what browser travis will actually run karma with, so we need to load in
+ * browser shims to make sure everything works that we expect. I'd love to
+ * put this somewhere else (ie, karma.conf.js), but I can't figure out how
+ * to tell karma to run a file before everything else. This is the next best
+ * thing I guess...
+ */
+const isBrowser = typeof window !== 'undefined' &&
+  Object.prototype.toString.call(window) === '[object Window]';
+
+if (isBrowser) {
+  require('airbnb-browser-shims');
+}

--- a/packages/enzyme-test-suite/test/selector-spec.jsx
+++ b/packages/enzyme-test-suite/test/selector-spec.jsx
@@ -1,4 +1,4 @@
-import './_helpers/setupAdapters';
+import './_helpers/setup';
 import React from 'react';
 import { expect } from 'chai';
 

--- a/packages/enzyme-test-suite/test/staticRender-spec.jsx
+++ b/packages/enzyme-test-suite/test/staticRender-spec.jsx
@@ -1,4 +1,4 @@
-import './_helpers/setupAdapters';
+import './_helpers/setup';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';


### PR DESCRIPTION
This fixes the travis karma flakiness, and removes the allowed failure. This does this by adding in airbnb-browser-shims to the karma tests so that we don't have to worry about which version of chrome they are running on.