### PR TITLE
Add test for querying components wrapped with HOCs

### DIFF
--- a/packages/enzyme-test-suite/test/selector-spec.jsx
+++ b/packages/enzyme-test-suite/test/selector-spec.jsx
@@ -331,6 +331,29 @@ describe('selectors', () => {
         expect(wrapper.find('a[href="https://www.foo.com"]')).to.have.lengthOf(1);
         expect(wrapper.find('a[href="foo.com"]')).to.have.lengthOf(1);
       });
+
+      it('parens in displayName', () => {
+        class Foo extends React.Component {
+          render() {
+            return <div />;
+          }
+        }
+        Foo.displayName = 'Wrapped(Foo)';
+        class Bar extends React.Component {
+          render() {
+            return <div />;
+          }
+        }
+        Bar.displayName = 'Wrapped(Twice(Bar))';
+        const wrapper = renderMethod(
+          <div>
+            <Foo />
+            <Bar />
+          </div>,
+        );
+        expect(wrapper.find('Wrapped(Foo)')).to.have.lengthOf(1);
+        expect(wrapper.find('Wrapped(Twice(Bar))')).to.have.lengthOf(1);
+      });
     });
   });
 });

--- a/packages/enzyme/package.json
+++ b/packages/enzyme/package.json
@@ -39,7 +39,7 @@
     "object.assign": "^4.0.4",
     "object.entries": "^1.0.4",
     "raf": "^3.3.2",
-    "rst-selector-parser": "^2.2.0"
+    "rst-selector-parser": "^2.2.1"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
In response to #1124, which was resolved by https://github.com/aweary/rst-selector-parser/pull/5. I published it as a patch release which matches our Semver range for that dependency.

This just adds a small test to prevent regressions on this. There's also a test in `rst-selector-parser` for this, so we get double the coverage.