### PR TITLE
Fix hydrating renders for React 15 adapters

### DIFF
--- a/packages/enzyme-adapter-react-15/src/ReactFifteenAdapter.js
+++ b/packages/enzyme-adapter-react-15/src/ReactFifteenAdapter.js
@@ -26,18 +26,35 @@ function compositeTypeToNodeType(type) {
       throw new Error(`Enzyme Internal Error: unknown composite type ${type}`);
   }
 }
+function childrenFromInst(inst, el) {
+  if (inst._renderedChildren) {
+    return values(inst._renderedChildren);
+  } else if (el.props) {
+    return values({ '.0': el.props.children });
+  }
+  return [];
+}
+
+function nodeType(inst) {
+  if (inst._compositeType != null) {
+    return compositeTypeToNodeType(inst._compositeType);
+  }
+  return 'host';
+}
 
 function instanceToTree(inst) {
   if (!inst || typeof inst !== 'object') {
     return inst;
   }
   const el = inst._currentElement;
-  if (!el) {
+  if (el == null || el === false) {
     return null;
+  } else if (typeof el !== 'object') {
+    return el;
   }
   if (inst._renderedChildren) {
     return {
-      nodeType: inst._hostNode ? 'host' : compositeTypeToNodeType(inst._compositeType),
+      nodeType: nodeType(inst),
       type: el.type,
       props: el.props,
       key: el.key,
@@ -47,10 +64,6 @@ function instanceToTree(inst) {
     };
   }
   if (inst._hostNode) {
-    if (typeof el !== 'object') {
-      return el;
-    }
-    const children = inst._renderedChildren || { '.0': el.props.children };
     return {
       nodeType: 'host',
       type: el.type,
@@ -58,12 +71,12 @@ function instanceToTree(inst) {
       key: el.key,
       ref: el.ref,
       instance: inst._instance || inst._hostNode || null,
-      rendered: values(children).map(instanceToTree),
+      rendered: childrenFromInst(inst, el).map(instanceToTree),
     };
   }
   if (inst._renderedComponent) {
     return {
-      nodeType: compositeTypeToNodeType(inst._compositeType),
+      nodeType: nodeType(inst),
       type: el.type,
       props: el.props,
       key: el.key,
@@ -72,7 +85,15 @@ function instanceToTree(inst) {
       rendered: instanceToTree(inst._renderedComponent),
     };
   }
-  throw new Error('Enzyme Internal Error: unknown instance encountered');
+  return {
+    nodeType: nodeType(inst),
+    type: el.type,
+    props: el.props,
+    key: el.key,
+    ref: el.ref,
+    instance: inst._instance || null,
+    rendered: childrenFromInst(inst, el).map(instanceToTree),
+  };
 }
 
 class ReactFifteenAdapter extends EnzymeAdapter {

--- a/packages/enzyme-test-suite/package.json
+++ b/packages/enzyme-test-suite/package.json
@@ -33,9 +33,11 @@
     "enzyme-adapter-utils": "^1.0.0-beta.4",
     "prop-types": "^15.5.10",
     "semver": "^5.4.1",
-    "sinon": "^2.4.1"
+    "sinon": "^2.4.1",
+    "jsdom": "^6.1.0"
   },
   "peerDependencies": {
-    "react": "^15.5.0"
+    "react": "^15.5.0",
+    "react-dom": "^15.5.0"
   }
 }

--- a/packages/enzyme-test-suite/test/_helpers/react-compat.js
+++ b/packages/enzyme-test-suite/test/_helpers/react-compat.js
@@ -7,6 +7,7 @@
 import { is } from './version';
 
 let createClass;
+let renderToString;
 
 if (is('>=15.5 || ^16.0.0-alpha')) {
   // eslint-disable-next-line import/no-extraneous-dependencies
@@ -15,6 +16,14 @@ if (is('>=15.5 || ^16.0.0-alpha')) {
   createClass = require('react').createClass;
 }
 
+if (is('^0.13.0')) {
+  renderToString = require('react').renderToStaticMarkup;
+} else {
+  // eslint-disable-next-line import/no-extraneous-dependencies
+  renderToString = require('react-dom/server').renderToString;
+}
+
 export {
   createClass,
+  renderToString,
 };


### PR DESCRIPTION
Found this corner case bug using the Airbnb test suite. Apparently there is some slightly different internal structure that gets created when mounting on top of existing HTML markup. This adds tests for that and fixes it for the 15 and 15.4 adapters.