### PR TITLE
Add public root method

### DIFF
--- a/packages/enzyme/src/ReactWrapper.js
+++ b/packages/enzyme/src/ReactWrapper.js
@@ -103,6 +103,15 @@ class ReactWrapper {
   }
 
   /**
+   * Returns the root wrapper
+   *
+   * @return {ReactWrapper}
+   */
+  root() {
+    return this[ROOT];
+  }
+
+  /**
    * Returns the wrapped component.
    *
    * @return {ReactComponent}
@@ -1075,7 +1084,6 @@ function privateWarning(prop, extraMessage) {
 privateWarning('node', 'Consider using the getElement() method instead.');
 privateWarning('nodes', 'Consider using the getElements() method instead.');
 privateWarning('renderer', '');
-privateWarning('root', '');
 privateWarning('options', '');
 privateWarning('complexSelector', '');
 

--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -145,6 +145,17 @@ class ShallowWrapper {
     privateSet(this, OPTIONS, root ? root[OPTIONS] : options);
   }
 
+
+  /**
+   * Returns the root wrapper
+   *
+   * @return {ShallowWrapper}
+   */
+  root() {
+    return this[ROOT];
+  }
+
+
   getNodeInternal() {
     if (this.length !== 1) {
       throw new Error(
@@ -1183,7 +1194,6 @@ function privateWarning(prop, extraMessage) {
 privateWarning('node', 'Consider using the getElement() method instead.');
 privateWarning('nodes', 'Consider using the getElements() method instead.');
 privateWarning('renderer', '');
-privateWarning('root', '');
 privateWarning('options', '');
 privateWarning('complexSelector', '');
 


### PR DESCRIPTION
This adds a public `root()` method to the shallow and mount wrappers. This is a reasonable public API to have, and chai-enzyme needs this for a couple of things.