### PR TITLE
Breaking: lifecycleExperimental by default

### DIFF
--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -3475,7 +3475,7 @@ describe('shallow', () => {
           },
         );
         wrapper.setState({ foo: 'baz' });
-        expect(spy.args).to.deep.equal([
+        const expected = [
           [
             'render',
           ],
@@ -3494,13 +3494,16 @@ describe('shallow', () => {
           [
             'render',
           ],
-          [
+        ];
+        if (!REACT16) {
+          expected.push([
             'componentDidUpdate',
             { foo: 'props' }, { foo: 'props' },
             { foo: 'bar' }, { foo: 'baz' },
-            REACT16 ? undefined : { foo: 'context' },
-          ],
-        ]);
+            { foo: 'context' },
+          ]);
+        }
+        expect(spy.args).to.deep.equal(expected);
       });
 
       it('should cancel rendering when Component returns false in shouldComponentUpdate', () => {

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -3197,7 +3197,6 @@ describe('shallow', () => {
           <Foo foo="bar" />,
           {
             context: { foo: 'context' },
-            lifecycleExperimental: true,
           },
         );
         wrapper.setProps({ foo: 'baz' });
@@ -3287,7 +3286,7 @@ describe('shallow', () => {
           }
         }
 
-        const wrapper = shallow(<Foo a="a" b="b" />, { lifecycleExperimental: true });
+        const wrapper = shallow(<Foo a="a" b="b" />);
 
         wrapper.setProps({ b: 'c', d: 'e' });
 
@@ -3338,7 +3337,7 @@ describe('shallow', () => {
           }
         }
 
-        const wrapper = shallow(<Foo foo="bar" />, { lifecycleExperimental: true });
+        const wrapper = shallow(<Foo foo="bar" />);
         expect(wrapper.instance().props.foo).to.equal('bar');
         wrapper.setProps({ foo: 'baz' });
         expect(wrapper.instance().props.foo).to.equal('baz');
@@ -3371,7 +3370,7 @@ describe('shallow', () => {
             return <div>{this.props.foo}</div>;
           }
         }
-        const result = shallow(<Foo />, { lifecycleExperimental: true });
+        const result = shallow(<Foo />);
         expect(spy).to.have.property('callCount', 1);
         result.setProps({ name: 'bar' });
         expect(spy).to.have.property('callCount', 2);
@@ -3400,7 +3399,7 @@ describe('shallow', () => {
             return <div>{this.props.foo}</div>;
           }
         }
-        const result = shallow(<Foo />, { lifecycleExperimental: true });
+        const result = shallow(<Foo />);
         expect(spy).to.have.property('callCount', 1);
         result.setProps({ name: 'bar' });
         expect(spy).to.have.property('callCount', 3);
@@ -3431,7 +3430,7 @@ describe('shallow', () => {
             return <div>{this.props.foo}</div>;
           }
         }
-        const result = shallow(<Foo />, { lifecycleExperimental: true });
+        const result = shallow(<Foo />);
         expect(spy).to.have.property('callCount', 1);
         result.setProps({ name: 'bar' });
         expect(spy).to.have.property('callCount', 3);
@@ -3473,7 +3472,6 @@ describe('shallow', () => {
           <Foo foo="props" />,
           {
             context: { foo: 'context' },
-            lifecycleExperimental: true,
           },
         );
         wrapper.setState({ foo: 'baz' });
@@ -3529,7 +3527,7 @@ describe('shallow', () => {
             return <div>foo</div>;
           }
         }
-        const wrapper = shallow(<Foo />, { lifecycleExperimental: true });
+        const wrapper = shallow(<Foo />);
         expect(wrapper.instance().state.foo).to.equal('bar');
         wrapper.setState({ foo: 'baz' });
         expect(wrapper.instance().state.foo).to.equal('baz');
@@ -3559,7 +3557,7 @@ describe('shallow', () => {
             return <div>{this.state.name}</div>;
           }
         }
-        const result = shallow(<Foo />, { lifecycleExperimental: true });
+        const result = shallow(<Foo />);
         expect(spy).to.have.property('callCount', 1);
         result.setState({ name: 'bar' });
         expect(spy).to.have.property('callCount', 3);
@@ -3591,7 +3589,7 @@ describe('shallow', () => {
             return <div>{this.state.name}</div>;
           }
         }
-        const result = shallow(<Foo />, { lifecycleExperimental: true });
+        const result = shallow(<Foo />);
         expect(spy).to.have.property('callCount', 1);
         result.setState({ name: 'bar' });
         expect(spy).to.have.property('callCount', 3);
@@ -3631,7 +3629,6 @@ describe('shallow', () => {
           <Foo foo="props" />,
           {
             context: { foo: 'bar' },
-            lifecycleExperimental: true,
           },
         );
         expect(wrapper.instance().context.foo).to.equal('bar');
@@ -3690,7 +3687,6 @@ describe('shallow', () => {
           <Foo />,
           {
             context: { foo: 'bar' },
-            lifecycleExperimental: true,
           },
         );
         wrapper.setContext({ foo: 'baz' });
@@ -3723,7 +3719,6 @@ describe('shallow', () => {
           <Foo />,
           {
             context: { foo: 'bar' },
-            lifecycleExperimental: true,
           },
         );
         expect(spy).to.have.property('callCount', 1);
@@ -3760,7 +3755,6 @@ describe('shallow', () => {
           <Foo />,
           {
             context: { foo: 'bar' },
-            lifecycleExperimental: true,
           },
         );
         expect(spy).to.have.property('callCount', 1);
@@ -3781,13 +3775,13 @@ describe('shallow', () => {
             return <div>foo</div>;
           }
         }
-        const wrapper = shallow(<Foo />, { lifecycleExperimental: true });
+        const wrapper = shallow(<Foo />);
         wrapper.unmount();
         expect(spy).to.have.property('callCount', 1);
       });
     });
 
-    it('should not call when lifecycleExperimental flag is false', () => {
+    it('should not call when disableLifecycleMethods flag is true', () => {
       const spy = sinon.spy();
       class Foo extends React.Component {
         componentDidMount() {
@@ -3797,11 +3791,11 @@ describe('shallow', () => {
           return <div>foo</div>;
         }
       }
-      shallow(<Foo />, { lifecycleExperimental: false });
+      shallow(<Foo />, { disableLifecycleMethods: true });
       expect(spy).to.have.property('callCount', 0);
     });
 
-    it('should call shouldComponentUpdate when lifecycleExperimental flag is false', () => {
+    it('should call shouldComponentUpdate when disableLifecycleMethods flag is true', () => {
       const spy = sinon.spy();
       class Foo extends React.Component {
         constructor(props) {
@@ -3822,7 +3816,7 @@ describe('shallow', () => {
         <Foo foo="foo" />,
         {
           context: { foo: 'foo' },
-          lifecycleExperimental: false,
+          disableLifecycleMethods: true,
         },
       );
       expect(spy).to.have.property('callCount', 0);

--- a/packages/enzyme/src/ReactWrapper.js
+++ b/packages/enzyme/src/ReactWrapper.js
@@ -11,6 +11,7 @@ import {
   nodeEqual,
   nodeMatches,
   getAdapter,
+  makeOptions,
   sym,
   privateSet,
   cloneElement,
@@ -66,12 +67,13 @@ function filterWhereUnwrapped(wrapper, predicate) {
  * @class ReactWrapper
  */
 class ReactWrapper {
-  constructor(nodes, root, options = {}) {
+  constructor(nodes, root, passedOptions = {}) {
     if (!global.window && !global.document) {
       throw new Error(
         'It looks like you called `mount()` without a global document being loaded.',
       );
     }
+    const options = makeOptions(passedOptions);
 
     if (!root) {
       privateSet(this, UNRENDERED, nodes);

--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -14,6 +14,7 @@ import {
   isCustomComponentElement,
   ITERATOR_SYMBOL,
   getAdapter,
+  makeOptions,
   sym,
   privateSet,
   cloneElement,
@@ -108,8 +109,9 @@ function getRootNode(node) {
  * @class ShallowWrapper
  */
 class ShallowWrapper {
-  constructor(nodes, root, options = {}) {
-    validateOptions(options);
+  constructor(nodes, root, passedOptions = {}) {
+    validateOptions(passedOptions);
+    const options = makeOptions(passedOptions);
     if (!root) {
       privateSet(this, ROOT, this);
       privateSet(this, UNRENDERED, nodes);

--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -118,7 +118,7 @@ class ShallowWrapper {
       this[RENDERER].render(nodes, options.context);
       const instance = this[RENDERER].getNode().instance;
       if (
-        options.lifecycleExperimental &&
+        !options.disableLifecycleMethods &&
         instance &&
         typeof instance.componentDidMount === 'function'
       ) {
@@ -277,7 +277,7 @@ class ShallowWrapper {
           // make sure that componentWillReceiveProps is called before shouldComponentUpdate
           let originalComponentWillReceiveProps;
           if (
-            this[OPTIONS].lifecycleExperimental &&
+            !this[OPTIONS].disableLifecycleMethods &&
             instance &&
             typeof instance.componentWillReceiveProps === 'function'
           ) {
@@ -288,7 +288,7 @@ class ShallowWrapper {
           // dirty hack: avoid calling shouldComponentUpdate twice
           let originalShouldComponentUpdate;
           if (
-            this[OPTIONS].lifecycleExperimental &&
+            !this[OPTIONS].disableLifecycleMethods &&
             instance &&
             typeof instance.shouldComponentUpdate === 'function'
           ) {
@@ -307,7 +307,7 @@ class ShallowWrapper {
               instance.shouldComponentUpdate = originalShouldComponentUpdate;
             }
             if (
-              this[OPTIONS].lifecycleExperimental &&
+              !this[OPTIONS].disableLifecycleMethods &&
               instance &&
               typeof instance.componentDidUpdate === 'function'
             ) {

--- a/packages/enzyme/src/Utils.js
+++ b/packages/enzyme/src/Utils.js
@@ -18,6 +18,13 @@ export function getAdapter(options = {}) {
   return adapter;
 }
 
+export function makeOptions(options) {
+  return {
+    ...configuration.get(),
+    ...options,
+  };
+}
+
 export function isCustomComponentElement(inst, adapter) {
   return !!inst && adapter.isValidElement(inst) && typeof inst.type === 'function';
 }


### PR DESCRIPTION
There is a discussion in #678 about this.
If enzyme chooses this option, the time has come.

I think this PR needs more works, which are tests and documentation.
Does enzyme enable lifecyleExperimental by default at v3?