### PR TITLE
Update ES5 examples to use Enzyme.configure

### DIFF
--- a/docs/installation/react-013.md
+++ b/docs/installation/react-013.md
@@ -38,7 +38,7 @@ ES5:
 var Enzyme = require('enzyme');
 var Adapter = require('enzyme-adapter-react-13');
 
-configure({ adapter: new Adapter() });
+Enzyme.configure({ adapter: new Adapter() });
 ```
 
 <!-- eslint no-var: 0 -->

--- a/docs/installation/react-014.md
+++ b/docs/installation/react-014.md
@@ -44,7 +44,7 @@ ES5:
 var Enzyme = require('enzyme');
 var Adapter = require('enzyme-adapter-react-14');
 
-configure({ adapter: new Adapter() });
+Enzyme.configure({ adapter: new Adapter() });
 ```
 
 <!-- eslint no-var: 0 -->

--- a/docs/installation/react-15.md
+++ b/docs/installation/react-15.md
@@ -44,7 +44,7 @@ ES5:
 var Enzyme = require('enzyme');
 var Adapter = require('enzyme-adapter-react-15');
 
-configure({ adapter: new Adapter() });
+Enzyme.configure({ adapter: new Adapter() });
 ```
 
 <!-- eslint no-var: 0 -->

--- a/docs/installation/react-16.md
+++ b/docs/installation/react-16.md
@@ -44,7 +44,7 @@ ES5:
 var Enzyme = require('enzyme');
 var Adapter = require('enzyme-adapter-react-16');
 
-configure({ adapter: new Adapter() });
+Enzyme.configure({ adapter: new Adapter() });
 ```
 
 <!-- eslint no-var: 0 -->


### PR DESCRIPTION
This updates the ES5 examples to use `Enzyme.configure({ adapter: new Adapter() });` instead of `configure({ adapter: new Adapter() });`. Using the current examples IRL will result in `ReferenceError: configure is not defined`.