### PR TITLE
Support all attribute selector operators

### DIFF
--- a/packages/enzyme-test-suite/test/RSTTraversal-spec.jsx
+++ b/packages/enzyme-test-suite/test/RSTTraversal-spec.jsx
@@ -8,7 +8,6 @@ import {
   treeFilter,
   pathToNode,
   getTextFromNode,
-  nodeHasProperty
 } from 'enzyme/build/RSTTraversal';
 
 import './_helpers/setupAdapters';
@@ -43,96 +42,6 @@ describe('RSTTraversal', () => {
       classes.toString = () => 'foo-bar';
       const node = $(<div className={classes} />);
       expect(hasClassName(node, 'foo-bar')).to.equal(true);
-    });
-  });
-
-  describe('nodeHasProperty', () => {
-    it('should find properties', () => {
-      function noop() {}
-      const node = $(<div onChange={noop} title="foo" />);
-
-      expect(nodeHasProperty(node, 'onChange')).to.equal(true);
-      expect(nodeHasProperty(node, 'title', 'foo')).to.equal(true);
-    });
-
-    it('should not match on html attributes', () => {
-      const node = $(<div htmlFor="foo" />);
-
-      expect(nodeHasProperty(node, 'for', 'foo')).to.equal(false);
-    });
-
-    it('should not find undefined properties', () => {
-      const node = $(<div title={undefined} />);
-
-      expect(nodeHasProperty(node, 'title')).to.equal(false);
-    });
-
-    it('should parse booleans', () => {
-      expect(nodeHasProperty(<div foo />, 'foo', true)).to.equal(true);
-      expect(nodeHasProperty(<div foo />, 'foo', false)).to.equal(false);
-      expect(nodeHasProperty(<div foo />, 'foo', 'true')).to.equal(false);
-      expect(nodeHasProperty(<div foo={false} />, 'foo', false)).to.equal(true);
-      expect(nodeHasProperty(<div foo={false} />, 'foo', true)).to.equal(false);
-      expect(nodeHasProperty(<div foo={false} />, 'foo', 'false')).to.equal(false);
-    });
-
-    it('should parse numeric literals', () => {
-      expect(nodeHasProperty(<div foo={2.3} />, 'foo', 2.3)).to.equal(true);
-      expect(nodeHasProperty(<div foo={2} />, 'foo', 2)).to.equal(true);
-      expect(nodeHasProperty(<div foo={2} />, 'foo', '2abc')).to.equal(false);
-      expect(nodeHasProperty(<div foo={2} />, 'foo', 'abc2')).to.equal(false);
-      expect(nodeHasProperty(<div foo={-2} />, 'foo', -2)).to.equal(true);
-      expect(nodeHasProperty(<div foo={2e8} />, 'foo', 2e8)).to.equal(true);
-      expect(nodeHasProperty(<div foo={Infinity} />, 'foo', Infinity)).to.equal(true);
-      expect(nodeHasProperty(<div foo={-Infinity} />, 'foo', -Infinity)).to.equal(true);
-    });
-
-    it('should parse zeroes properly', () => {
-      expect(nodeHasProperty(<div foo={0} />, 'foo', 0)).to.equal(true);
-      expect(nodeHasProperty(<div foo={0} />, 'foo', +0)).to.equal(true);
-      expect(nodeHasProperty(<div foo={-0} />, 'foo', -0)).to.equal(true);
-      expect(nodeHasProperty(<div foo={-0} />, 'foo', 0)).to.equal(false);
-      expect(nodeHasProperty(<div foo={0} />, 'foo', -0)).to.equal(false);
-      expect(nodeHasProperty(<div foo={1} />, 'foo', 0)).to.equal(false);
-      expect(nodeHasProperty(<div foo={2} />, 'foo', -0)).to.equal(false);
-    });
-
-    it('should work with empty strings', () => {
-      expect(nodeHasProperty(<div foo="" />, 'foo', '')).to.equal(true);
-      expect(nodeHasProperty(<div foo={''} />, 'foo', '')).to.equal(true);
-      expect(nodeHasProperty(<div foo={'bar'} />, 'foo', '')).to.equal(false);
-    });
-
-    it('should work with NaN', () => {
-      expect(nodeHasProperty(<div foo={NaN} />, 'foo', NaN)).to.equal(true);
-      expect(nodeHasProperty(<div foo={0} />, 'foo', NaN)).to.equal(false);
-    });
-
-    it('should work with null', () => {
-      expect(nodeHasProperty(<div foo={null} />, 'foo', null)).to.equal(true);
-      expect(nodeHasProperty(<div foo={0} />, 'foo', null)).to.equal(false);
-    });
-
-    it('should work with false', () => {
-      expect(nodeHasProperty(<div foo={false} />, 'foo', false)).to.equal(true);
-      expect(nodeHasProperty(<div foo={0} />, 'foo', false)).to.equal(false);
-    });
-
-    it('should work with ±Infinity', () => {
-      expect(nodeHasProperty(<div foo={Infinity} />, 'foo', Infinity)).to.equal(true);
-      expect(nodeHasProperty(<div foo={Infinity} />, 'foo', +Infinity)).to.equal(true);
-      expect(nodeHasProperty(<div foo={Infinity} />, 'foo', -Infinity)).to.equal(false);
-      expect(nodeHasProperty(<div foo={Infinity} />, 'foo', 'Infinity')).to.equal(false);
-      expect(nodeHasProperty(<div foo={Infinity} />, 'foo', NaN)).to.equal(false);
-      expect(nodeHasProperty(<div foo={0} />, 'foo', Infinity)).to.equal(false);
-      expect(nodeHasProperty(<div foo={-Infinity} />, 'foo', -Infinity)).to.equal(true);
-      expect(nodeHasProperty(<div foo={-Infinity} />, 'foo', Infinity)).to.equal(false);
-      expect(nodeHasProperty(<div foo={-Infinity} />, 'foo', Infinity)).to.equal(false);
-      expect(nodeHasProperty(<div foo={-Infinity} />, 'foo', '-Infinity')).to.equal(false);
-      expect(nodeHasProperty(<div foo={-Infinity} />, 'foo', NaN)).to.equal(false);
-      expect(nodeHasProperty(<div foo={NaN} />, 'foo', Infinity)).to.equal(false);
-      expect(nodeHasProperty(<div foo={NaN} />, 'foo', -Infinity)).to.equal(false);
-      expect(nodeHasProperty(<div foo={0} />, 'foo', -Infinity)).to.equal(false);
     });
   });
 

--- a/packages/enzyme-test-suite/test/RSTTraversal-spec.jsx
+++ b/packages/enzyme-test-suite/test/RSTTraversal-spec.jsx
@@ -4,11 +4,11 @@ import { expect } from 'chai';
 import { elementToTree } from 'enzyme-adapter-utils';
 import {
   hasClassName,
-  nodeHasProperty,
   treeForEach,
   treeFilter,
   pathToNode,
   getTextFromNode,
+  nodeHasProperty
 } from 'enzyme/build/RSTTraversal';
 
 import './_helpers/setupAdapters';

--- a/packages/enzyme-test-suite/test/selector-spec.jsx
+++ b/packages/enzyme-test-suite/test/selector-spec.jsx
@@ -418,13 +418,13 @@ describe('selectors', () => {
         expectAttributeMatch(<div data-foo={Infinity} />, '[data-foo=-Infinity]', false);
         expectAttributeMatch(<div data-foo={Infinity} />, '[data-foo=NaN]', false);
         expectAttributeMatch(<div data-foo={0} />, '[data-foo=Infinity]', false);
+        expectAttributeMatch(<div data-foo={0} />, '[data-foo=-Infinity]', false);
         expectAttributeMatch(<div data-foo={-Infinity} />, '[data-foo=-Infinity]', true);
         expectAttributeMatch(<div data-foo={-Infinity} />, '[data-foo=Infinity]', false);
         expectAttributeMatch(<div data-foo={-Infinity} />, '[data-foo="-Infinity"]', false);
         expectAttributeMatch(<div data-foo={-Infinity} />, '[data-foo=NaN]', false);
         expectAttributeMatch(<div data-foo={NaN} />, '[data-foo=Infinity]', false);
         expectAttributeMatch(<div data-foo={NaN} />, '[data-foo=-Infinity]', false);
-        expectAttributeMatch(<div data-foo={0} />, '[data-foo=Infinity]', false);
       });
 
       it('whitespace list attribute selector', () => {

--- a/packages/enzyme-test-suite/test/selector-spec.jsx
+++ b/packages/enzyme-test-suite/test/selector-spec.jsx
@@ -426,6 +426,56 @@ describe('selectors', () => {
         expectAttributeMatch(<div data-foo={NaN} />, '[data-foo=-Infinity]', false);
         expectAttributeMatch(<div data-foo={0} />, '[data-foo=Infinity]', false);
       });
+
+      it('whitespace list attribute selector', () => {
+        expectAttributeMatch(<div rel="foo bar baz" />, '[rel~="bar"]', true);
+        expectAttributeMatch(<div rel="foo bar baz" />, '[rel~="baz"]', true);
+        expectAttributeMatch(<div rel="foo bar baz" />, '[rel~="foo"]', true);
+        expectAttributeMatch(<div rel="foo bar baz" />, '[rel~="foo bar"]', false);
+        expectAttributeMatch(<div rel={1} />, '[rel~=1]', false);
+        expectAttributeMatch(<div rel="1" />, '[rel~=1]', false);
+      });
+
+      it('hypen attribute selector', () => {
+        expectAttributeMatch(<a hrefLang="en-US" />, '[hrefLang|="en"]', true);
+        expectAttributeMatch(<a hrefLang="en-US" />, '[hrefLang|="en-US"]', true);
+        expectAttributeMatch(<a hrefLang="en-US" />, '[hrefLang|="US"]', false);
+        expectAttributeMatch(<a hrefLang="en-US" />, '[hrefLang|="enUS"]', false);
+        expectAttributeMatch(<a hrefLang={1} />, '[hrefLang|=1]', false);
+        expectAttributeMatch(<a hrefLang="1" />, '[hrefLang|=1]', false);
+      });
+
+      it('prefix attribute operator', () => {
+        expectAttributeMatch(<img alt="" src="foo-bar.jpg" />, '[src^="foo"]', true);
+        expectAttributeMatch(<img alt="" src="foo-bar.jpg" />, '[src^="foo-bar"]', true);
+        expectAttributeMatch(<img alt="" src="foo-bar.jpg" />, '[src^="foo-bar.jpg"]', true);
+        expectAttributeMatch(<img alt="" src="foo-bar.jpg" />, '[src^="bar"]', false);
+        expectAttributeMatch(<img alt="" src="foo-bar.jpg" />, '[src^=""]', false);
+        expectAttributeMatch(<img alt="" src={1} />, '[src^=1]', false);
+        expectAttributeMatch(<img alt="" src="1" />, '[src^=1]', false);
+      });
+
+      it('suffix attribute operator', () => {
+        expectAttributeMatch(<img alt="" src="foo-bar.jpg" />, '[src$=".jpg"]', true);
+        expectAttributeMatch(<img alt="" src="foo-bar.jpg" />, '[src$="bar.jpg"]', true);
+        expectAttributeMatch(<img alt="" src="foo-bar.jpg" />, '[src$="foo-bar.jpg"]', true);
+        expectAttributeMatch(<img alt="" src="foo-bar.jpg" />, '[src$="foo"]', false);
+        expectAttributeMatch(<img alt="" src="foo-bar.jpg" />, '[src$=""]', false);
+        expectAttributeMatch(<img alt="" src={1} />, '[src$=1]', false);
+        expectAttributeMatch(<img alt="" src="1" />, '[src$=1]', false);
+      });
+
+      it('substring attribute operator', () => {
+        expectAttributeMatch(<div id="foo bar baz" />, '[id*="foo"]', true);
+        expectAttributeMatch(<div id="foo bar baz" />, '[id*="foo bar"]', true);
+        expectAttributeMatch(<div id="foo bar baz" />, '[id*="foo bar baz"]', true);
+        expectAttributeMatch(<div id="foo bar baz" />, '[id*="foo "]', true);
+        expectAttributeMatch(<div id="foo bar baz" />, '[id*="fo"]', true);
+        expectAttributeMatch(<div id="foo bar baz" />, '[id*="foz"]', false);
+        expectAttributeMatch(<div id="foo bar baz" />, '[id*=1]', false);
+        expectAttributeMatch(<div id={1} />, '[id*=1]', false);
+        expectAttributeMatch(<div id="1" />, '[id*=1]', false);
+      });
     });
   });
 });

--- a/packages/enzyme/package.json
+++ b/packages/enzyme/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "cheerio": "^1.0.0-rc.2",
     "function.prototype.name": "^1.0.3",
+    "has": "^1.0.1",
     "is-subset": "^0.1.1",
     "lodash": "^4.17.4",
     "object-is": "^1.0.1",

--- a/packages/enzyme/src/Utils.js
+++ b/packages/enzyme/src/Utils.js
@@ -219,23 +219,17 @@ export function AND(fns) {
   return x => fnsReversed.every(fn => fn(x));
 }
 
-export function nodeHasProperty(node, propKey, propValue) {
+export function nodeHasMatchingProperty(node, propKey, matcher) {
   const nodeProps = propsOfNode(node);
   const descriptor = Object.getOwnPropertyDescriptor(nodeProps, propKey);
   if (descriptor && descriptor.get) {
     return false;
   }
   const nodePropValue = nodeProps[propKey];
-
   if (typeof nodePropValue === 'undefined') {
     return false;
   }
-
-  if (typeof propValue !== 'undefined') {
-    return is(nodePropValue, propValue);
-  }
-
-  return Object.prototype.hasOwnProperty.call(nodeProps, propKey);
+  return matcher(nodePropValue, nodeProps);
 }
 
 export function displayNameOfNode(node) {

--- a/packages/enzyme/src/Utils.js
+++ b/packages/enzyme/src/Utils.js
@@ -29,7 +29,7 @@ export function isCustomComponentElement(inst, adapter) {
   return !!inst && adapter.isValidElement(inst) && typeof inst.type === 'function';
 }
 
-function propsOfNode(node) {
+export function propsOfNode(node) {
   return entries((node && node.props) || {})
     .filter(([, value]) => typeof value !== 'undefined')
     .reduce((acc, [key, value]) => Object.assign(acc, { [key]: value }), {});
@@ -217,19 +217,6 @@ export function withSetStateAllowed(fn) {
 export function AND(fns) {
   const fnsReversed = fns.slice().reverse();
   return x => fnsReversed.every(fn => fn(x));
-}
-
-export function nodeHasMatchingProperty(node, propKey, matcher) {
-  const nodeProps = propsOfNode(node);
-  const descriptor = Object.getOwnPropertyDescriptor(nodeProps, propKey);
-  if (descriptor && descriptor.get) {
-    return false;
-  }
-  const nodePropValue = nodeProps[propKey];
-  if (typeof nodePropValue === 'undefined') {
-    return false;
-  }
-  return matcher(nodePropValue, nodeProps);
 }
 
 export function displayNameOfNode(node) {

--- a/packages/enzyme/src/selectors.js
+++ b/packages/enzyme/src/selectors.js
@@ -94,7 +94,7 @@ function matchAttributeSelector(node, token) {
       return is(nodePropValue, value);
     /**
      * Represents an element with the att attribute whose value is a whitespace-separated
-     * list of words, one of which is exactly 
+     * list of words, one of which is exactly
      * @example
      *  [rel~="copyright"] matches rel="copyright other"
      */

--- a/packages/enzyme/src/selectors.js
+++ b/packages/enzyme/src/selectors.js
@@ -36,7 +36,7 @@ const PSEUDO_ELEMENT = 'pseudoElementSelector';
 
 const EXACT_ATTRIBUTE_OPERATOR = '=';
 const WHITELIST_ATTRIBUTE_OPERATOR = '~=';
-const HYPEN_ATTRIBUTE_OPERATOR = '|=';
+const HYPHENATED_ATTRIBUTE_OPERATOR = '|=';
 const PREFIX_ATTRIBUTE_OPERATOR = '^=';
 const SUFFIX_ATTRIBUTE_OPERATOR = '$=';
 const SUBSTRING_ATTRIBUTE_OPERATOR = '*=';
@@ -106,7 +106,7 @@ function matchAttributeSelector(node, token) {
      * @example
      * [hreflang|="en"] matches hreflang="en-US"
      */
-    case HYPEN_ATTRIBUTE_OPERATOR:
+    case HYPHENATED_ATTRIBUTE_OPERATOR:
       return nodePropValue === value || nodePropValue.startsWith(`${value}-`);
     /**
      * Represents an element with the att attribute whose value begins with the prefix value.

--- a/packages/enzyme/src/selectors.js
+++ b/packages/enzyme/src/selectors.js
@@ -70,8 +70,10 @@ function matchAttributeSelector(node, token) {
       return Object.prototype.hasOwnProperty.call(nodeProps, token.name);
     }
     // Only the exact value operator ("=") can match non-strings
-    if (typeof nodePropValue !== 'string' && operator !== EXACT_ATTRIBUTE_OPERATOR) {
+    if (typeof nodePropValue !== 'string' || typeof value !== 'string') {
+      if (operator !== EXACT_ATTRIBUTE_OPERATOR) {
       return false;
+    }
     }
     switch (operator) {
       /**

--- a/packages/enzyme/src/selectors.js
+++ b/packages/enzyme/src/selectors.js
@@ -72,8 +72,8 @@ function matchAttributeSelector(node, token) {
     // Only the exact value operator ("=") can match non-strings
     if (typeof nodePropValue !== 'string' || typeof value !== 'string') {
       if (operator !== EXACT_ATTRIBUTE_OPERATOR) {
-      return false;
-    }
+        return false;
+      }
     }
     switch (operator) {
       /**
@@ -111,10 +111,10 @@ function matchAttributeSelector(node, token) {
        * Represents an element with the att attribute whose value ends with the suffix value.
        * If the value is the empty string then the selector does not represent anything.
        * @example
-       * [type^="image"] matches type="imageobject"
+       * [type$="image"] matches type="imageobject"
        */
       case SUFFIX_ATTRIBUTE_OPERATOR:
-        return value === '' ? false : nodePropValue.substr(0, -value.length) === value;
+        return value === '' ? false : nodePropValue.substr(-value.length) === value;
       /**
        * Represents an element with the att attribute whose value contains at least one
        * instance of the value. If value is the empty string then the

--- a/packages/enzyme/src/selectors.js
+++ b/packages/enzyme/src/selectors.js
@@ -4,6 +4,7 @@ import isEmpty from 'lodash/isEmpty';
 import flatten from 'lodash/flatten';
 import unique from 'lodash/uniq';
 import is from 'object-is';
+import has from 'has';
 import {
   treeFilter,
   nodeHasId,
@@ -67,7 +68,7 @@ function matchAttributeSelector(node, token) {
   return nodeHasMatchingProperty(node, token.name, (nodePropValue, nodeProps) => {
     const { operator, value } = token;
     if (token.type === ATTRIBUTE_PRESENCE) {
-      return Object.prototype.hasOwnProperty.call(nodeProps, token.name);
+    return has(nodeProps, token.name);
     }
     // Only the exact value operator ("=") can match non-strings
     if (typeof nodePropValue !== 'string' || typeof value !== 'string') {

--- a/packages/enzyme/src/selectors.js
+++ b/packages/enzyme/src/selectors.js
@@ -115,7 +115,7 @@ function matchAttributeSelector(node, token) {
      * [type^="image"] matches type="imageobject"
      */
     case PREFIX_ATTRIBUTE_OPERATOR:
-      return value === '' ? false : nodePropValue.substr(0, value.length) === value;
+      return value === '' ? false : nodePropValue.slice(0, value.length) === value;
     /**
      * Represents an element with the att attribute whose value ends with the suffix value.
      * If the value is the empty string then the selector does not represent anything.
@@ -123,7 +123,7 @@ function matchAttributeSelector(node, token) {
      * [type$="image"] matches type="imageobject"
      */
     case SUFFIX_ATTRIBUTE_OPERATOR:
-      return value === '' ? false : nodePropValue.substr(-value.length) === value;
+      return value === '' ? false : nodePropValue.slice(-value.length) === value;
     /**
      * Represents an element with the att attribute whose value contains at least one
      * instance of the value. If value is the empty string then the


### PR DESCRIPTION
* Adds support for all attribute selector operators
* Removes `nodeHasProperty` in favor of `nodeHasMatchingProperty`
* Updates property/attribute tests to use the public API instead of importing the internal `nodeHasProperty` utility. This decouples the tests from the internal implementation and also makes them more robust. I discovered https://github.com/airbnb/enzyme/issues/1155 while doing this.