### PR TITLE
auto update wrappers behind a flag

### DIFF
--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -4446,7 +4446,7 @@ describe('shallow', () => {
     });
   });
 
-  describe('out-of-band state updates', () => {
+  describe('out-of-band state updates with autoUpdate', () => {
     class Child extends React.Component {
       render() {
         return <span />;
@@ -4486,19 +4486,17 @@ describe('shallow', () => {
     }
 
     it('should have updated output after an asynchronous setState', (done) => {
-      const wrapper = shallow(<Test />);
+      const wrapper = shallow(<Test />, { autoUpdate: true });
       wrapper.find('.async-btn').simulate('click');
       setImmediate(() => {
-        wrapper.update();
         expect(wrapper.find('.show-me').length).to.equal(1);
         done();
       });
     });
 
     it('should have updated output after child prop callback invokes setState', () => {
-      const wrapper = shallow(<Test />);
+      const wrapper = shallow(<Test />, { autoUpdate: true });
       wrapper.find(Child).props().callback();
-      wrapper.update();
       expect(wrapper.find('.show-me').length).to.equal(1);
     });
   });

--- a/packages/enzyme/src/ReactWrapper.js
+++ b/packages/enzyme/src/ReactWrapper.js
@@ -124,6 +124,10 @@ class ReactWrapper {
         'ReactWrapper::getNode() can only be called when wrapping one node',
       );
     }
+    if (this[ROOT] === this && this[OPTIONS].autoUpdate) {
+      this[NODE] = this[RENDERER].getNode();
+      this[NODES] = [this[NODE]];
+    }
     return this[NODES][0];
   }
 
@@ -133,6 +137,10 @@ class ReactWrapper {
    * @return {Array<ReactComponent>}
    */
   getNodesInternal() {
+    if (this[ROOT] === this && this[OPTIONS].autoUpdate) {
+      this[NODE] = this[RENDERER].getNode();
+      this[NODES] = [this[NODE]];
+    }
     return this[NODES];
   }
 
@@ -675,7 +683,7 @@ class ReactWrapper {
    */
   parents(selector) {
     const allParents = this.wrap(
-      this.single('parents', n => parentsOfNode(n, this[ROOT].getNodeInternal())),
+      this.single('parents', n => parentsOfNode(n, this[ROOT][NODE])),
     );
     return selector ? allParents.filter(selector) : allParents;
   }

--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -164,6 +164,10 @@ class ShallowWrapper {
         'ShallowWrapper::getNode() can only be called when wrapping one node',
       );
     }
+    if (this[ROOT] === this && this[OPTIONS].autoUpdate) {
+      this[NODE] = getRootNode(this[RENDERER].getNode());
+      this[NODES] = [this[NODE]];
+    }
     return this[NODE];
   }
 
@@ -198,6 +202,10 @@ class ShallowWrapper {
   }
 
   getNodesInternal() {
+    if (this[ROOT] === this && this[OPTIONS].autoUpdate) {
+      this[NODE] = getRootNode(this[RENDERER].getNode());
+      this[NODES] = [this[NODE]];
+    }
     return this[NODES];
   }
 


### PR DESCRIPTION
This restores the auto update feature introduced by #490 for v3, but behind a feature flag. `mount` now needs the same treatment to keep the tree in sync that shallow used to. Fixes #1175.

For what it's worth, since pre-v3 both shallow and mount essentially auto-updated by default, the only Enzyme tests that break *without* the flag checks are these two, which are fixable by asserting with deep equality if that's on the table.
https://github.com/airbnb/enzyme/blob/106b5d14c79a1dfc4d3ee13f87b13ffb609c5c4a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx#L3696-L3710