### PR TITLE
ES5 setup file correction

### DIFF
--- a/docs/installation/react-16.md
+++ b/docs/installation/react-16.md
@@ -41,10 +41,10 @@ ES5:
 <!-- eslint no-var: 0 -->
 ```js
 // setup file
-var Enzyme = require('enzyme');
+var enzyme = require('enzyme');
 var Adapter = require('enzyme-adapter-react-16');
 
-configure({ adapter: new Adapter() });
+enzyme.configure({ adapter: new Adapter() });
 ```
 
 <!-- eslint no-var: 0 -->


### PR DESCRIPTION
ES5 configuration proposed originally basically doesn't work.
We're requiring 'enzyme' as Enzyme, but using configure() method out of nowhere:
```js
var Enzyme = require('enzyme');
var Adapter = require('enzyme-adapter-react-16');

configure({ adapter: new Adapter() });
```

I derived my variant from the original ES6 version and it works fine for me:
```js
var enzyme = require('enzyme');
var Adapter = require('enzyme-adapter-react-16');

enzyme.configure({ adapter: new Adapter() });
```
Need it specifically for the .babelrc `["env", { "modules": false }]` case.