### PR TITLE
Dont use ssh for docs publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "docs:prepare": "gitbook install",
     "docs:build": "npm run docs:prepare && gitbook build",
     "docs:watch": "npm run docs:prepare && gitbook serve",
-    "docs:publish": "npm run docs:clean && npm run docs:build && cd _book && git init && git commit --allow-empty -m 'update book' && git fetch git@github.com:airbnb/enzyme.git gh-pages && git checkout -b gh-pages && git add . && git commit -am 'update book' && git push git@github.com:airbnb/enzyme.git gh-pages --force",
+    "docs:publish": "npm run docs:clean && npm run docs:build && cd _book && git init && git commit --allow-empty -m 'update book' && git fetch https://github.com/airbnb/enzyme.git gh-pages && git checkout -b gh-pages && git add . && git commit -am 'update book' && git push https://github.com/airbnb/enzyme.git gh-pages --force",
     "pretravis": "npm run build",
     "travis": "babel-node \"$(which istanbul)\" cover --report html _mocha -- packages/enzyme-test-suite/test --recursive"
   },


### PR DESCRIPTION
Since i'm usually the one that publishes the docs, i don't know if this should affect anyone, but docs publishing has been broken for me for a while due to me having 2fa setup on my ssh git (i think?). Either way, this script can't succeed for me locally unless i use git over https.