### PR TITLE
ES5 docs fix: enzyme.configure()

### DIFF
--- a/docs/installation/react-013.md
+++ b/docs/installation/react-013.md
@@ -35,10 +35,10 @@ ES5:
 <!-- eslint no-var: 0 -->
 ```js
 // setup file
-var Enzyme = require('enzyme');
+var enzyme = require('enzyme');
 var Adapter = require('enzyme-adapter-react-13');
 
-configure({ adapter: new Adapter() });
+enzyme.configure({ adapter: new Adapter() });
 ```
 
 <!-- eslint no-var: 0 -->

--- a/docs/installation/react-014.md
+++ b/docs/installation/react-014.md
@@ -41,10 +41,10 @@ ES5:
 <!-- eslint no-var: 0 -->
 ```js
 // setup file
-var Enzyme = require('enzyme');
+var enzyme = require('enzyme');
 var Adapter = require('enzyme-adapter-react-14');
 
-configure({ adapter: new Adapter() });
+enzyme.configure({ adapter: new Adapter() });
 ```
 
 <!-- eslint no-var: 0 -->

--- a/docs/installation/react-15.md
+++ b/docs/installation/react-15.md
@@ -41,10 +41,10 @@ ES5:
 <!-- eslint no-var: 0 -->
 ```js
 // setup file
-var Enzyme = require('enzyme');
+var enzyme = require('enzyme');
 var Adapter = require('enzyme-adapter-react-15');
 
-configure({ adapter: new Adapter() });
+enzyme.configure({ adapter: new Adapter() });
 ```
 
 <!-- eslint no-var: 0 -->


### PR DESCRIPTION
**react-013.md**

ES5:
<!-- eslint no-var: 0 -->
```js
// setup file
var enzyme = require('enzyme');
var Adapter = require('enzyme-adapter-react-13');

enzyme.configure({ adapter: new Adapter() });
```

**react-014.md**

ES5:
<!-- eslint no-var: 0 -->
```js
// setup file
var enzyme = require('enzyme');
var Adapter = require('enzyme-adapter-react-14');

enzyme.configure({ adapter: new Adapter() });
```

**react-15.md**

ES5:
<!-- eslint no-var: 0 -->
```js
// setup file
var enzyme = require('enzyme');
var Adapter = require('enzyme-adapter-react-15');

enzyme.configure({ adapter: new Adapter() });
```

`react-16.md` already fixed in the previous merged pull request: https://github.com/airbnb/enzyme/pull/1194