### PR TITLE
Make react-test-renderer a dependency instead of a peer dependency

### DIFF
--- a/docs/installation/react-014.md
+++ b/docs/installation/react-014.md
@@ -7,12 +7,6 @@ installed, you should do so:
 npm i --save react@0.14 react-dom@0.14
 ```
 
-Further, enzyme with React 0.14 requires the test utilities addon be installed:
-
-```bash
-npm i --save-dev react-addons-test-utils@0.14
-```
-
 Next, to get started with enzyme, you can simply install it with npm:
 
 ```bash

--- a/docs/installation/react-15.md
+++ b/docs/installation/react-15.md
@@ -7,12 +7,6 @@ installed, you should do so:
 npm i --save react@15 react-dom@15
 ```
 
-Further, enzyme requires the test utilities addon be installed:
-
-```bash
-npm i --save-dev react-test-renderer@15
-```
-
 Next, to get started with enzyme, you can simply install it with npm:
 
 ```bash

--- a/docs/installation/react-16.md
+++ b/docs/installation/react-16.md
@@ -7,12 +7,6 @@ installed, you should do so:
 npm i --save react@16 react-dom@16
 ```
 
-Further, enzyme requires the test utilities addon be installed:
-
-```bash
-npm i --save-dev react-test-renderer@16
-```
-
 Next, to get started with enzyme, you can simply install it with npm:
 
 ```bash

--- a/packages/enzyme-adapter-react-14/package.json
+++ b/packages/enzyme-adapter-react-14/package.json
@@ -35,12 +35,12 @@
     "lodash": "^4.17.4",
     "object.assign": "^4.0.4",
     "object.values": "^1.0.4",
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.5.10",
+    "react-addons-test-utils": "^0.14.0"
   },
   "peerDependencies": {
     "enzyme": "^3.0.0",
     "react": "^0.14.0",
-    "react-addons-test-utils": "^0.14.0",
     "react-dom": "^0.14.0"
   },
   "devDependencies": {

--- a/packages/enzyme-adapter-react-15.4/package.json
+++ b/packages/enzyme-adapter-react-15.4/package.json
@@ -35,12 +35,12 @@
     "lodash": "^4.17.4",
     "object.assign": "^4.0.4",
     "object.values": "^1.0.4",
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.5.10",
+    "react-addons-test-utils": "15.0.0-0 - 15.4.x"
   },
   "peerDependencies": {
     "enzyme": "^3.0.0",
     "react": "15.0.0-0 - 15.4.x",
-    "react-addons-test-utils": "15.0.0-0 - 15.4.x",
     "react-dom": "15.0.0-0 - 15.4.x"
   },
   "devDependencies": {

--- a/packages/enzyme-adapter-react-15/package.json
+++ b/packages/enzyme-adapter-react-15/package.json
@@ -35,13 +35,13 @@
     "lodash": "^4.17.4",
     "object.assign": "^4.0.4",
     "object.values": "^1.0.4",
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.5.10",
+    "react-test-renderer": "^15.5.0"
   },
   "peerDependencies": {
     "enzyme": "^3.0.0",
     "react": "^15.5.0",
-    "react-dom": "^15.5.0",
-    "react-test-renderer": "^15.5.0"
+    "react-dom": "^15.5.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/packages/enzyme-adapter-react-16/package.json
+++ b/packages/enzyme-adapter-react-16/package.json
@@ -35,13 +35,13 @@
     "lodash": "^4.17.4",
     "object.assign": "^4.0.4",
     "object.values": "^1.0.4",
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.5.10",
+    "react-test-renderer": "^16.0.0-0"
   },
   "peerDependencies": {
     "enzyme": "^3.0.0",
     "react": "^16.0.0-0",
-    "react-dom": "^16.0.0-0",
-    "react-test-renderer": "^16.0.0-0"
+    "react-dom": "^16.0.0-0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
This addresses #1161 . It makes react test renderer a regular dependency instead of a peer dependency so that users do not have to install it themselves. They should not have to because they don't use it directly.

This is safe because the test renderer does not have a dependency on react, so there will be no second copy. It has a peer dependency, and as long the version of test renderer that is installed has its peer dependency satisfied, everything should be fine.