### PR TITLE
Fix to call componentDidUpdate on setState of React v16

### DIFF
--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -1028,7 +1028,7 @@ describe('shallow', () => {
       expect(wrapper.first('div').text()).to.equal('yolo');
     });
 
-    it('should call componentWillReceiveProps, shouldComponentUpdate and componentWillUpdate with merged newProps', () => {
+    it('should call componentWillReceiveProps, shouldComponentUpdate, componentWillUpdate, and componentDidUpdate with merged newProps', () => {
       const spy = sinon.spy();
 
       class Foo extends React.Component {
@@ -1041,6 +1041,9 @@ describe('shallow', () => {
         }
         componentWillUpdate(nextProps) {
           spy('componentWillUpdate', this.props, nextProps);
+        }
+        componentDidUpdate(prevProps) {
+          spy('componentDidUpdate', prevProps, this.props);
         }
         render() {
           return (
@@ -1066,6 +1069,11 @@ describe('shallow', () => {
         ],
         [
           'componentWillUpdate',
+          { a: 'a', b: 'b' },
+          { a: 'a', b: 'c', d: 'e' },
+        ],
+        [
+          'componentDidUpdate',
           { a: 'a', b: 'b' },
           { a: 'a', b: 'c', d: 'e' },
         ],
@@ -3098,7 +3106,7 @@ describe('shallow', () => {
         ]);
       });
 
-      // componentDidUpdate does not seem to get called in react 16 beta.
+      // componentDidUpdate is not called in react 16
       itIf(REACT16, 'calls expected methods for setState', () => {
         wrapper.setState({ bar: 'bar' });
         expect(spy.args).to.deep.equal([
@@ -3519,15 +3527,13 @@ describe('shallow', () => {
           [
             'render',
           ],
-        ];
-        if (!REACT16) {
-          expected.push([
+          [
             'componentDidUpdate',
             { foo: 'props' }, { foo: 'props' },
             { foo: 'bar' }, { foo: 'baz' },
-            { foo: 'context' },
-          ]);
-        }
+            REACT16 ? undefined : { foo: 'context' },
+          ],
+        ];
         expect(spy.args).to.deep.equal(expected);
       });
 

--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -235,7 +235,7 @@ class ShallowWrapper {
 
   /**
    * A method is for re-render with new props and context.
-   * This calls componentDidUpdate method if lifecycleExperimental is enabled.
+   * This calls componentDidUpdate method if disableLifecycleMethods is not enabled.
    *
    * NOTE: can only be called on a wrapper instance that is also the root instance.
    *
@@ -373,7 +373,7 @@ class ShallowWrapper {
         // so we replace shouldComponentUpdate to know the result and restore it later.
         let originalShouldComponentUpdate;
         if (
-          this[OPTIONS].lifecycleExperimental &&
+          !this[OPTIONS].disableLifecycleMethods &&
           adapter.options.enableComponentDidUpdateOnSetState &&
           instance &&
           typeof instance.shouldComponentUpdate === 'function'
@@ -388,7 +388,7 @@ class ShallowWrapper {
         instance.setState(state, callback);
         if (
           shouldRender &&
-          this[OPTIONS].lifecycleExperimental &&
+          !this[OPTIONS].disableLifecycleMethods &&
           adapter.options.enableComponentDidUpdateOnSetState &&
           instance &&
           typeof instance.componentDidUpdate === 'function'


### PR DESCRIPTION
@ljharb @lelandrichardson This is to fix #1247 🙏 
Currently, componentDidUpdate is not called when calling setState with React v16.