### PR TITLE
Add Portal support

### DIFF
--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -69,7 +69,7 @@ function toTree(vnode) {
   switch (node.tag) {
     case HostRoot: // 3
       return toTree(node.child);
-    case HostPortal:
+    case HostPortal: // 4
       return toTree(node.child);
     case ClassComponent:
       return {

--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -25,6 +25,7 @@ const HostRoot = 3;
 const ClassComponent = 2;
 const Fragment = 10;
 const FunctionalComponent = 1;
+const HostPortal = 4;
 const HostComponent = 5;
 const HostText = 6;
 
@@ -67,6 +68,8 @@ function toTree(vnode) {
   const node = findCurrentFiberUsingSlowPath(vnode);
   switch (node.tag) {
     case HostRoot: // 3
+      return toTree(node.child);
+    case HostPortal:
       return toTree(node.child);
     case ClassComponent:
       return {

--- a/packages/enzyme-test-suite/test/Adapter-spec.jsx
+++ b/packages/enzyme-test-suite/test/Adapter-spec.jsx
@@ -156,6 +156,43 @@ describe('Adapter', () => {
       }));
     });
 
+    itIf(REACT16, 'renders react portals', () => {
+      // eslint-disable-next-line global-require, import/no-unresolved
+      const ReactDOM = require('react-dom'); // only available in 0.14+
+
+      const document = jsdom.jsdom();
+      const options = { mode: 'mount' };
+      const renderer = adapter.createRenderer(options);
+      const Foo = () => (
+        ReactDOM.createPortal(
+          <div className="Foo">Hello World!</div>,
+          document.body,
+        )
+      );
+
+      renderer.render(<Foo />);
+
+      const node = renderer.getNode();
+
+      cleanNode(node);
+
+      expect(prettyFormat(node)).to.equal(prettyFormat({
+        nodeType: 'function',
+        type: Foo,
+        props: {},
+        ref: null,
+        instance: null,
+        rendered: {
+          nodeType: 'host',
+          type: 'div',
+          props: { className: 'Foo' },
+          ref: null,
+          instance: null,
+          rendered: ['Hello World!'],
+        },
+      }));
+    });
+
     itIf(!REACT013, 'renders simple components returning host components', () => {
       const options = { mode: 'mount' };
       const renderer = adapter.createRenderer(options);

--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -11,7 +11,7 @@ import {
 import { ITERATOR_SYMBOL, sym } from 'enzyme/build/Utils';
 
 import './_helpers/setupAdapters';
-import { createClass } from './_helpers/react-compat';
+import { createClass, createPortal } from './_helpers/react-compat';
 import {
   describeWithDOM,
   describeIf,
@@ -756,6 +756,23 @@ describeWithDOM('mount', () => {
       expect(wrapper.find('[data-foo="bar baz"]')).to.have.length(0);
       expect(wrapper.find('[data-foo="foo  bar"]')).to.have.length(0);
       expect(wrapper.find('[data-foo="bar  baz quz"]')).to.have.length(0);
+    });
+
+    itIf(REACT16, 'should find elements through portals', () => {
+      const containerDiv = global.document.createElement('div');
+
+      class FooPortal extends React.Component {
+        render() {
+          return createPortal(
+            this.props.children,
+            containerDiv,
+          );
+        }
+      }
+
+      const wrapper = mount(<FooPortal><h1>Successful Portal!</h1></FooPortal>);
+      expect(wrapper.find('h1').length).to.equal(1);
+      expect(containerDiv.querySelectorAll('h1').length).to.equal(1);
     });
 
     describeIf(!REACT013, 'stateless function components', () => {

--- a/packages/enzyme-test-suite/test/_helpers/react-compat.js
+++ b/packages/enzyme-test-suite/test/_helpers/react-compat.js
@@ -8,6 +8,7 @@ import { is } from './version';
 
 let createClass;
 let renderToString;
+let createPortal;
 
 if (is('>=15.5 || ^16.0.0-alpha')) {
   // eslint-disable-next-line import/no-extraneous-dependencies
@@ -23,7 +24,14 @@ if (is('^0.13.0')) {
   ({ renderToString } = require('react-dom/server'));
 }
 
+if (is('^16.0.0-alpha')) {
+  ({ createPortal } = require('react-dom'));
+} else {
+  createPortal = null;
+}
+
 export {
   createClass,
   renderToString,
+  createPortal,
 };


### PR DESCRIPTION
I’m happy to add tests, but i don’t really understand the test suite nor where the appropriate place to add them is for the v16 only feature. 


@aweary from what I can tell the Portal fiber is similar to a host component in that it’s essentially a transparent wrapper over it’s rendered children. It does hold some host container info which may be required for actual DOM traversal but in terms of the RST tree this should give an accurate representation as React sees it.

