### PR TITLE
revert peer dependency change for react-test-renderer 14, 15, and 15.4

### DIFF
--- a/docs/installation/react-014.md
+++ b/docs/installation/react-014.md
@@ -7,6 +7,12 @@ installed, you should do so:
 npm i --save react@0.14 react-dom@0.14
 ```
 
+Further, enzyme with React 0.14 requires the test utilities addon be installed:
+
+```bash
+npm i --save-dev react-addons-test-utils@0.14
+```
+
 Next, to get started with enzyme, you can simply install it with npm:
 
 ```bash

--- a/docs/installation/react-15.md
+++ b/docs/installation/react-15.md
@@ -7,6 +7,12 @@ installed, you should do so:
 npm i --save react@15 react-dom@15
 ```
 
+Further, enzyme requires the test utilities addon be installed:
+
+```bash
+npm i --save-dev react-test-renderer@15
+```
+
 Next, to get started with enzyme, you can simply install it with npm:
 
 ```bash

--- a/packages/enzyme-adapter-react-14/package.json
+++ b/packages/enzyme-adapter-react-14/package.json
@@ -38,12 +38,12 @@
     "lodash": "^4.17.4",
     "object.assign": "^4.0.4",
     "object.values": "^1.0.4",
-    "prop-types": "^15.5.10",
-    "react-addons-test-utils": "^0.14.0"
+    "prop-types": "^15.5.10"
   },
   "peerDependencies": {
     "enzyme": "^3.0.0",
     "react": "^0.14.0",
+    "react-addons-test-utils": "^0.14.0",
     "react-dom": "^0.14.0"
   },
   "devDependencies": {

--- a/packages/enzyme-adapter-react-15.4/package.json
+++ b/packages/enzyme-adapter-react-15.4/package.json
@@ -38,13 +38,13 @@
     "lodash": "^4.17.4",
     "object.assign": "^4.0.4",
     "object.values": "^1.0.4",
-    "prop-types": "^15.5.10",
-    "react-addons-test-utils": "15.0.0-0 - 15.4.x"
+    "prop-types": "^15.5.10"
   },
   "peerDependencies": {
     "enzyme": "^3.0.0",
     "react": "15.0.0-0 - 15.4.x",
-    "react-dom": "15.0.0-0 - 15.4.x"
+    "react-dom": "15.0.0-0 - 15.4.x",
+    "react-addons-test-utils": "15.0.0-0 - 15.4.x"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/packages/enzyme-adapter-react-15/package.json
+++ b/packages/enzyme-adapter-react-15/package.json
@@ -38,13 +38,13 @@
     "lodash": "^4.17.4",
     "object.assign": "^4.0.4",
     "object.values": "^1.0.4",
-    "prop-types": "^15.5.10",
-    "react-test-renderer": "^15.5.0"
+    "prop-types": "^15.5.10"
   },
   "peerDependencies": {
     "enzyme": "^3.0.0",
     "react": "^15.5.0",
-    "react-dom": "^15.5.0"
+    "react-dom": "^15.5.0",
+    "react-test-renderer": "^15.5.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
Fix #1277 by reverting the portions of #1252 that affected react 14, 15, and 15.4. React-test-renderer/react-addons-test-utils will again be a peer dependency for those versions.

Leaving react 16's test renderer as a regular dependency because they changed their versioning scheme for 16 so it should be safe (see https://github.com/facebook/react/issues/11278).