### PR TITLE
fix: move react-test-renderer to hard deps for ^15.5.x adapter

### DIFF
--- a/packages/enzyme-adapter-react-15/package.json
+++ b/packages/enzyme-adapter-react-15/package.json
@@ -38,13 +38,13 @@
     "lodash": "^4.17.4",
     "object.assign": "^4.0.4",
     "object.values": "^1.0.4",
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.5.10",
+    "react-test-renderer": "^15.5.0"
   },
   "peerDependencies": {
     "enzyme": "^3.0.0",
     "react": "^15.5.0",
-    "react-dom": "^15.5.0",
-    "react-test-renderer": "^15.5.0"
+    "react-dom": "^15.5.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
The ^16.0.0 adapter includes `react-test-renderer` by default, so it was surprising that the appropriate version wasn't included for ^15.5.0 as well.

I left the 15.0-15.4 adapter alone since its dependency structure is different, but the change should perhaps be made for test utils as well.