### PR TITLE
Better support for iterable children

### DIFF
--- a/packages/enzyme-adapter-utils/src/Utils.js
+++ b/packages/enzyme-adapter-utils/src/Utils.js
@@ -110,11 +110,11 @@ function getIteratorFn(obj) {
 }
 
 function isIterable(obj) {
-  return Boolean(getIteratorFn(obj));
+  return !!getIteratorFn(obj);
 }
 
 export function isArrayLike(obj) {
-  return Array.isArray(obj) || (isIterable(obj) && typeof obj !== 'string');
+  return Array.isArray(obj) || (typeof obj !== 'string' && isIterable(obj));
 }
 
 export function flatten(arrs) {

--- a/packages/enzyme-adapter-utils/src/Utils.js
+++ b/packages/enzyme-adapter-utils/src/Utils.js
@@ -118,6 +118,15 @@ export function isArrayLike(obj) {
 }
 
 export function flatten(arrs) {
+  // optimize for the most common case
+  if (Array.isArray(arrs)) {
+    return arrs.reduce(
+      (flatArrs, item) => flatArrs.concat(isArrayLike(item) ? flatten(item) : item),
+      [],
+    );
+  }
+
+  // fallback for arbitrary iterable children
   let flatArrs = [];
 
   const iteratorFn = getIteratorFn(arrs);

--- a/packages/enzyme-test-suite/test/RSTTraversal-spec.jsx
+++ b/packages/enzyme-test-suite/test/RSTTraversal-spec.jsx
@@ -227,12 +227,13 @@ describe('RSTTraversal', () => {
 
     describe('support for arbitrary iterable children', () => {
       const makeDivIterator = (lowerBound, upperBound) => {
+        const baseCode = 'a'.charCodeAt(0);
         let counter = lowerBound;
 
         return {
           next() {
             if (counter < upperBound) {
-              const key = String.fromCharCode('a'.charCodeAt(0) + counter);
+              const key = String.fromCharCode(baseCode + counter);
 
               const nextValue = {
                 value: <div key={key} />,

--- a/packages/enzyme-test-suite/test/RSTTraversal-spec.jsx
+++ b/packages/enzyme-test-suite/test/RSTTraversal-spec.jsx
@@ -225,6 +225,115 @@ describe('RSTTraversal', () => {
       expect(nodes).to.deep.equal([node, divA, divB, divC, divD]);
     });
 
+    describe('support for arbitrary iterable children', () => {
+      const makeDivIterator = (lowerBound, upperBound) => {
+        let counter = lowerBound;
+
+        return {
+          next() {
+            if (counter < upperBound) {
+              const key = String.fromCharCode('a'.charCodeAt(0) + counter);
+
+              const nextValue = {
+                value: <div key={key} />,
+                done: false,
+              };
+
+              counter += 1;
+
+              return nextValue;
+            }
+
+            return { done: true };
+          },
+        };
+      };
+
+      it('should handle iterable with Symbol.iterator property children', () => {
+        const spy = sinon.spy();
+
+        const iterableChildren = { [Symbol.iterator]: () => makeDivIterator(0, 2) };
+
+        const divA = $(<div key="a" />);
+        const divB = $(<div key="b" />);
+        const node = $((
+          <div>
+            {iterableChildren}
+          </div>
+        ));
+
+        treeForEach(node, spy);
+        expect(spy.callCount).to.equal(3);
+        const nodes = spy.args.map(arg => arg[0]);
+        expect(nodes).to.deep.equal([node, divA, divB]);
+      });
+
+      it('should handle iterable with Symbol.iterator property siblings', () => {
+        const spy = sinon.spy();
+
+        const iterableChildren1 = { [Symbol.iterator]: () => makeDivIterator(0, 2) };
+        const iterableChildren2 = { [Symbol.iterator]: () => makeDivIterator(2, 4) };
+
+        const divA = $(<div key="a" />);
+        const divB = $(<div key="b" />);
+        const divC = $(<div key="c" />);
+        const divD = $(<div key="d" />);
+        const node = $((
+          <div>
+            {iterableChildren1}
+            {iterableChildren2}
+          </div>
+        ));
+
+        treeForEach(node, spy);
+        expect(spy.callCount).to.equal(5);
+        const nodes = spy.args.map(arg => arg[0]);
+        expect(nodes).to.deep.equal([node, divA, divB, divC, divD]);
+      });
+
+      it('should handle iterable with @@iterator property children', () => {
+        const spy = sinon.spy();
+
+        const legacyIterableChildren = { '@@iterator': () => makeDivIterator(0, 2) };
+
+        const divA = $(<div key="a" />);
+        const divB = $(<div key="b" />);
+        const node = $((
+          <div>
+            {legacyIterableChildren}
+          </div>
+        ));
+
+        treeForEach(node, spy);
+        expect(spy.callCount).to.equal(3);
+        const nodes = spy.args.map(arg => arg[0]);
+        expect(nodes).to.deep.equal([node, divA, divB]);
+      });
+
+      it('should handle iterable with @@iterator property siblings', () => {
+        const spy = sinon.spy();
+
+        const legacyIterableChildren1 = { '@@iterator': () => makeDivIterator(0, 2) };
+        const legacyIterableChildren2 = { '@@iterator': () => makeDivIterator(2, 4) };
+
+        const divA = $(<div key="a" />);
+        const divB = $(<div key="b" />);
+        const divC = $(<div key="c" />);
+        const divD = $(<div key="d" />);
+        const node = $((
+          <div>
+            {legacyIterableChildren1}
+            {legacyIterableChildren2}
+          </div>
+        ));
+
+        treeForEach(node, spy);
+        expect(spy.callCount).to.equal(5);
+        const nodes = spy.args.map(arg => arg[0]);
+        expect(nodes).to.deep.equal([node, divA, divB, divC, divD]);
+      });
+    });
+
     it('should not get trapped from empty strings', () => {
       const spy = sinon.spy();
       const node = $((

--- a/packages/enzyme-test-suite/test/Utils-spec.jsx
+++ b/packages/enzyme-test-suite/test/Utils-spec.jsx
@@ -7,6 +7,7 @@ import {
   displayNameOfNode,
 } from 'enzyme/build/Utils';
 import {
+  flatten,
   mapNativeEventNames,
   propFromEvent,
 } from 'enzyme-adapter-utils';
@@ -540,6 +541,14 @@ describe('Utils', () => {
       const children = ['with', 1, <div />, 'other node'];
       const simplified = ['with1', <div />, 'other node'];
       expectEqualArrays(childrenToSimplifiedArray(children), simplified);
+    });
+  });
+
+  describe('flatten', () => {
+    it('should recursively flatten a nested iterable structure', () => {
+      const nested = [1, [2, [3, [4]], 5], 6, [7, [8, 9]], 10];
+      const flat = flatten(nested);
+      expect(flat).to.deep.equal([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     });
   });
 });


### PR DESCRIPTION
…e Object.

Update isIterable function to leverage getIteratorFn.
Rewrite flatten function to leverage getIteratorFn.
Add unit test for flatten function.
Add unit tests for arbitrary iterable children.
Support for Symbol.iterator and @@iterator iterables.