### PR TITLE
Change ShallowWrapper.text() trim spaces with same behavior as ReactWrapper.text()

### DIFF
--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -1648,11 +1648,12 @@ describe('shallow', () => {
           <div>&nbsp;</div>
           <div>&nbsp;&nbsp;</div>
         </div>
-      )
+      );
+
       const wrapper = shallow(Space);
       const mounted = mount(Space);
+
       expect(wrapper.text()).to.equal(mounted.text());
-    })
     });
 
     describeIf(!REACT013, 'stateless function components', () => {

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { shallow, render, ShallowWrapper } from 'enzyme';
+import { shallow, render, ShallowWrapper, mount } from 'enzyme';
 import { ITERATOR_SYMBOL, withSetStateAllowed, sym } from 'enzyme/build/Utils';
 
 import './_helpers/setupAdapters';
@@ -1631,6 +1631,28 @@ describe('shallow', () => {
 
     it('should handle html entities', () => {
       matchesRender(<div>&gt;</div>);
+    });
+
+    it('should handle spaces with same behavior as ReactWarpper.text()', () => {
+      const Space = (
+        <div>
+          <div> test  </div>
+          <div>Hello
+
+
+            World</div>
+          <div>Hello World</div>
+          <div>Hello
+            World</div>
+          <div>Hello     World</div>
+          <div>&nbsp;</div>
+          <div>&nbsp;&nbsp;</div>
+        </div>
+      )
+      const wrapper = shallow(Space);
+      const mounted = mount(Space);
+      expect(wrapper.text()).to.equal(mounted.text());
+    })
     });
 
     describeIf(!REACT013, 'stateless function components', () => {

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -1633,17 +1633,19 @@ describe('shallow', () => {
       matchesRender(<div>&gt;</div>);
     });
 
-    it('should handle spaces with same behavior as ReactWarpper.text()', () => {
+    it('should handle spaces with same behavior as ReactWrapper.text()', () => {
       const Space = (
         <div>
           <div> test  </div>
           <div>Hello
 
 
-            World</div>
+            World
+          </div>
           <div>Hello World</div>
           <div>Hello
-            World</div>
+            World
+          </div>
           <div>Hello     World</div>
           <div>&nbsp;</div>
           <div>&nbsp;&nbsp;</div>

--- a/packages/enzyme/src/RSTTraversal.js
+++ b/packages/enzyme/src/RSTTraversal.js
@@ -126,8 +126,5 @@ export function getTextFromNode(node) {
   }
 
   return childrenOfNode(node).map(getTextFromNode)
-    .join('')
-    .replace(/^[ \t\n\r]+$/g, '') // remove empty nodes
-    .replace(/[ \t\n\r]+/, ' ') // remove double spaces
-    .replace(/(^[ \t\n\r]*|[ \t\n\r]*$)/, ''); // remove spaces from beginning or end
+    .join('');
 }

--- a/packages/enzyme/src/RSTTraversal.js
+++ b/packages/enzyme/src/RSTTraversal.js
@@ -127,5 +127,7 @@ export function getTextFromNode(node) {
 
   return childrenOfNode(node).map(getTextFromNode)
     .join('')
-    .replace(/\s+/, ' ');
+    .replace(/^[ \t\n\r]+$/g, '') // remove empty nodes
+    .replace(/[ \t\n\r]+/, ' ') // remove double spaces
+    .replace(/(^[ \t\n\r]*|[ \t\n\r]*$)/, ''); // remove spaces from beginning or end
 }


### PR DESCRIPTION
ReactWrapper.text() return string with the spaces as is, ShallowWrapper.text() removing double spaces and replacing &nbsp; with regular space (removing doubles as well).

