### PR TITLE
fix env command on Windows

### DIFF
--- a/env.js
+++ b/env.js
@@ -73,7 +73,7 @@ Promise.resolve()
     const peerDeps = adapterJson.peerDependencies;
     const installs = Object.keys(peerDeps)
       .filter(key => !key.startsWith('enzyme'))
-      .map(key => `${key}@'${peerDeps[key]}'`)
+      .map(key => `${key}@"${peerDeps[key]}"`)
       .join(' ');
 
     testJson.dependencies[adapterName] = adapterJson.version;


### PR DESCRIPTION
`npm run react:16` fails on Windows, seem like it's trying to use the quote as part of the version

```
$ npm run react:16

> enzyme@0.0.1 react:16 C:\prj\enzyme
> npm run env -- 16

npm WARN invalid config loglevel="notice"

> enzyme@0.0.1 env C:\prj\enzyme
> babel-node ./env.js "16"

{ Error: Command failed: npm i --no-save react@'^16.0.0-0' react-dom@'^16.0.0-0'
npm WARN invalid config loglevel="notice"
npm ERR! code ETARGET
npm ERR! notarget No matching version found for react@'16.0.0-0'
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\idan\AppData\Roaming\npm-cache\_logs\2017-11-13T00_12_18_992Z-debug.log

    at ChildProcess.exithandler (child_process.js:198:12)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
    at maybeClose (internal/child_process.js:891:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:226:5)
  killed: false,
  code: 1,
  signal: null,
  cmd: 'npm i --no-save react@\'^16.0.0-0\' react-dom@\'^16.0.0-0\'' }
```

Some one please confirm it's still OK on Mac
On Windows & Travis it's working