### PR TITLE
Fix code example in .exists() documentation

### DIFF
--- a/docs/api/ReactWrapper/exists.md
+++ b/docs/api/ReactWrapper/exists.md
@@ -14,5 +14,5 @@ Returns whether or not the current node exists.
 
 ```jsx
 const wrapper = mount(<div className="some-class" />);
-expect(wrapper.find('.other-class').exists()).to.be(false);
+expect(wrapper.find('.other-class').exists()).to.equal(false);
 ```

--- a/docs/api/ReactWrapper/isEmpty.md
+++ b/docs/api/ReactWrapper/isEmpty.md
@@ -15,5 +15,5 @@ Returns whether or not the current node is empty.
 
 ```jsx
 const wrapper = mount(<div className="some-class" />);
-expect(wrapper.find('.other-class').isEmpty()).to.be(true);
+expect(wrapper.find('.other-class').isEmpty()).to.equal(true);
 ```

--- a/docs/api/ReactWrapper/isEmptyRender.md
+++ b/docs/api/ReactWrapper/isEmptyRender.md
@@ -14,5 +14,5 @@ function Foo() {
 }
 
 const wrapper = mount(<Foo />);
-expect(wrapper.isEmptyRender()).to.be(true);
+expect(wrapper.isEmptyRender()).to.equal(true);
 ```

--- a/docs/api/ShallowWrapper/exists.md
+++ b/docs/api/ShallowWrapper/exists.md
@@ -14,5 +14,5 @@ Returns whether or not the current node exists.
 
 ```jsx
 const wrapper = shallow(<div className="some-class" />);
-expect(wrapper.find('.other-class').exists()).to.be(false);
+expect(wrapper.find('.other-class').exists()).to.equal(false);
 ```

--- a/docs/api/ShallowWrapper/isEmpty.md
+++ b/docs/api/ShallowWrapper/isEmpty.md
@@ -15,5 +15,5 @@ Returns whether or not the current node is empty.
 
 ```jsx
 const wrapper = shallow(<div className="some-class" />);
-expect(wrapper.find('.other-class').isEmpty()).to.be(true);
+expect(wrapper.find('.other-class').isEmpty()).to.equal(true);
 ```

--- a/docs/api/ShallowWrapper/isEmptyRender.md
+++ b/docs/api/ShallowWrapper/isEmptyRender.md
@@ -14,5 +14,5 @@ function Foo() {
 }
 
 const wrapper = shallow(<Foo />);
-expect(wrapper.isEmptyRender()).to.be(true);
+expect(wrapper.isEmptyRender()).to.equal(true);
 ```


### PR DESCRIPTION
Corrects `.to.be(false)` to `to.be.false`