### PR TITLE
Update react test renderer to v16.1.1 for React@16

### DIFF
--- a/packages/enzyme-adapter-react-16/package.json
+++ b/packages/enzyme-adapter-react-16/package.json
@@ -39,7 +39,7 @@
     "object.assign": "^4.0.4",
     "object.values": "^1.0.4",
     "prop-types": "^15.5.10",
-    "react-test-renderer": "^16.0.0-0"
+    "react-test-renderer": "^16.1.1"
   },
   "peerDependencies": {
     "enzyme": "^3.0.0",


### PR DESCRIPTION
This addressed the following issue: https://github.com/airbnb/enzyme/issues/1366