### PR TITLE
`enzyme-adapter-react-helper`: [New] add `ifReact`

### DIFF
--- a/packages/enzyme-adapter-react-helper/src/ifReact.js
+++ b/packages/enzyme-adapter-react-helper/src/ifReact.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { intersects } from 'semver';
+
+export default function ifReact(range, yes, no) {
+  if (typeof yes !== 'function') { throw new TypeError('"yes" must be a function'); }
+  if (typeof no !== 'function') { throw new TypeError('"no" must be a function'); }
+  return intersects(range, React.version) ? yes : no;
+}


### PR DESCRIPTION
This PR adds an `ifReact` entry point. The goal is to use it like this:
```js
import ifReact from 'enzyme-adapter-react-helper/build/ifReact';

describe('some stuff', () => {
  ifReact('>= 14', it, it.skip)('is a test with SFCs', () => {
    …
  });
});
```

The reason to take a yes and a no function, instead of hardcoding it/it.skip, is so that it's not tightly coupled to mocha/jest/jasmine.