### PR TITLE
[enzyme-adapter-react-helper] [New] add `safeSFC`

### DIFF
--- a/packages/enzyme-adapter-react-helper/package.json
+++ b/packages/enzyme-adapter-react-helper/package.json
@@ -57,6 +57,7 @@
     "install-peerdeps": "^1.4.1",
     "npm-run": "^4.1.2",
     "object.assign": "^4.0.4",
+    "object.getownpropertydescriptors": "^2.0.3",
     "semver": "^5.4.1"
   }
 }

--- a/packages/enzyme-adapter-react-helper/src/safeSFC.jsx
+++ b/packages/enzyme-adapter-react-helper/src/safeSFC.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import gOPDs from 'object.getownpropertydescriptors';
+
+import ifReact from './ifReact';
+
+function assertFunction(fn) {
+  if (typeof fn !== 'function') {
+    throw new TypeError('Component must be a function');
+  }
+  return fn;
+}
+
+function safeSFC(fn) {
+  assertFunction(fn);
+
+  class SafeSFC extends React.Component {
+    render() {
+      return fn(this.props, this.context);
+    }
+  }
+  SafeSFC.displayName = fn.displayName || fn.name;
+  const {
+    prototype: oldProto,
+    ...descriptors
+  } = gOPDs(fn);
+  Object.defineProperties(SafeSFC, descriptors);
+  return SafeSFC;
+}
+
+export default ifReact('>= 0.14', assertFunction, safeSFC);


### PR DESCRIPTION
Where you’d otherwise have an SFC in tests, use safeSFC to make your tests work in React 0.13 also:
```js
const Foo = safeSFC(function Foo(props, context) {
  return null;
});

const wrapper = shallow(<Foo />);
```

Static properties are copied over.

The intention was to ensure that SFCs only worked in React 0.13 *in tests*, for convenience - never in production code, to mirror actual React 0.13 usage.

Other alternatives I considered and rejected include:
 - a babel transform only in test dirs (too hard to have reliable component detection)
 - an alternative enzyme adapter (would be overly complex to integrate with the helper's main export, and would work for production components too)
 - monkeypatching React 0.13 (nope_octopus.gif)