### PR TITLE
.contains() edge cases

### DIFF
--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -369,31 +369,6 @@ describeWithDOM('mount', () => {
         const b = <Foo />;
         expect(wrapper.contains(b)).to.equal(true);
       });
-
-      it('should match composite components based on component display name', () => {
-        function Foo() {
-          return <div />;
-        }
-        const wrapper = mount((
-          <div>
-            <Foo />
-          </div>
-        ));
-        expect(wrapper.contains('Foo')).to.equal(true);
-      });
-
-      it('should match composite components based on component display name if rendered by function', () => {
-        function Foo() {
-          return <div />;
-        }
-        const renderStatelessComponent = () => <Foo />;
-        const wrapper = mount((
-          <div>
-            {renderStatelessComponent()}
-          </div>
-        ));
-        expect(wrapper.contains('Foo')).to.equal(true);
-      });
     });
   });
 

--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -344,7 +344,9 @@ describeWithDOM('mount', () => {
 
     describeIf(!REACT013, 'stateless components', () => {
       it('should match composite components', () => {
-        const Foo = () => <div />;
+        function Foo() {
+          return <div />;
+        }
         const wrapper = mount((
           <div>
             <Foo />
@@ -352,6 +354,45 @@ describeWithDOM('mount', () => {
         ));
         const b = <Foo />;
         expect(wrapper.contains(b)).to.equal(true);
+      });
+
+      it('should match composite components if rendered by function', () => {
+        function Foo() {
+          return <div />;
+        }
+        const renderStatelessComponent = () => <Foo />;
+        const wrapper = mount((
+          <div>
+            {renderStatelessComponent()}
+          </div>
+        ));
+        const b = <Foo />;
+        expect(wrapper.contains(b)).to.equal(true);
+      });
+
+      it('should match composite components based on component display name', () => {
+        function Foo() {
+          return <div />;
+        }
+        const wrapper = mount((
+          <div>
+            <Foo />
+          </div>
+        ));
+        expect(wrapper.contains('Foo')).to.equal(true);
+      });
+
+      it('should match composite components based on component display name if rendered by function', () => {
+        function Foo() {
+          return <div />;
+        }
+        const renderStatelessComponent = () => <Foo />;
+        const wrapper = mount((
+          <div>
+            {renderStatelessComponent()}
+          </div>
+        ));
+        expect(wrapper.contains('Foo')).to.equal(true);
       });
     });
   });
@@ -481,6 +522,29 @@ describeWithDOM('mount', () => {
         </div>
       ));
       expect(wrapper.find('Foo').type()).to.equal(Foo);
+    });
+
+    describeIf(!REACT013, 'stateless components', () => {
+      it('should find a stateless component based on a component displayName', () => {
+        const Foo = () => <div />;
+        const wrapper = mount((
+          <div>
+            <Foo className="foo" />
+          </div>
+        ));
+        expect(wrapper.find('Foo').type()).to.equal(Foo);
+      });
+
+      it('should find a stateless component based on a component displayName if rendered by function', () => {
+        const Foo = () => <div />;
+        const renderStatelessComponent = () => <Foo className="foo" />;
+        const wrapper = mount((
+          <div>
+            {renderStatelessComponent()}
+          </div>
+        ));
+        expect(wrapper.find('Foo').type()).to.equal(Foo);
+      });
     });
 
     it('should find component based on a react prop', () => {

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -322,31 +322,6 @@ describe('shallow', () => {
         const b = <Foo />;
         expect(wrapper.contains(b)).to.equal(true);
       });
-
-      it('should match composite components based on component display name', () => {
-        function Foo() {
-          return <div />;
-        }
-        const wrapper = shallow((
-          <div>
-            <Foo />
-          </div>
-        ));
-        expect(wrapper.contains('Foo')).to.equal(true);
-      });
-
-      it('should match composite components based on component display name if rendered by function', () => {
-        function Foo() {
-          return <div />;
-        }
-        const renderStatelessComponent = () => <Foo />;
-        const wrapper = shallow((
-          <div>
-            {renderStatelessComponent()}
-          </div>
-        ));
-        expect(wrapper.contains('Foo')).to.equal(true);
-      });
     });
   });
 

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -296,9 +296,9 @@ describe('shallow', () => {
 
     describeIf(!REACT013, 'stateless function components', () => {
       it('should match composite components', () => {
-        const Foo = () => (
-          <div />
-        );
+        function Foo() {
+          return <div />;
+        }
 
         const wrapper = shallow((
           <div>
@@ -307,6 +307,45 @@ describe('shallow', () => {
         ));
         const b = <Foo />;
         expect(wrapper.contains(b)).to.equal(true);
+      });
+
+      it('should match composite components if rendered by function', () => {
+        function Foo() {
+          return <div />;
+        }
+        const renderStatelessComponent = () => <Foo />;
+        const wrapper = shallow((
+          <div>
+            {renderStatelessComponent()}
+          </div>
+        ));
+        const b = <Foo />;
+        expect(wrapper.contains(b)).to.equal(true);
+      });
+
+      it('should match composite components based on component display name', () => {
+        function Foo() {
+          return <div />;
+        }
+        const wrapper = shallow((
+          <div>
+            <Foo />
+          </div>
+        ));
+        expect(wrapper.contains('Foo')).to.equal(true);
+      });
+
+      it('should match composite components based on component display name if rendered by function', () => {
+        function Foo() {
+          return <div />;
+        }
+        const renderStatelessComponent = () => <Foo />;
+        const wrapper = shallow((
+          <div>
+            {renderStatelessComponent()}
+          </div>
+        ));
+        expect(wrapper.contains('Foo')).to.equal(true);
       });
     });
   });


### PR DESCRIPTION
I've added a few more passing tests in [**686f31a**](https://github.com/airbnb/enzyme/pull/1410/commits/686f31a2b9a0e223d7f50eb24f158e8b7d4b5166). Based on the illustrated behaviour of both `.find` and `.contains` I assumed the behaviour of `.find` illustrated in [**46f5da8**](https://github.com/airbnb/enzyme/pull/1410/commits/46f5da83e9c2e9f1f8525e17769fc6a97d0317c6). Not sure whether this is a bug report or a feature request.

Passing:
```jsx
const Foo = () => <div />;
const wrapper = mount((
  <div>
    <Foo className="foo" />
  </div>
));
expect(wrapper.find('Foo').type()).to.equal(Foo);
```

Not passing:
```jsx
const Foo = () => <div />;
const wrapper = mount((
  <div>
    <Foo className="foo" />
  </div>
));
expect(wrapper.contains('Foo')).to.equal(true);
```