### PR TITLE
[Fix] Convert nodes to RST nodes before comparing

### DIFF
--- a/packages/enzyme/src/ReactWrapper.js
+++ b/packages/enzyme/src/ReactWrapper.js
@@ -374,9 +374,13 @@ class ReactWrapper {
    * @returns {Boolean}
    */
   contains(nodeOrNodes) {
+    const isArray = Array.isArray(nodeOrNodes);
+    const rstNodeOrNodes = isArray
+      ? nodeOrNodes.map(getAdapter().elementToNode)
+      : getAdapter().elementToNode(nodeOrNodes);
     const predicate = Array.isArray(nodeOrNodes)
-      ? other => containsChildrenSubArray(nodeEqual, other, nodeOrNodes)
-      : other => nodeEqual(nodeOrNodes, other);
+      ? other => containsChildrenSubArray(nodeEqual, other, rstNodeOrNodes)
+      : other => nodeEqual(rstNodeOrNodes, other);
     return findWhereUnwrapped(this, predicate).length > 0;
   }
 
@@ -397,7 +401,8 @@ class ReactWrapper {
    * @returns {Boolean}
    */
   containsMatchingElement(node) {
-    const predicate = other => nodeMatches(node, other, (a, b) => a <= b);
+    const rstNode = getAdapter().elementToNode(node);
+    const predicate = other => nodeMatches(rstNode, other, (a, b) => a <= b);
     return findWhereUnwrapped(this, predicate).length > 0;
   }
 
@@ -424,7 +429,9 @@ class ReactWrapper {
       throw new TypeError('nodes should be an Array');
     }
 
-    return nodes.every(node => this.containsMatchingElement(node));
+    const rstNodes = nodes.map(getAdapter().elementToNode);
+
+    return rstNodes.every(rstNode => this.containsMatchingElement(rstNode));
   }
 
   /**
@@ -446,7 +453,10 @@ class ReactWrapper {
    * @returns {Boolean}
    */
   containsAnyMatchingElements(nodes) {
-    return Array.isArray(nodes) && nodes.some(node => this.containsMatchingElement(node));
+    const rstNodes = nodes.map(getAdapter().elementToNode);
+
+    return Array.isArray(rstNodes)
+    && rstNodes.some(rstNode => this.containsMatchingElement(rstNode));
   }
 
   /**

--- a/packages/enzyme/src/ReactWrapper.js
+++ b/packages/enzyme/src/ReactWrapper.js
@@ -358,8 +358,10 @@ class ReactWrapper {
    * @returns {Boolean}
    */
   matchesElement(node) {
-    const rstNode = getAdapter().elementToNode(node);
-    return this.single('matchesElement', () => nodeMatches(rstNode, this.getNodeInternal(), (a, b) => a <= b));
+    return this.single('matchesElement', () => {
+      const rstNode = getAdapter().elementToNode(node);
+      return nodeMatches(rstNode, this.getNodeInternal(), (a, b) => a <= b);
+    });
   }
 
   /**
@@ -376,12 +378,16 @@ class ReactWrapper {
    */
   contains(nodeOrNodes) {
     const isArray = Array.isArray(nodeOrNodes);
-    const rstNodeOrNodes = isArray
-      ? nodeOrNodes.map(getAdapter().elementToNode)
-      : getAdapter().elementToNode(nodeOrNodes);
-    const predicate = Array.isArray(nodeOrNodes)
-      ? other => containsChildrenSubArray(nodeEqual, other, rstNodeOrNodes)
-      : other => nodeEqual(rstNodeOrNodes, other);
+    let predicate;
+
+    if (isArray) {
+      const rstNodes = nodeOrNodes.map(getAdapter().elementToNode);
+      predicate = other => containsChildrenSubArray(nodeEqual, other, rstNodes);
+    } else {
+      const rstNode = getAdapter().elementToNode(nodeOrNodes);
+      predicate = other => nodeEqual(rstNode, other);
+    }
+
     return findWhereUnwrapped(this, predicate).length > 0;
   }
 
@@ -454,10 +460,9 @@ class ReactWrapper {
    * @returns {Boolean}
    */
   containsAnyMatchingElements(nodes) {
+    if (!Array.isArray(nodes)) { return false; }
     const rstNodes = nodes.map(getAdapter().elementToNode);
-
-    return Array.isArray(rstNodes)
-    && rstNodes.some(rstNode => this.containsMatchingElement(rstNode));
+    return rstNodes.some(rstNode => this.containsMatchingElement(rstNode));
   }
 
   /**

--- a/packages/enzyme/src/ReactWrapper.js
+++ b/packages/enzyme/src/ReactWrapper.js
@@ -383,7 +383,7 @@ class ReactWrapper {
       ? other => containsChildrenSubArray(
         nodeEqual,
         other,
-        nodeOrNodes.map(adapter.elementToNode),
+        nodeOrNodes.map(node => adapter.elementToNode(node)),
       )
       : other => nodeEqual(adapter.elementToNode(nodeOrNodes), other);
 

--- a/packages/enzyme/src/ReactWrapper.js
+++ b/packages/enzyme/src/ReactWrapper.js
@@ -358,7 +358,8 @@ class ReactWrapper {
    * @returns {Boolean}
    */
   matchesElement(node) {
-    return this.single('matchesElement', () => nodeMatches(node, this.getNodeInternal(), (a, b) => a <= b));
+    const rstNode = getAdapter().elementToNode(node);
+    return this.single('matchesElement', () => nodeMatches(rstNode, this.getNodeInternal(), (a, b) => a <= b));
   }
 
   /**

--- a/packages/enzyme/src/ReactWrapper.js
+++ b/packages/enzyme/src/ReactWrapper.js
@@ -377,16 +377,15 @@ class ReactWrapper {
    * @returns {Boolean}
    */
   contains(nodeOrNodes) {
-    const isArray = Array.isArray(nodeOrNodes);
-    let predicate;
+    const adapter = getAdapter(this[OPTIONS]);
 
-    if (isArray) {
-      const rstNodes = nodeOrNodes.map(getAdapter().elementToNode);
-      predicate = other => containsChildrenSubArray(nodeEqual, other, rstNodes);
-    } else {
-      const rstNode = getAdapter().elementToNode(nodeOrNodes);
-      predicate = other => nodeEqual(rstNode, other);
-    }
+    const predicate = Array.isArray(nodeOrNodes)
+      ? other => containsChildrenSubArray(
+        nodeEqual,
+        other,
+        nodeOrNodes.map(adapter.elementToNode),
+      )
+      : other => nodeEqual(adapter.elementToNode(nodeOrNodes), other);
 
     return findWhereUnwrapped(this, predicate).length > 0;
   }
@@ -408,7 +407,7 @@ class ReactWrapper {
    * @returns {Boolean}
    */
   containsMatchingElement(node) {
-    const rstNode = getAdapter().elementToNode(node);
+    const rstNode = getAdapter(this[OPTIONS]).elementToNode(node);
     const predicate = other => nodeMatches(rstNode, other, (a, b) => a <= b);
     return findWhereUnwrapped(this, predicate).length > 0;
   }
@@ -436,9 +435,7 @@ class ReactWrapper {
       throw new TypeError('nodes should be an Array');
     }
 
-    const rstNodes = nodes.map(getAdapter().elementToNode);
-
-    return rstNodes.every(rstNode => this.containsMatchingElement(rstNode));
+    return nodes.every(node => this.containsMatchingElement(node));
   }
 
   /**
@@ -460,9 +457,7 @@ class ReactWrapper {
    * @returns {Boolean}
    */
   containsAnyMatchingElements(nodes) {
-    if (!Array.isArray(nodes)) { return false; }
-    const rstNodes = nodes.map(getAdapter().elementToNode);
-    return rstNodes.some(rstNode => this.containsMatchingElement(rstNode));
+    return Array.isArray(nodes) && nodes.some(node => this.containsMatchingElement(node));
   }
 
   /**

--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -451,7 +451,7 @@ class ShallowWrapper {
       ? other => containsChildrenSubArray(
         nodeEqual,
         other,
-        nodeOrNodes.map(adapter.elementToNode),
+        nodeOrNodes.map(node => adapter.elementToNode(node)),
       )
       : other => nodeEqual(adapter.elementToNode(nodeOrNodes), other);
 

--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -476,7 +476,8 @@ class ShallowWrapper {
    * @returns {Boolean}
    */
   containsMatchingElement(node) {
-    const predicate = other => nodeMatches(node, other, (a, b) => a <= b);
+    const rstNode = getAdapter().elementToNode(node);
+    const predicate = other => nodeMatches(rstNode, other, (a, b) => a <= b);
     return findWhereUnwrapped(this, predicate).length > 0;
   }
 
@@ -564,7 +565,10 @@ class ShallowWrapper {
    * @returns {Boolean}
    */
   matchesElement(node) {
-    return this.single('matchesElement', () => nodeMatches(node, this.getNodeInternal(), (a, b) => a <= b));
+    return this.single('matchesElement', () => {
+      const rstNode = getAdapter().elementToNode(node);
+      return nodeMatches(rstNode, this.getNodeInternal(), (a, b) => a <= b);
+    });
   }
 
   /**


### PR DESCRIPTION
- Convert nodes in `contains` functions to RST before comparing 

- Fixes #1422