### PR TITLE
Add example to contains() docs with an embedded expression

### DIFF
--- a/docs/api/ShallowWrapper/contains.md
+++ b/docs/api/ShallowWrapper/contains.md
@@ -56,6 +56,17 @@ expect(wrapper.contains([
 ])).to.equal(false);
 ```
 
+```jsx
+const calculatedValue = 2 + 2;
+
+const wrapper = shallow((
+  <div>
+    <div data-foo="foo" data-bar="bar">{calculatedValue}</div>
+  </div>
+));
+
+expect(wrapper.contains(<div data-foo="foo" data-bar="bar">{4}</div>)).to.equal(true);
+```
 
 #### Common Gotchas
 


### PR DESCRIPTION
This may be obvious to most, but it wasn't for me, that contains() is comparing JSX (rather than the resulting html) and therefore curly braces are required with embedded expressions.