### PR TITLE
Make it clear that shallow rendering does call lifecycle methods.

### DIFF
--- a/docs/api/mount.md
+++ b/docs/api/mount.md
@@ -1,8 +1,6 @@
 # Full Rendering API (`mount(...)`)
 
-Full DOM rendering is ideal for use cases where you have components that may interact with DOM APIs,
-or may require the full lifecycle in order to fully test the component (i.e., `componentDidMount`
-etc.)
+Full DOM rendering is ideal for use cases where you have components that may interact with DOM APIs or need to test components that are wrapped in higher order components.
 
 Full DOM rendering requires that a full DOM API be available at the global scope. This means that
 it must be run in an environment that at least “looks like” a browser environment. If you do not

--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -3,7 +3,7 @@
 Shallow rendering is useful to constrain yourself to testing a component as a unit, and to ensure
 that your tests aren't indirectly asserting on behavior of child components.
 
-As of Enzyme v3, the `shallow` API does call React lifecycle methods such as `componentDidMount` and `componentDidUpdate`.
+As of Enzyme v3, the `shallow` API does call React lifecycle methods such as `componentDidMount` and `componentDidUpdate`. You can read more about this in the [version 3 migration guide](../guides/migration-from-2-to-3.md#lifecycle-methods).
 
 ```jsx
 import { shallow } from 'enzyme';

--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -3,6 +3,8 @@
 Shallow rendering is useful to constrain yourself to testing a component as a unit, and to ensure
 that your tests aren't indirectly asserting on behavior of child components.
 
+As of Enzyme v3, the `shallow` API does call React lifecycle methods such as `componentDidMount` and `componentDidUpdate`.
+
 ```jsx
 import { shallow } from 'enzyme';
 import sinon from 'sinon';


### PR DESCRIPTION
I know it was in the v3 migration guide and it is mentioned if you carefully read the docs but as a regular Enzyme user I managed to completely miss this change!

This is 100% my fault, I'm not saying otherwise, but thought this small tweak to the docs might make that clearer in case any other devs make my mistake. If you disagree feel free to close :)