### PR TITLE
Provide migration instructions for `ref(refName)`

### DIFF
--- a/docs/guides/migration-from-2-to-3.md
+++ b/docs/guides/migration-from-2-to-3.md
@@ -391,6 +391,11 @@ expect(wrapper.ref('abc')).toBeInstanceOf(Box);
 In our experience, this is most often what people would actually want and expect out of the `.ref(...)`
 method.
 
+To get the wrapper that was returned by enzyme 2:
+```js
+const wrapper = mount(<Bar />);
+const refWrapper = wrapper.findWhere(n => n.instance() === wrapper.ref('abc'));
+```
 
 ## With `mount`, `.instance()` can be called at any level of the tree
 


### PR DESCRIPTION
The migration guide does not currently include any information on how to migrate tests that rely on the enzyme 2 behavior for `ref(refName)`