### PR TITLE
Add null option to shallow type() comment & docs

### DIFF
--- a/docs/api/ReactWrapper/name.md
+++ b/docs/api/ReactWrapper/name.md
@@ -1,7 +1,7 @@
 # `.name() => String|null`
 
 Returns the name of the current node of this wrapper. If it's a composite component, this will be
-the name of the component. If it's native DOM node, it will be a string of the tag name. If it's
+the name of the component. If it's a native DOM node, it will be a string of the tag name. If it's
 `null`, it will be `null`.
 
 The order of precedence on returning the name is: `type.displayName` -> `type.name` -> `type`.

--- a/docs/api/ReactWrapper/type.md
+++ b/docs/api/ReactWrapper/type.md
@@ -1,7 +1,7 @@
 # `.type() => String|Function`
 
 Returns the type of the current node of this wrapper. If it's a composite component, this will be
-the component constructor. If it's native DOM node, it will be a string of the tag name.
+the component constructor. If it's a native DOM node, it will be a string of the tag name.
 
 Note: can only be called on a wrapper of a single node.
 

--- a/docs/api/ShallowWrapper/name.md
+++ b/docs/api/ShallowWrapper/name.md
@@ -1,7 +1,7 @@
 # `.name() => String|null`
 
 Returns the name of the current node of this wrapper. If it's a composite component, this will be
-the name of the top-most rendered component. If it's native DOM node, it will be a string of the
+the name of the top-most rendered component. If it's a native DOM node, it will be a string of the
 tag name. If it's `null`, it will be `null`.
 
 The order of precedence on returning the name is: `type.displayName` -> `type.name` -> `type`.

--- a/docs/api/ShallowWrapper/type.md
+++ b/docs/api/ShallowWrapper/type.md
@@ -1,7 +1,7 @@
 # `.type() => String|Function|null`
 
 Returns the type of the current node of this wrapper. If it's a composite component, this will be
-the component constructor. If it's native DOM node, it will be a string of the tag name. If it's `null`, it will be `null`.
+the component constructor. If it's a native DOM node, it will be a string of the tag name. If it's `null`, it will be `null`.
 
 Note: can only be called on a wrapper of a single node.
 

--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -192,7 +192,7 @@ Calls `.forceUpdate()` on the root component instance.
 #### [`.debug() => String`](ShallowWrapper/debug.md)
 Returns a string representation of the current shallow render tree for debugging purposes.
 
-#### [`.type() => String|Function`](ShallowWrapper/type.md)
+#### [`.type() => String|Function|null`](ShallowWrapper/type.md)
 Returns the type of the current node of the wrapper.
 
 #### [`.name() => String`](ShallowWrapper/name.md)

--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -852,9 +852,10 @@ class ShallowWrapper {
 
   /**
    * Returns the type of the current node of this wrapper. If it's a composite component, this will
-   * be the component constructor. If it's a native DOM node, it will be a string.
+   * be the component constructor. If it's a native DOM node, it will be a string of the tag name.
+   * If it's null, it will be null.
    *
-   * @returns {String|Function}
+   * @returns {String|Function|null}
    */
   type() {
     return this.single('type', typeOfNode);


### PR DESCRIPTION
Also fixes a docs typo I ran into that was replicated in a few places.