### PR TITLE
Fix ShallowWrapper for array-rendering components

### DIFF
--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -231,7 +231,9 @@ class ReactSixteenAdapter extends EnzymeAdapter {
           key: cachedNode.key || undefined,
           ref: cachedNode.ref,
           instance: renderer._instance,
-          rendered: elementToTree(output),
+          rendered: Array.isArray(output)
+            ? flatten(output).map(elementToTree)
+            : elementToTree(output),
         };
       },
       simulateEvent(node, event, ...args) {

--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -3117,6 +3117,19 @@ describeWithDOM('mount', () => {
     expect(rendered.html()).to.equal(null);
   });
 
+  itIf(REACT16, 'works with class components that return arrays', () => {
+    class Foo extends React.Component {
+      render() {
+        return [<div />, <div />];
+      }
+    }
+    const wrapper = mount(<Foo />);
+    expect(wrapper).to.have.lengthOf(1);
+    expect(wrapper.type()).to.equal(Foo);
+    expect(wrapper.children()).to.have.lengthOf(2);
+    expect(wrapper.find('div')).to.have.lengthOf(2);
+  });
+
   itIf(is('>=15 || ^16.0.0-alpha'), 'works with SFCs that return null', () => {
     const Foo = () => null;
 

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -3964,6 +3964,17 @@ describe('shallow', () => {
     expect(rendered.html()).to.equal(null);
   });
 
+  itIf(REACT16, 'works with class components that return arrays', () => {
+    class Foo extends React.Component {
+      render() {
+        return [<div />, <div />];
+      }
+    }
+    const wrapper = shallow(<Foo />);
+    expect(wrapper).to.have.lengthOf(2);
+    expect(wrapper.find('div')).to.have.lengthOf(2);
+  });
+
   itIf(is('>=15 || ^16.0.0-alpha'), 'works with SFCs that return null', () => {
     const Foo = () => null;
 

--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -99,6 +99,17 @@ function getRootNode(node) {
   return node.rendered;
 }
 
+function privateSetNodes(wrapper, nodes) {
+  if (!Array.isArray(nodes)) {
+    privateSet(wrapper, NODE, nodes);
+    privateSet(wrapper, NODES, [nodes]);
+  } else {
+    privateSet(wrapper, NODE, nodes[0]);
+    privateSet(wrapper, NODES, nodes);
+  }
+  privateSet(wrapper, 'length', wrapper[NODES].length);
+}
+
 /**
  * @class ShallowWrapper
  */
@@ -122,25 +133,15 @@ class ShallowWrapper {
           instance.componentDidMount();
         });
       }
-      privateSet(this, NODE, getRootNode(this[RENDERER].getNode()));
-      privateSet(this, NODES, [this[NODE]]);
-      this.length = 1;
+      privateSetNodes(this, getRootNode(this[RENDERER].getNode()));
     } else {
       privateSet(this, ROOT, root);
       privateSet(this, UNRENDERED, null);
       privateSet(this, RENDERER, root[RENDERER]);
-      if (!Array.isArray(nodes)) {
-        privateSet(this, NODE, nodes);
-        privateSet(this, NODES, [nodes]);
-      } else {
-        privateSet(this, NODE, nodes[0]);
-        privateSet(this, NODES, nodes);
-      }
-      this.length = this[NODES].length;
+      privateSetNodes(this, nodes);
     }
     privateSet(this, OPTIONS, root ? root[OPTIONS] : options);
   }
-
 
   /**
    * Returns the root wrapper
@@ -227,8 +228,7 @@ class ShallowWrapper {
       throw new Error('ShallowWrapper::update() can only be called on the root');
     }
     this.single('update', () => {
-      this[NODE] = getRootNode(this[RENDERER].getNode());
-      this[NODES] = [this[NODE]];
+      privateSetNodes(this, getRootNode(this[RENDERER].getNode()));
     });
     return this;
   }


### PR DESCRIPTION
This PR is in support of https://github.com/airbnb/enzyme/issues/1149.
There are two main assumptions that I've fixed:

- in `ReactSixteenAdapter`, flatten and map over the render output if possible, instead of assuming that it is always an element
- in `ShallowWrapper`, reuse existing logic to set `NODE` and `NODES` appropriately when the root node is an array