### PR TITLE
Updating docs for shallow disableLifecycleMethods

### DIFF
--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -48,7 +48,7 @@ describe('<MyComponent />', () => {
   - `options.context`: (`Object` [optional]): Context to be passed into the component
   - `options.disableLifecycleMethods`: (`Boolean` [optional]): If set to true, `componentDidMount`
 is not called on the component, and `componentDidUpdate` is not called after
-[`setProps`](ShallowWrapper/setProps.md) and [`setContext`](ShallowWrapper/setContext.md). Default to `false`.
+[`setProps`](ShallowWrapper/setProps.md) and [`setContext`](ShallowWrapper/setContext.md). Defaults to `true`.
 
 #### Returns
 


### PR DESCRIPTION
As of enzyme v3, disableLifecycleMethods defaults to true instead of false. Even though this is explained in a variety of places, the actual documentation for `shallow()` still says that it defaults to false, which is no longer true.