### PR TITLE
return null for missing keys

### DIFF
--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -3153,6 +3153,15 @@ describeWithDOM('mount', () => {
       expect(wrapper.at(1).key()).to.equal('bar');
       expect(wrapper.at(2).key()).to.equal('');
     });
+
+    it('should return null when no key is specified', () => {
+      const wrapper = mount((
+        <ul>
+          <li>foo</li>
+        </ul>
+      )).find('li');
+      expect(wrapper.key()).to.equal(null);
+    });
   });
 
   describe('.matchesElement(node)', () => {

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -4014,6 +4014,15 @@ describe('shallow', () => {
       expect(wrapper.at(1).key()).to.equal('bar');
       expect(wrapper.at(2).key()).to.equal('');
     });
+
+    it('should return null when no key is specified', () => {
+      const wrapper = shallow((
+        <ul>
+          <li>foo</li>
+        </ul>
+      )).find('li');
+      expect(wrapper.key()).to.equal(null);
+    });
   });
 
   describe('.matchesElement(node)', () => {

--- a/packages/enzyme/src/ReactWrapper.js
+++ b/packages/enzyme/src/ReactWrapper.js
@@ -703,7 +703,7 @@ class ReactWrapper {
    * @returns {String}
    */
   key() {
-    return this.single('key', n => n.key);
+    return this.single('key', n => (n.key === undefined ? null : n.key));
   }
 
   /**

--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -845,7 +845,7 @@ class ShallowWrapper {
    * @returns {String}
    */
   key() {
-    return this.single('key', n => n.key);
+    return this.single('key', n => (n.key === undefined ? null : n.key));
   }
 
   /**


### PR DESCRIPTION
Fixes #1488 by checking if a key is undefined, and if so, returning null.

Without the code changes, the new tests will fail with errors like this

`AssertionError: expected undefined to equal null`