### PR TITLE
Fix to call ref for a root element

### DIFF
--- a/packages/enzyme-adapter-react-13/src/ReactThirteenAdapter.js
+++ b/packages/enzyme-adapter-react-13/src/ReactThirteenAdapter.js
@@ -111,12 +111,15 @@ class ReactThirteenAdapter extends EnzymeAdapter {
     return {
       render(el, context, callback) {
         if (instance === null) {
-          const ReactWrapperComponent = createMountWrapper(el, options);
-          const wrappedEl = React.createElement(ReactWrapperComponent, {
-            Component: el.type,
-            props: el.props,
+          const { ref, type, props } = el;
+          const wrapperProps = {
+            Component: type,
+            props,
             context,
-          });
+            ...(ref && { ref }),
+          };
+          const ReactWrapperComponent = createMountWrapper(el, options);
+          const wrappedEl = React.createElement(ReactWrapperComponent, wrapperProps);
           instance = React.render(wrappedEl, domNode);
           if (typeof callback === 'function') {
             callback();

--- a/packages/enzyme-adapter-react-14/src/ReactFourteenAdapter.js
+++ b/packages/enzyme-adapter-react-14/src/ReactFourteenAdapter.js
@@ -83,12 +83,15 @@ class ReactFifteenAdapter extends EnzymeAdapter {
     return {
       render(el, context, callback) {
         if (instance === null) {
-          const ReactWrapperComponent = createMountWrapper(el, options);
-          const wrappedEl = React.createElement(ReactWrapperComponent, {
-            Component: el.type,
-            props: el.props,
+          const { type, props, ref } = el;
+          const wrapperProps = {
+            Component: type,
+            props,
             context,
-          });
+            ...(ref && { ref }),
+          };
+          const ReactWrapperComponent = createMountWrapper(el, options);
+          const wrappedEl = React.createElement(ReactWrapperComponent, wrapperProps);
           instance = ReactDOM.render(wrappedEl, domNode);
           if (typeof callback === 'function') {
             callback();

--- a/packages/enzyme-adapter-react-15.4/src/ReactFifteenFourAdapter.js
+++ b/packages/enzyme-adapter-react-15.4/src/ReactFifteenFourAdapter.js
@@ -114,12 +114,15 @@ class ReactFifteenFourAdapter extends EnzymeAdapter {
     return {
       render(el, context, callback) {
         if (instance === null) {
-          const ReactWrapperComponent = createMountWrapper(el, options);
-          const wrappedEl = React.createElement(ReactWrapperComponent, {
-            Component: el.type,
-            props: el.props,
+          const { type, props, ref } = el;
+          const wrapperProps = {
+            Component: type,
+            props,
             context,
-          });
+            ...(ref && { ref }),
+          };
+          const ReactWrapperComponent = createMountWrapper(el, options);
+          const wrappedEl = React.createElement(ReactWrapperComponent, wrapperProps);
           instance = ReactDOM.render(wrappedEl, domNode);
           if (typeof callback === 'function') {
             callback();

--- a/packages/enzyme-adapter-react-15/src/ReactFifteenAdapter.js
+++ b/packages/enzyme-adapter-react-15/src/ReactFifteenAdapter.js
@@ -114,12 +114,15 @@ class ReactFifteenAdapter extends EnzymeAdapter {
     return {
       render(el, context, callback) {
         if (instance === null) {
-          const ReactWrapperComponent = createMountWrapper(el, options);
-          const wrappedEl = React.createElement(ReactWrapperComponent, {
-            Component: el.type,
-            props: el.props,
+          const { type, props, ref } = el;
+          const wrapperProps = {
+            Component: type,
+            props,
             context,
-          });
+            ...(ref && { ref }),
+          };
+          const ReactWrapperComponent = createMountWrapper(el, options);
+          const wrappedEl = React.createElement(ReactWrapperComponent, wrapperProps);
           instance = ReactDOM.render(wrappedEl, domNode);
           if (typeof callback === 'function') {
             callback();

--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -171,12 +171,15 @@ class ReactSixteenAdapter extends EnzymeAdapter {
     return {
       render(el, context, callback) {
         if (instance === null) {
-          const ReactWrapperComponent = createMountWrapper(el, options);
-          const wrappedEl = React.createElement(ReactWrapperComponent, {
-            Component: el.type,
-            props: el.props,
+          const { type, props, ref } = el;
+          const wrapperProps = {
+            Component: type,
+            props,
             context,
-          });
+            ...(ref && { ref }),
+          };
+          const ReactWrapperComponent = createMountWrapper(el, options);
+          const wrappedEl = React.createElement(ReactWrapperComponent, wrapperProps);
           instance = ReactDOM.render(wrappedEl, domNode);
           if (typeof callback === 'function') {
             callback();

--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -56,6 +56,12 @@ describeWithDOM('mount', () => {
       expect(wrapper.children().instance()).to.be.instanceOf(Box);
       expect(wrapper.children().props().bam).to.equal(true);
     });
+
+    it('should call ref', () => {
+      const spy = sinon.spy();
+      mount(<div ref={spy} />);
+      expect(spy).to.have.property('callCount', 1);
+    });
   });
 
   describe('context', () => {


### PR DESCRIPTION
Fix #1504 
We should pass the `ref` to the wrapped element if a root element has `ref`.