### PR TITLE
Implement verbose debug output

### DIFF
--- a/packages/enzyme-test-suite/test/Debug-spec.jsx
+++ b/packages/enzyme-test-suite/test/Debug-spec.jsx
@@ -629,6 +629,36 @@ describe('debug', () => {
 </div>`
       ));
     });
+
+    it('options.verbose causes arrays and objects to be verbosely printed', () => {
+      class Foo extends React.Component {
+        render() {
+          const nestedData = {
+            a: [1, 3, { true: true }],
+            b: false,
+            c: { d: 'f' },
+          };
+          nestedData.d = nestedData.a;
+          const arry = [1, 2, { f: nestedData.c }];
+          return (
+            <div data-json={nestedData} data-arry={arry}>Test Component</div>
+          );
+        }
+      }
+
+      const wrapper = shallow(<Foo />);
+      expect(wrapper.debug({ verbose: true })).to.equal((
+        `<div data-json={{ a: [ 1, 3, { true: true } ], b: false, c: { d: 'f' }, d: [ 1, 3, { true: true } ] }} data-arry={[ 1, 2, { f: { d: 'f' } } ]}>
+  Test Component
+</div>`
+      ));
+
+      expect(wrapper.debug({ verbose: false })).to.equal((
+        `<div data-json={{...}} data-arry={{...}}>
+  Test Component
+</div>`
+      ));
+    });
   });
 
   describeWithDOM('debug React wrapper', () => {
@@ -682,6 +712,40 @@ describe('debug', () => {
     </span>
   </div>
 </Bar>`
+      ));
+    });
+
+    it('options.verbose causes arrays and objects to be verbosely printed', () => {
+      class Foo extends React.Component {
+        render() {
+          const nestedData = {
+            a: [1, 3, { true: true }],
+            b: false,
+            c: { d: 'f' },
+          };
+          nestedData.d = nestedData.a;
+          const arry = [1, 2, { f: nestedData.c }];
+          return (
+            <div data-json={nestedData} data-arry={arry}>Test Component</div>
+          );
+        }
+      }
+
+      const wrapper = mount(<Foo />);
+      expect(wrapper.debug({ verbose: true })).to.equal((
+        `<Foo>
+  <div data-json={{ a: [ 1, 3, { true: true } ], b: false, c: { d: 'f' }, d: [ 1, 3, { true: true } ] }} data-arry={[ 1, 2, { f: { d: 'f' } } ]}>
+    Test Component
+  </div>
+</Foo>`
+      ));
+
+      expect(wrapper.debug({ verbose: false })).to.equal((
+        `<Foo>
+  <div data-json={{...}} data-arry={{...}}>
+    Test Component
+  </div>
+</Foo>`
       ));
     });
   });

--- a/packages/enzyme/src/Debug.js
+++ b/packages/enzyme/src/Debug.js
@@ -29,7 +29,7 @@ export function indent(depth, string) {
   return string.split('\n').map(x => `${spaces(depth)}${x}`).join('\n');
 }
 
-function propString(prop) {
+function propString(prop, options) {
   if (isString(prop)) {
     return inspect(String(prop), { quoteStyle: 'double' });
   }
@@ -43,15 +43,19 @@ function propString(prop) {
     return `{${inspect(prop)}}`;
   }
   if (typeof prop === 'object') {
+    if (options.verbose) {
+      return `{${inspect(prop)}}`;
+    }
+
     return '{{...}}';
   }
   return `{[${typeof prop}]}`;
 }
 
-function propsString(node) {
+function propsString(node, options) {
   const props = propsOfNode(node);
   const keys = without(Object.keys(props), 'children');
-  return keys.map(key => `${key}=${propString(props[key])}`).join(' ');
+  return keys.map(key => `${key}=${propString(props[key], options)}`).join(' ');
 }
 
 function indentChildren(childrenStrs, indentLength) {
@@ -67,7 +71,7 @@ export function debugNode(node, indentLength = 2, options = {}) {
   const childrenStrs = compact(childrenOfNode(node).map(n => debugNode(n, indentLength, options)));
   const type = typeName(node);
 
-  const props = options.ignoreProps ? '' : propsString(node);
+  const props = options.ignoreProps ? '' : propsString(node, options);
   const beforeProps = props ? ' ' : '';
   const afterProps = childrenStrs.length
     ? '>'

--- a/packages/enzyme/src/ReactWrapper.js
+++ b/packages/enzyme/src/ReactWrapper.js
@@ -989,8 +989,9 @@ class ReactWrapper {
   /**
    * Returns an HTML-like string of the shallow render for debugging purposes.
    *
-   * @param {Object} options - (Optional) Property bag of additional options.
-   * options.ignoreProps - if true, props are omitted from the string.
+   * @param {Object} [options] - Property bag of additional options.
+   * @param {boolean} [options.ignoreProps] - if true, props are omitted from the string.
+   * @param {boolean} [options.verbose] - if true, arrays and objects to be verbosely printed.
    * @returns {String}
    */
   debug(options = {}) {

--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -1132,8 +1132,9 @@ class ShallowWrapper {
   /**
    * Returns an HTML-like string of the shallow render for debugging purposes.
    *
-   * @param {Object} options - (Optional) Property bag of additional options.
-   * options.ignoreProps - if true, props are omitted from the string.
+   * @param {Object} [options] - Property bag of additional options.
+   * @param {boolean} [options.ignoreProps] - if true, props are omitted from the string.
+   * @param {boolean} [options.verbose] - if true, arrays and objects to be verbosely printed.
    * @returns {String}
    */
   debug(options = {}) {


### PR DESCRIPTION
This implements `.debug({verbose: true})` which prevents boxing primitive values when stringified.

Fix for #1476 