### PR TITLE
Add event name mapping for animation events

### DIFF
--- a/packages/enzyme-adapter-react-15.4/src/ReactFifteenFourAdapter.js
+++ b/packages/enzyme-adapter-react-15.4/src/ReactFifteenFourAdapter.js
@@ -148,7 +148,7 @@ class ReactFifteenFourAdapter extends EnzymeAdapter {
         return instance ? instanceToTree(instance._reactInternalInstance).rendered : null;
       },
       simulateEvent(node, event, mock) {
-        const mappedEvent = mapNativeEventNames(event);
+        const mappedEvent = mapNativeEventNames(event, { animation: true });
         const eventFn = TestUtils.Simulate[mappedEvent];
         if (!eventFn) {
           throw new TypeError(`ReactWrapper::simulate() event '${event}' does not exist`);

--- a/packages/enzyme-adapter-react-15/src/ReactFifteenAdapter.js
+++ b/packages/enzyme-adapter-react-15/src/ReactFifteenAdapter.js
@@ -148,7 +148,7 @@ class ReactFifteenAdapter extends EnzymeAdapter {
         return instance ? instanceToTree(instance._reactInternalInstance).rendered : null;
       },
       simulateEvent(node, event, mock) {
-        const mappedEvent = mapNativeEventNames(event);
+        const mappedEvent = mapNativeEventNames(event, { animation: true });
         const eventFn = TestUtils.Simulate[mappedEvent];
         if (!eventFn) {
           throw new TypeError(`ReactWrapper::simulate() event '${event}' does not exist`);

--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -205,7 +205,7 @@ class ReactSixteenAdapter extends EnzymeAdapter {
         return instance ? toTree(instance._reactInternalFiber).rendered : null;
       },
       simulateEvent(node, event, mock) {
-        const mappedEvent = mapNativeEventNames(event);
+        const mappedEvent = mapNativeEventNames(event, { animation: true });
         const eventFn = TestUtils.Simulate[mappedEvent];
         if (!eventFn) {
           throw new TypeError(`ReactWrapper::simulate() event '${event}' does not exist`);

--- a/packages/enzyme-adapter-utils/src/Utils.js
+++ b/packages/enzyme-adapter-utils/src/Utils.js
@@ -3,7 +3,9 @@ import createRenderWrapper from './createRenderWrapper';
 
 export { createMountWrapper, createRenderWrapper };
 
-export function mapNativeEventNames(event) {
+export function mapNativeEventNames(event, {
+  animation = false, // should be true for React 15+
+} = {}) {
   const nativeToReactEventMap = {
     compositionend: 'compositionEnd',
     compositionstart: 'compositionStart',
@@ -42,6 +44,11 @@ export function mapNativeEventNames(event) {
     mouseenter: 'mouseEnter',
     mouseleave: 'mouseLeave',
     transitionend: 'transitionEnd',
+    ...(animation && {
+      animationstart: 'animationStart',
+      animationiteration: 'animationIteration',
+      animationend: 'animationEnd',
+    }),
   };
 
   return nativeToReactEventMap[event] || event;

--- a/packages/enzyme-test-suite/test/Utils-spec.jsx
+++ b/packages/enzyme-test-suite/test/Utils-spec.jsx
@@ -467,6 +467,18 @@ describe('Utils', () => {
         expect(result).to.equal('dragEnter');
       });
     });
+
+    describe('conditionally supported events', () => {
+      it('ignores unsupported events', () => {
+        const result = mapNativeEventNames('animationiteration');
+        expect(result).to.equal('animationiteration');
+      });
+
+      it('transforms events when supported', () => {
+        const result = mapNativeEventNames('animationiteration', { animation: true });
+        expect(result).to.equal('animationIteration');
+      });
+    });
   });
 
   describe('displayNameOfNode', () => {


### PR DESCRIPTION
Adding support for css3 animation events:
- [animationstart](https://developer.mozilla.org/en-US/docs/Web/Events/animationstart)
- [animationiteration](https://developer.mozilla.org/en-US/docs/Web/Events/animationiteration)
- [animationend](https://developer.mozilla.org/en-US/docs/Web/Events/animationend)

The support for these events in React's documentation can be found [here](https://reactjs.org/docs/events.html#animation-events)