### PR TITLE
You need to import the component

### DIFF
--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -8,6 +8,7 @@ As of Enzyme v3, the `shallow` API does call React lifecycle methods such as `co
 ```jsx
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
+import Foo from './Foo';
 
 describe('<MyComponent />', () => {
   it('should render three <Foo /> components', () => {


### PR DESCRIPTION
It's important for the users to know that they need to import the component. Since after rendering React component , they turn into html tags.