### PR TITLE
Upgrading npm-run to pickup security fix

### DIFF
--- a/packages/enzyme-adapter-react-helper/package.json
+++ b/packages/enzyme-adapter-react-helper/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "airbnb-js-shims": "^1.4.0",
     "install-peerdeps": "^1.4.1",
-    "npm-run": "^4.1.2",
+    "npm-run": "^5.0.1",
     "object.assign": "^4.1.0",
     "object.getownpropertydescriptors": "^2.0.3",
     "rimraf": "^2.6.2",


### PR DESCRIPTION
Upgrading npm-run to pick up this security fix: https://github.com/timoxley/npm-run/pull/17

Security advisory: https://nodesecurity.io/advisories/310

Tested locally