### PR TITLE
fix: package.json peerDependency range for React deps

### DIFF
--- a/packages/enzyme-adapter-react-16/package.json
+++ b/packages/enzyme-adapter-react-16/package.json
@@ -40,12 +40,12 @@
     "object.values": "^1.0.4",
     "prop-types": "^15.6.0",
     "react-reconciler": "^0.7.0",
-    "react-test-renderer": "^16.0.0-0"
+    "react-test-renderer": "^16.0.0"
   },
   "peerDependencies": {
     "enzyme": "^3.0.0",
-    "react": "^16.0.0-0",
-    "react-dom": "^16.0.0-0"
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
Sets the range from prerelease to release.

Now that React 16 is out, this will warn if you are using React 16 proper.