### PR TITLE
Add getSnapshotBeforeUpdate support into shallow

### DIFF
--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -163,6 +163,7 @@ class ReactSixteenAdapter extends EnzymeAdapter {
     this.options = {
       ...this.options,
       enableComponentDidUpdateOnSetState: true,
+      supportGetSnapshotBeforeUpdate: true,
     };
   }
   createMountRenderer(options) {

--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -304,13 +304,22 @@ class ShallowWrapper {
             }
             if (
               !this[OPTIONS].disableLifecycleMethods &&
-              instance &&
-              typeof instance.componentDidUpdate === 'function'
+              instance
             ) {
-              if (adapter.options.supportPrevContextArgumentOfComponentDidUpdate) {
-                instance.componentDidUpdate(prevProps, state, prevContext);
-              } else {
-                instance.componentDidUpdate(prevProps, state);
+              if (
+                adapter.options.supportGetSnapshotBeforeUpdate
+                && typeof instance.getSnapshotBeforeUpdate === 'function'
+              ) {
+                const snapshot = instance.getSnapshotBeforeUpdate(prevProps, state);
+                if (typeof instance.componentDidUpdate === 'function') {
+                  instance.componentDidUpdate(prevProps, state, snapshot);
+                }
+              } else if (typeof instance.componentDidUpdate === 'function') {
+                if (adapter.options.supportPrevContextArgumentOfComponentDidUpdate) {
+                  instance.componentDidUpdate(prevProps, state, prevContext);
+                } else {
+                  instance.componentDidUpdate(prevProps, state);
+                }
               }
             }
             this.update();
@@ -400,13 +409,22 @@ class ShallowWrapper {
           shouldRender &&
           !this[OPTIONS].disableLifecycleMethods &&
           adapter.options.enableComponentDidUpdateOnSetState &&
-          instance &&
-          typeof instance.componentDidUpdate === 'function'
+          instance
         ) {
-          if (adapter.options.supportPrevContextArgumentOfComponentDidUpdate) {
-            instance.componentDidUpdate(prevProps, prevState, prevContext);
-          } else {
-            instance.componentDidUpdate(prevProps, prevState);
+          if (
+            adapter.options.supportGetSnapshotBeforeUpdate &&
+            typeof instance.getSnapshotBeforeUpdate === 'function'
+          ) {
+            const snapshot = instance.getSnapshotBeforeUpdate(prevProps, prevState);
+            if (typeof instance.componentDidUpdate === 'function') {
+              instance.componentDidUpdate(prevProps, prevState, snapshot);
+            }
+          } else if (typeof instance.componentDidUpdate === 'function') {
+            if (adapter.options.supportPrevContextArgumentOfComponentDidUpdate) {
+              instance.componentDidUpdate(prevProps, prevState, prevContext);
+            } else {
+              instance.componentDidUpdate(prevProps, prevState);
+            }
           }
         }
         this.update();


### PR DESCRIPTION
Fix #1602

This PR is to support `getSnapshotBeforeUpdate` on shallow.
I've added `supportGetSnapshotBeforeUpdate` flag into `ReactSixteenAdapter` to implement this.
As a result, `getSnapshotBeforeUpdate` is called even if you use `react-test-renderer@<16.3.0` so we have to add a new adapter like `enzyme-adapter-react16.2` that turn off `supportGetSnapshotBeforeUpdate`.

You might think `getSnapshotBeforeUpdate` should be called before `render`, but the order is same as `react-dom`.

https://codepen.io/koba04/pen/erbbvB?editors=0011

React calls `getSnapshotBeforeUpdate` at commit phase and call `render` at render phase so when `getSnapshotBeforeUpdate` is called `render` has already been called.

```
〜 render phase 〜
Call render

〜 commit phase 〜
Call getSnapshotBeforeUpdate
Update host environment(DOM)
Call componentDidUpdate
```

So It's reasonable for me that `shallow` calls `getSnapshotBeforeUpdate` after `render` .
