### PR TITLE
Drop Node v4 and add v10 for TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
+  - "10"
   - "8"
   - "6"
-  - "4"
 before_install:
   - 'nvm install-latest-npm'
 install:


### PR DESCRIPTION
Node v4 is no longer maintained. We should support Node v10 instead of v4.