### PR TITLE
[WIP] Add a failed test on finding forwardRef component

### DIFF
--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -538,6 +538,34 @@ describeWithDOM('mount', () => {
       });
     });
 
+    describeIf(REACT16, 'forwardRef component', () => {
+      it('should find the forwardRef component', () => {
+        const FancyButton = React.forwardRef((props, forwardedRef) => (
+          <button ref={forwardedRef} />
+        ));
+
+        class App extends React.Component {
+          constructor() {
+            super();
+            this.buttonRef = null;
+          }
+
+          render() {
+            return (
+              <FancyButton
+                ref={(buttonRef) => {
+                  this.buttonRef = buttonRef;
+                }}
+              />
+            );
+          }
+        }
+
+        const wrapper = mount(<App />);
+        expect(wrapper.find(FancyButton).length).toBe(1);
+      });
+    });
+
     it('should find component based on a react prop', () => {
       const wrapper = mount((
         <div>


### PR DESCRIPTION
Hi Enzyme maintainers,

We came across an issue where `wrapper.find` failed on finding a component wrapped by `React.forwardRef` in React 16. I added a failed test case in this PR. I'll continue digging deeper to the cause.

Plz leave comments if you have some thoughts that could help me fix this issue. Much appreciated!