### PR TITLE
Make `.exists` take optional selector

### DIFF
--- a/docs/api/ReactWrapper/exists.md
+++ b/docs/api/ReactWrapper/exists.md
@@ -1,11 +1,18 @@
-# `.exists() => Boolean`
+# `.exists([selector]) => Boolean`
 
-Returns whether or not the current node exists.
+Returns whether or not the current node exists. Or, if a selector is passed in, whether that selector has any matching results.
+
+
+
+#### Arguments
+
+1. `selector` ([`EnzymeSelector`](../selector.md) [optional]): The selector to check existence for.
+
 
 
 #### Returns
 
-`Boolean`: whether or not the current node exists.
+`Boolean`: whether or not the current node exists, or the selector had any results.
 
 
 
@@ -14,5 +21,6 @@ Returns whether or not the current node exists.
 
 ```jsx
 const wrapper = mount(<div className="some-class" />);
+expect(wrapper.exists('.some-class')).to.equal(true);
 expect(wrapper.find('.other-class').exists()).to.equal(false);
 ```

--- a/docs/api/ShallowWrapper/exists.md
+++ b/docs/api/ShallowWrapper/exists.md
@@ -1,11 +1,18 @@
-# `.exists() => Boolean`
+# `.exists([selector]) => Boolean`
 
-Returns whether or not the current node exists.
+Returns whether or not the current node exists. Or, if a selector is passed in, whether that selector has any matching results.
+
+
+
+#### Arguments
+
+1. `selector` ([`EnzymeSelector`](../selector.md) [optional]): The selector to check existence for.
+
 
 
 #### Returns
 
-`Boolean`: whether or not the current node exists.
+`Boolean`: whether or not the current node exists, or the selector had any results.
 
 
 
@@ -13,6 +20,7 @@ Returns whether or not the current node exists.
 
 
 ```jsx
-const wrapper = shallow(<div className="some-class" />);
+const wrapper = mount(<div className="some-class" />);
+expect(wrapper.exists('.some-class')).to.equal(true);
 expect(wrapper.find('.other-class').exists()).to.equal(false);
 ```

--- a/docs/api/mount.md
+++ b/docs/api/mount.md
@@ -90,8 +90,8 @@ Returns whether or not the current root node has the given class name or not.
 #### [`.is(selector) => Boolean`](ReactWrapper/is.md)
 Returns whether or not the current node matches a provided selector.
 
-#### [`.exists() => Boolean`](ReactWrapper/exists.md)
-Returns whether or not the current node exists.
+#### [`.exists([selector]) => Boolean`](ReactWrapper/exists.md)
+Returns whether or not the current node exists, or, if given a selector, whether that selector has any matching results.
 
 #### [`.isEmpty() => Boolean`](ReactWrapper/isEmpty.md)
 *Deprecated*: Use [.exists()](ReactWrapper/exists.md) instead.

--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -97,8 +97,8 @@ Returns whether or not the current node has the given class name or not.
 #### [`.is(selector) => Boolean`](ShallowWrapper/is.md)
 Returns whether or not the current node matches a provided selector.
 
-#### [`.exists() => Boolean`](ShallowWrapper/exists.md)
-Returns whether or not the current node exists.
+#### [`.exists([selector]) => Boolean`](ShallowWrapper/exists.md)
+Returns whether or not the current node exists, or, if given a selector, whether that selector has any matching results.
 
 #### [`.isEmpty() => Boolean`](ShallowWrapper/isEmpty.md)
 *Deprecated*: Use [.exists()](ShallowWrapper/exists.md) instead.

--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -2943,10 +2943,28 @@ describeWithDOM('mount', () => {
   });
 
   describe('.exists()', () => {
-    it('should return true if node exists in wrapper', () => {
-      const wrapper = mount(<div className="foo" />);
-      expect(wrapper.find('.bar').exists()).to.equal(false);
-      expect(wrapper.find('.foo').exists()).to.equal(true);
+    it('has no required arguments', () => {
+      expect(ReactWrapper.prototype.exists).to.have.lengthOf(0);
+    });
+
+    describe('without arguments', () => {
+      it('should return true if node exists in wrapper', () => {
+        const wrapper = mount(<div className="foo" />);
+        expect(wrapper.find('.bar').exists()).to.equal(false);
+        expect(wrapper.find('.foo').exists()).to.equal(true);
+      });
+    });
+    describe('with argument', () => {
+      it('should return .find(arg).exists() instead', () => {
+        const wrapper = mount(<div />);
+        const fakeFindExistsReturnVal = Symbol('fake .find(arg).exists() return value');
+        const fakeSelector = '.someClass';
+        wrapper.find = sinon.stub().returns({ exists: () => fakeFindExistsReturnVal });
+        const existsResult = wrapper.exists(fakeSelector);
+        expect(wrapper.find.callCount).to.equal(1);
+        expect(wrapper.find.firstCall.args[0]).to.equal(fakeSelector);
+        expect(existsResult).to.equal(fakeFindExistsReturnVal);
+      });
     });
   });
 

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -2858,12 +2858,30 @@ describe('shallow', () => {
   });
 
   describe('.exists()', () => {
-    it('should return true if node exists in wrapper', () => {
-      const wrapper = shallow((
-        <div className="foo" />
-      ));
-      expect(wrapper.find('.bar').exists()).to.equal(false);
-      expect(wrapper.find('.foo').exists()).to.equal(true);
+    it('has no required arguments', () => {
+      expect(ShallowWrapper.prototype.exists).to.have.lengthOf(0);
+    });
+
+    describe('without argument', () => {
+      it('should return true if node exists in wrapper', () => {
+        const wrapper = shallow((
+          <div className="foo" />
+        ));
+        expect(wrapper.find('.bar').exists()).to.equal(false);
+        expect(wrapper.find('.foo').exists()).to.equal(true);
+      });
+    });
+    describe('with argument', () => {
+      it('should return .find(arg).exists() instead', () => {
+        const wrapper = shallow(<div />);
+        const fakeFindExistsReturnVal = Symbol('fake .find(arg).exists() return value');
+        const fakeSelector = '.someClass';
+        wrapper.find = sinon.stub().returns({ exists: () => fakeFindExistsReturnVal });
+        const existsResult = wrapper.exists(fakeSelector);
+        expect(wrapper.find.callCount).to.equal(1);
+        expect(wrapper.find.firstCall.args[0]).to.equal(fakeSelector);
+        expect(existsResult).to.equal(fakeFindExistsReturnVal);
+      });
     });
   });
 

--- a/packages/enzyme/src/ReactWrapper.js
+++ b/packages/enzyme/src/ReactWrapper.js
@@ -951,11 +951,16 @@ class ReactWrapper {
 
   /**
    * Returns true if the current wrapper has nodes. False otherwise.
+   * If called with a selector it returns `.find(selector).exists()` instead.
    *
+   * @param {String|Function} selector (optional)
    * @returns {boolean}
    */
-  exists() {
-    return this.length > 0;
+  exists(selector = null) {
+    if (arguments.length > 0 && typeof selector !== 'string') {
+      throw new TypeError('`selector` argument must be a string, if present.');
+    }
+    return typeof selector === 'string' ? this.find(selector).exists() : this.length > 0;
   }
 
   /**

--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -1120,11 +1120,16 @@ class ShallowWrapper {
 
   /**
    * Returns true if the current wrapper has nodes. False otherwise.
+   * If called with a selector it returns `.find(selector).exists()` instead.
    *
+   * @param {String|Function} selector (optional)
    * @returns {boolean}
    */
-  exists() {
-    return this.length > 0;
+  exists(selector = null) {
+    if (arguments.length > 0 && typeof selector !== 'string') {
+      throw new TypeError('`selector` argument must be a string, if present.');
+    }
+    return typeof selector === 'string' ? this.find(selector).exists() : this.length > 0;
   }
 
   /**


### PR DESCRIPTION
This PR makes `.exists` optionally take a selector, in which case it will delegate to `.find(selector).exists()`.