### PR TITLE
react 16: `shallow`: SFCs do not get a `this`

### DIFF
--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -232,6 +232,18 @@ class ReactSixteenAdapter extends EnzymeAdapter {
           isDOM = true;
         } else {
           isDOM = false;
+          const { type: Component } = el;
+          const isStateful = Component.prototype && (
+            Component.prototype.isReactComponent
+            || Array.isArray(Component.__reactAutoBindPairs) // fallback for createClass components
+          );
+          if (!isStateful) {
+            const wrappedEl = Object.assign(
+              (...args) => Component(...args), // eslint-disable-line new-cap
+              Component,
+            );
+            return withSetStateAllowed(() => renderer.render({ ...el, type: wrappedEl }, context));
+          }
           return withSetStateAllowed(() => renderer.render(el, context));
         }
       },

--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -21,6 +21,7 @@ import {
 } from './_helpers';
 import { REACT013, REACT014, REACT16, REACT163, is } from './_helpers/version';
 import realArrowFunction from './_helpers/realArrowFunction';
+import sloppyReturnThis from './_helpers/untranspiledSloppyReturnThis';
 
 const getElementPropSelector = prop => x => x.props[prop];
 const getWrapperPropSelector = prop => x => x.prop(prop);
@@ -2056,6 +2057,49 @@ describeWithDOM('mount', () => {
         const wrapper = mount(<Foo foo="hi" bar="bye" />);
 
         expect(wrapper.props()).to.eql({ bar: 'bye', foo: 'hi' });
+      });
+
+      const SloppyReceiver = sloppyReturnThis((
+        receiver,
+        props = { NO_PROPS: true },
+        context,
+      ) => (
+        <div
+          data-is-global={receiver === global}
+          data-is-undefined={typeof receiver === 'undefined'}
+          {...props}
+          {...context}
+        />
+      ));
+
+      const StrictReceiver = function SFC(
+        props = { NO_PROPS: true },
+        context,
+      ) {
+        return (
+          <div
+            data-is-global={this === global}
+            data-is-undefined={typeof this === 'undefined'}
+            {...props}
+            {...context}
+          />
+        );
+      };
+
+      it('does not provide a `this` to a sloppy-mode SFC', () => {
+        const wrapper = mount(<SloppyReceiver />);
+        expect(wrapper.childAt(0).props()).to.be.an('object').that.has.all.keys({
+          'data-is-global': true,
+          'data-is-undefined': false,
+        });
+      });
+
+      it('does not provide a `this` to a strict-mode SFC', () => {
+        const wrapper = mount(<StrictReceiver />);
+        expect(wrapper.childAt(0).props()).to.be.an('object').that.has.all.keys({
+          'data-is-global': false,
+          'data-is-undefined': true,
+        });
       });
     });
   });

--- a/packages/enzyme-test-suite/test/_helpers/untranspiledSloppyReturnThis.js
+++ b/packages/enzyme-test-suite/test/_helpers/untranspiledSloppyReturnThis.js
@@ -1,0 +1,10 @@
+/* eslint
+  prefer-spread: 0,
+  func-names: 0,
+  prefer-rest-params: 0,
+*/
+module.exports = function (fn) {
+  return function () {
+    return fn.apply(null, [this].concat(Array.prototype.slice.call(arguments)));
+  };
+};


### PR DESCRIPTION
This works around a bug in `react-test-renderer`: https://github.com/facebook/react/issues/13141

This seems to only be an issue in react 16, and only when using `shallow`.

In the future, when that bugfix is published, i'll remove this fix and bump the minimum required version.