### PR TITLE
Adding Fragment support for shallow `.find` and `.findWhere`

### DIFF
--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -21,6 +21,7 @@ import {
   Portal,
 } from 'react-is';
 import { EnzymeAdapter } from 'enzyme';
+import { typeOfNode } from 'enzyme/build/Utils';
 import {
   displayNameOfNode,
   elementToTree,
@@ -386,6 +387,10 @@ class ReactSixteenAdapter extends EnzymeAdapter {
 
   isValidElementType(object) {
     return isValidElementType(object);
+  }
+
+  isFragment(fragment) {
+    return typeOfNode(fragment) === Fragment;
   }
 
   createElement(...args) {

--- a/packages/enzyme-test-suite/test/Adapter-spec.jsx
+++ b/packages/enzyme-test-suite/test/Adapter-spec.jsx
@@ -17,7 +17,7 @@ import {
   Profiler,
 } from './_helpers/react-compat';
 import { is } from './_helpers/version';
-import { itIf, describeWithDOM } from './_helpers';
+import { itIf, describeWithDOM, describeIf } from './_helpers';
 
 const { adapter } = get();
 
@@ -904,6 +904,16 @@ describe('Adapter', () => {
 
     itIf(is('>= 16.4'), 'supports Profiler', () => {
       expect(getDisplayName(<Profiler />)).to.equal('Profiler');
+    });
+  });
+
+  describeIf(is('>= 16.2'), 'determines if node isFragment', () => {
+    it('correctly identifies Fragment', () => {
+      expect(adapter.isFragment(<Fragment />)).to.equal(true);
+    });
+
+    it('correctly identifies a non-Fragment', () => {
+      expect(adapter.isFragment(<div />)).to.equal(false);
     });
   });
 });

--- a/packages/enzyme/src/selectors.js
+++ b/packages/enzyme/src/selectors.js
@@ -287,8 +287,9 @@ function matchAdjacentSiblings(nodes, predicate, root) {
     if (!parent) {
       return matches;
     }
-    const nodeIndex = parent.rendered.indexOf(node);
-    const adjacentSibling = parent.rendered[nodeIndex + 1];
+    const parentChildren = childrenOfNode(parent);
+    const nodeIndex = parentChildren.indexOf(node);
+    const adjacentSibling = parentChildren[nodeIndex + 1];
     // No sibling
     if (!adjacentSibling) {
       return matches;
@@ -313,8 +314,9 @@ function matchGeneralSibling(nodes, predicate, root) {
     if (!parent) {
       return matches;
     }
-    const nodeIndex = parent.rendered.indexOf(node);
-    const youngerSiblings = parent.rendered.slice(nodeIndex + 1);
+    const parentChildren = childrenOfNode(parent);
+    const nodeIndex = parentChildren.indexOf(node);
+    const youngerSiblings = parentChildren.slice(nodeIndex + 1);
     return matches.concat(youngerSiblings.filter(predicate));
   }, nodes);
 }


### PR DESCRIPTION
This fixes #1664 by altering `childrenOfNode()` in `RSTTraversal` to return (recursively if needed to accommodate nesting) the children of any node it encounters that is a Fragment instead of the Fragment element. It additionally updates `matchAdjacentSiblings()` and `matchGeneralSibling()` to make use of `childrenOfNode()` instead of looking directly at `parent.rendered` in order to make use of the new Fragment logic, which lives inside of the `ReactSixteenAdapter`'s `isFragment()`

Consider the following example
```jsx
const FragmentExample = () => (
  <div className="container">
    <React.Fragment>
      <React.Fragment>
        <span>A span</span>
      </React.Fragment>
    </React.Fragment>
  </div>
);
```

Calling `const wrapper = mount(<FragmentExample />);` will yield a wrapper with the following structure:
```jsx
<FragmentExample>
  <div className="container">
    <span>
      A span
    </span>
  </div>
</FragmentExample>
```
and direct selectors like `wrapper.find('.container > span')` will behave as expected to find the span. 

If we instead say `const wrapper = shallow(<FragmentExample />)`, however, the wrapper has additional layers in the form of `<Symbol(React.fragment)>`:
```jsx
<div className="container">
  <Symbol(React.fragment)>
    <Symbol(React.fragment)>
      <span>
        A span
      </span>
    </Symbol(React.fragment)>   
  </Symbol(React.fragment)>
</div>
```
These additional layers caused direct selectors to fail, since simply looking at the `.rendered` of the container div would show the symbol type node, and not a span, as expected. 

Please let me know if I need any additional tests.