### PR TITLE
fix to run all tests in ShallowWrapper-spec.jsx

### DIFF
--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -1330,7 +1330,7 @@ describe('shallow', () => {
       expect(wrapper.find('.bar')).to.have.lengthOf(1);
     });
 
-    describe.only('merging props', () => {
+    describe('merging props', () => {
       it('merges, not replaces, props when rerendering', () => {
         class Foo extends React.Component {
           render() {


### PR DESCRIPTION
Currently, the other tests except `merging props` don't run by `npm run test:only`.
I guess that `describe.only` intend to avoid failing by `should call componentWillReceiveProps for new renders` so I've skiped the test.

https://travis-ci.org/airbnb/enzyme/jobs/413839140