### PR TITLE
[New] add pointer events support

### DIFF
--- a/packages/enzyme-adapter-react-15.4/src/ReactFifteenFourAdapter.js
+++ b/packages/enzyme-adapter-react-15.4/src/ReactFifteenFourAdapter.js
@@ -103,6 +103,8 @@ function instanceToTree(inst) {
   };
 }
 
+const eventOptions = { animation: true };
+
 class ReactFifteenFourAdapter extends EnzymeAdapter {
   constructor() {
     super();
@@ -153,7 +155,7 @@ class ReactFifteenFourAdapter extends EnzymeAdapter {
         return instance ? instanceToTree(instance._reactInternalInstance).rendered : null;
       },
       simulateEvent(node, event, mock) {
-        const mappedEvent = mapNativeEventNames(event, { animation: true });
+        const mappedEvent = mapNativeEventNames(event, eventOptions);
         const eventFn = TestUtils.Simulate[mappedEvent];
         if (!eventFn) {
           throw new TypeError(`ReactWrapper::simulate() event '${event}' does not exist`);
@@ -201,7 +203,7 @@ class ReactFifteenFourAdapter extends EnzymeAdapter {
         };
       },
       simulateEvent(node, event, ...args) {
-        const handler = node.props[propFromEvent(event)];
+        const handler = node.props[propFromEvent(event, eventOptions)];
         if (handler) {
           withSetStateAllowed(() => {
             // TODO(lmr): create/use synthetic events

--- a/packages/enzyme-adapter-react-15/src/ReactFifteenAdapter.js
+++ b/packages/enzyme-adapter-react-15/src/ReactFifteenAdapter.js
@@ -103,6 +103,8 @@ function instanceToTree(inst) {
   };
 }
 
+const eventOptions = { animation: true };
+
 class ReactFifteenAdapter extends EnzymeAdapter {
   constructor() {
     super();
@@ -153,7 +155,7 @@ class ReactFifteenAdapter extends EnzymeAdapter {
         return instance ? instanceToTree(instance._reactInternalInstance).rendered : null;
       },
       simulateEvent(node, event, mock) {
-        const mappedEvent = mapNativeEventNames(event, { animation: true });
+        const mappedEvent = mapNativeEventNames(event, eventOptions);
         const eventFn = TestUtils.Simulate[mappedEvent];
         if (!eventFn) {
           throw new TypeError(`ReactWrapper::simulate() event '${event}' does not exist`);
@@ -201,7 +203,7 @@ class ReactFifteenAdapter extends EnzymeAdapter {
         };
       },
       simulateEvent(node, event, ...args) {
-        const handler = node.props[propFromEvent(event)];
+        const handler = node.props[propFromEvent(event, eventOptions)];
         if (handler) {
           withSetStateAllowed(() => {
             // TODO(lmr): create/use synthetic events

--- a/packages/enzyme-adapter-react-16.1/src/ReactSixteenOneAdapter.js
+++ b/packages/enzyme-adapter-react-16.1/src/ReactSixteenOneAdapter.js
@@ -166,6 +166,8 @@ function nodeToHostNode(_node) {
   return ReactDOM.findDOMNode(node.instance);
 }
 
+const eventOptions = { animation: true };
+
 class ReactSixteenOneAdapter extends EnzymeAdapter {
   constructor() {
     super();
@@ -218,7 +220,7 @@ class ReactSixteenOneAdapter extends EnzymeAdapter {
         return instance ? toTree(instance._reactInternalFiber).rendered : null;
       },
       simulateEvent(node, event, mock) {
-        const mappedEvent = mapNativeEventNames(event, { animation: true });
+        const mappedEvent = mapNativeEventNames(event, eventOptions);
         const eventFn = TestUtils.Simulate[mappedEvent];
         if (!eventFn) {
           throw new TypeError(`ReactWrapper::simulate() event '${event}' does not exist`);
@@ -283,7 +285,7 @@ class ReactSixteenOneAdapter extends EnzymeAdapter {
         };
       },
       simulateEvent(node, event, ...args) {
-        const handler = node.props[propFromEvent(event)];
+        const handler = node.props[propFromEvent(event, eventOptions)];
         if (handler) {
           withSetStateAllowed(() => {
             // TODO(lmr): create/use synthetic events

--- a/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
+++ b/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
@@ -167,6 +167,8 @@ function nodeToHostNode(_node) {
   return ReactDOM.findDOMNode(node.instance);
 }
 
+const eventOptions = { animation: true };
+
 class ReactSixteenTwoAdapter extends EnzymeAdapter {
   constructor() {
     super();
@@ -220,7 +222,7 @@ class ReactSixteenTwoAdapter extends EnzymeAdapter {
         return instance ? toTree(instance._reactInternalFiber).rendered : null;
       },
       simulateEvent(node, event, mock) {
-        const mappedEvent = mapNativeEventNames(event, { animation: true });
+        const mappedEvent = mapNativeEventNames(event, eventOptions);
         const eventFn = TestUtils.Simulate[mappedEvent];
         if (!eventFn) {
           throw new TypeError(`ReactWrapper::simulate() event '${event}' does not exist`);
@@ -285,7 +287,7 @@ class ReactSixteenTwoAdapter extends EnzymeAdapter {
         };
       },
       simulateEvent(node, event, ...args) {
-        const handler = node.props[propFromEvent(event)];
+        const handler = node.props[propFromEvent(event, eventOptions)];
         if (handler) {
           withSetStateAllowed(() => {
             // TODO(lmr): create/use synthetic events

--- a/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
+++ b/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
@@ -185,6 +185,8 @@ function nodeToHostNode(_node) {
   return ReactDOM.findDOMNode(node.instance);
 }
 
+const eventOptions = { animation: true };
+
 class ReactSixteenThreeAdapter extends EnzymeAdapter {
   constructor() {
     super();
@@ -238,7 +240,7 @@ class ReactSixteenThreeAdapter extends EnzymeAdapter {
         return instance ? toTree(instance._reactInternalFiber).rendered : null;
       },
       simulateEvent(node, event, mock) {
-        const mappedEvent = mapNativeEventNames(event, { animation: true });
+        const mappedEvent = mapNativeEventNames(event, eventOptions);
         const eventFn = TestUtils.Simulate[mappedEvent];
         if (!eventFn) {
           throw new TypeError(`ReactWrapper::simulate() event '${event}' does not exist`);
@@ -303,7 +305,7 @@ class ReactSixteenThreeAdapter extends EnzymeAdapter {
         };
       },
       simulateEvent(node, event, ...args) {
-        const handler = node.props[propFromEvent(event)];
+        const handler = node.props[propFromEvent(event, eventOptions)];
         if (handler) {
           withSetStateAllowed(() => {
             // TODO(lmr): create/use synthetic events

--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -186,6 +186,10 @@ function nodeToHostNode(_node) {
   return ReactDOM.findDOMNode(node.instance);
 }
 
+const eventOptions = {
+  animation: true,
+};
+
 class ReactSixteenAdapter extends EnzymeAdapter {
   constructor() {
     super();
@@ -239,12 +243,11 @@ class ReactSixteenAdapter extends EnzymeAdapter {
         return instance ? toTree(instance._reactInternalFiber).rendered : null;
       },
       simulateEvent(node, event, mock) {
-        const mappedEvent = mapNativeEventNames(event, { animation: true });
+        const mappedEvent = mapNativeEventNames(event, eventOptions);
         const eventFn = TestUtils.Simulate[mappedEvent];
         if (!eventFn) {
           throw new TypeError(`ReactWrapper::simulate() event '${event}' does not exist`);
         }
-        // eslint-disable-next-line react/no-find-dom-node
         eventFn(nodeToHostNode(node), mock);
       },
       batchedUpdates(fn) {
@@ -304,7 +307,7 @@ class ReactSixteenAdapter extends EnzymeAdapter {
         };
       },
       simulateEvent(node, event, ...args) {
-        const handler = node.props[propFromEvent(event)];
+        const handler = node.props[propFromEvent(event, eventOptions)];
         if (handler) {
           withSetStateAllowed(() => {
             // TODO(lmr): create/use synthetic events
@@ -340,7 +343,7 @@ class ReactSixteenAdapter extends EnzymeAdapter {
 
   // Provided a bag of options, return an `EnzymeRenderer`. Some options can be implementation
   // specific, like `attach` etc. for React, but not part of this interface explicitly.
-  // eslint-disable-next-line class-methods-use-this, no-unused-vars
+  // eslint-disable-next-line class-methods-use-this
   createRenderer(options) {
     switch (options.mode) {
       case EnzymeAdapter.MODES.MOUNT: return this.createMountRenderer(options);
@@ -354,7 +357,7 @@ class ReactSixteenAdapter extends EnzymeAdapter {
   // converts an RSTNode to the corresponding JSX Pragma Element. This will be needed
   // in order to implement the `Wrapper.mount()` and `Wrapper.shallow()` methods, but should
   // be pretty straightforward for people to implement.
-  // eslint-disable-next-line class-methods-use-this, no-unused-vars
+  // eslint-disable-next-line class-methods-use-this
   nodeToElement(node) {
     if (!node || typeof node !== 'object') return null;
     return React.createElement(node.type, propsWithKeysAndRef(node));

--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -188,6 +188,7 @@ function nodeToHostNode(_node) {
 
 const eventOptions = {
   animation: true,
+  pointerEvents: true, // 16.4+
 };
 
 class ReactSixteenAdapter extends EnzymeAdapter {

--- a/packages/enzyme-adapter-utils/src/Utils.js
+++ b/packages/enzyme-adapter-utils/src/Utils.js
@@ -6,6 +6,7 @@ export { createMountWrapper, createRenderWrapper };
 
 export function mapNativeEventNames(event, {
   animation = false, // should be true for React 15+
+  pointerEvents = false, // should be true for React 16.4+
 } = {}) {
   const nativeToReactEventMap = {
     compositionend: 'compositionEnd',
@@ -50,6 +51,18 @@ export function mapNativeEventNames(event, {
       animationiteration: 'animationIteration',
       animationend: 'animationEnd',
     }),
+    ...(pointerEvents && {
+      pointerdown: 'pointerDown',
+      pointermove: 'pointerMove',
+      pointerup: 'pointerUp',
+      pointercancel: 'pointerCancel',
+      gotpointercapture: 'gotPointerCapture',
+      lostpointercapture: 'lostPointerCapture',
+      pointerenter: 'pointerEnter',
+      pointerleave: 'pointerLeave',
+      pointerover: 'pointerOver',
+      pointerout: 'pointerOut',
+    }),
   };
 
   return nativeToReactEventMap[event] || event;
@@ -57,8 +70,8 @@ export function mapNativeEventNames(event, {
 
 // 'click' => 'onClick'
 // 'mouseEnter' => 'onMouseEnter'
-export function propFromEvent(event) {
-  const nativeEvent = mapNativeEventNames(event);
+export function propFromEvent(event, eventOptions = {}) {
+  const nativeEvent = mapNativeEventNames(event, eventOptions);
   return `on${nativeEvent[0].toUpperCase()}${nativeEvent.slice(1)}`;
 }
 

--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -2091,6 +2091,36 @@ describeWithDOM('mount', () => {
           expect(spy).to.have.property('callCount', 1);
         });
       });
+
+      describeIf(is('>= 16.4'), 'pointer events', () => {
+        it('should convert lowercase events to React camelcase', () => {
+          const spy = sinon.spy();
+          class Foo extends React.Component {
+            render() {
+              return (
+                <a onGotPointerCapture={spy}>foo</a>
+              );
+            }
+          }
+
+          const wrapper = mount(<Foo />);
+
+          wrapper.simulate('gotpointercapture');
+          expect(spy).to.have.property('callCount', 1);
+        });
+
+        it('should convert lowercase events to React camelcase in stateless components', () => {
+          const spy = sinon.spy();
+          const Foo = () => (
+            <a onGotPointerCapture={spy}>foo</a>
+          );
+
+          const wrapper = mount(<Foo />);
+
+          wrapper.simulate('gotpointercapture');
+          expect(spy).to.have.property('callCount', 1);
+        });
+      });
     });
 
     it('should be batched updates', () => {

--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -2061,6 +2061,36 @@ describeWithDOM('mount', () => {
           expect(spy).to.have.property('callCount', 1);
         });
       });
+
+      describeIf(is('>= 15'), 'animation events', () => {
+        it('should convert lowercase events to React camelcase', () => {
+          const spy = sinon.spy();
+          class Foo extends React.Component {
+            render() {
+              return (
+                <a onAnimationIteration={spy}>foo</a>
+              );
+            }
+          }
+
+          const wrapper = mount(<Foo />);
+
+          wrapper.simulate('animationiteration');
+          expect(spy).to.have.property('callCount', 1);
+        });
+
+        it('should convert lowercase events to React camelcase in stateless components', () => {
+          const spy = sinon.spy();
+          const Foo = () => (
+            <a onAnimationIteration={spy}>foo</a>
+          );
+
+          const wrapper = mount(<Foo />);
+
+          wrapper.simulate('animationiteration');
+          expect(spy).to.have.property('callCount', 1);
+        });
+      });
     });
 
     it('should be batched updates', () => {

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -2012,6 +2012,36 @@ describe('shallow', () => {
           expect(spy).to.have.property('callCount', 1);
         });
       });
+
+      describeIf(is('>= 16.4'), 'pointer events', () => {
+        it('should convert lowercase events to React camelcase', () => {
+          const spy = sinon.spy();
+          class Foo extends React.Component {
+            render() {
+              return (
+                <a onGotPointerCapture={spy}>foo</a>
+              );
+            }
+          }
+
+          const wrapper = shallow(<Foo />);
+
+          wrapper.simulate('gotpointercapture');
+          expect(spy).to.have.property('callCount', 1);
+        });
+
+        it('should convert lowercase events to React camelcase in stateless components', () => {
+          const spy = sinon.spy();
+          const Foo = () => (
+            <a onGotPointerCapture={spy}>foo</a>
+          );
+
+          const wrapper = shallow(<Foo />);
+
+          wrapper.simulate('gotpointercapture');
+          expect(spy).to.have.property('callCount', 1);
+        });
+      });
     });
 
     itIf(BATCHING, 'should be batched updates', () => {

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -1982,6 +1982,36 @@ describe('shallow', () => {
           expect(spy).to.have.property('callCount', 1);
         });
       });
+
+      describeIf(is('>= 15'), 'animation events', () => {
+        it('should convert lowercase events to React camelcase', () => {
+          const spy = sinon.spy();
+          class Foo extends React.Component {
+            render() {
+              return (
+                <a onAnimationIteration={spy}>foo</a>
+              );
+            }
+          }
+
+          const wrapper = shallow(<Foo />);
+
+          wrapper.simulate('animationiteration');
+          expect(spy).to.have.property('callCount', 1);
+        });
+
+        it('should convert lowercase events to React camelcase in stateless components', () => {
+          const spy = sinon.spy();
+          const Foo = () => (
+            <a onAnimationIteration={spy}>foo</a>
+          );
+
+          const wrapper = shallow(<Foo />);
+
+          wrapper.simulate('animationiteration');
+          expect(spy).to.have.property('callCount', 1);
+        });
+      });
     });
 
     itIf(BATCHING, 'should be batched updates', () => {

--- a/packages/enzyme-test-suite/test/Utils-spec.jsx
+++ b/packages/enzyme-test-suite/test/Utils-spec.jsx
@@ -441,11 +441,26 @@ describe('Utils', () => {
   });
 
   describe('propFromEvent', () => {
-    const fn = propFromEvent;
-
     it('should work', () => {
-      expect(fn('click')).to.equal('onClick');
-      expect(fn('mouseEnter')).to.equal('onMouseEnter');
+      expect(propFromEvent('click')).to.equal('onClick');
+      expect(propFromEvent('mouseEnter')).to.equal('onMouseEnter');
+    });
+
+    describe('conditionally supported events', () => {
+      it('ignores unsupported events', () => {
+        const result = propFromEvent('animationIteration');
+        expect(result).to.equal('onAnimationIteration');
+      });
+
+      it('transforms animation events when supported', () => {
+        const result = propFromEvent('animationIteration', { animation: true });
+        expect(result).to.equal('onAnimationIteration');
+      });
+
+      it('transforms pointer events when supported', () => {
+        const result = propFromEvent('pointerOver', { pointerEvents: true });
+        expect(result).to.equal('onPointerOver');
+      });
     });
   });
 
@@ -478,9 +493,14 @@ describe('Utils', () => {
         expect(result).to.equal('animationiteration');
       });
 
-      it('transforms events when supported', () => {
+      it('transforms animation events when supported', () => {
         const result = mapNativeEventNames('animationiteration', { animation: true });
         expect(result).to.equal('animationIteration');
+      });
+
+      it('transforms pointer events when supported', () => {
+        const result = mapNativeEventNames('pointerover', { pointerEvents: true });
+        expect(result).to.equal('pointerOver');
       });
     });
   });


### PR DESCRIPTION
Fixes #1719.

Reviewers, please check these claims:
 - using the new adapter-utils package, but old adapters, will quietly lack pointer events support
 - using the old adapter-utils package, but new adapters, will quietly lack pointer events support
 - using new everything will have pointer events support