### PR TITLE
Mounted portals show in debug and can be found

### DIFF
--- a/packages/enzyme-adapter-react-16.1/src/ReactSixteenOneAdapter.js
+++ b/packages/enzyme-adapter-react-16.1/src/ReactSixteenOneAdapter.js
@@ -111,16 +111,19 @@ function toTree(vnode) {
   switch (node.tag) {
     case HostRoot: // 3
       return childrenToTree(node.child);
-    case HostPortal: // 4
+    case HostPortal: { // 4
+      const { stateNode: { containerInfo } } = node;
+      const props = { containerInfo };
       return {
         nodeType: 'portal',
         type: Portal,
-        props: {},
+        props,
         key: ensureKeyOrUndefined(node.key),
         ref: node.ref,
         instance: null,
         rendered: childrenToTree(node.child),
       };
+    }
     case ClassComponent:
       return {
         nodeType: 'class',

--- a/packages/enzyme-adapter-react-16.1/src/ReactSixteenOneAdapter.js
+++ b/packages/enzyme-adapter-react-16.1/src/ReactSixteenOneAdapter.js
@@ -111,9 +111,16 @@ function toTree(vnode) {
   switch (node.tag) {
     case HostRoot: // 3
       return childrenToTree(node.child);
-    case HostPortal: { // 4
-      return childrenToTree(node.child);
-    }
+    case HostPortal: // 4
+      return {
+        nodeType: 'portal',
+        type: Portal,
+        props: {},
+        key: ensureKeyOrUndefined(node.key),
+        ref: node.ref,
+        instance: null,
+        rendered: childrenToTree(node.child),
+      };
     case ClassComponent:
       return {
         nodeType: 'class',

--- a/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
+++ b/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
@@ -112,16 +112,19 @@ function toTree(vnode) {
   switch (node.tag) {
     case HostRoot: // 3
       return childrenToTree(node.child);
-    case HostPortal: // 4
+    case HostPortal: { // 4
+      const { stateNode: { containerInfo } } = node;
+      const props = { containerInfo };
       return {
         nodeType: 'portal',
         type: Portal,
-        props: {},
+        props,
         key: ensureKeyOrUndefined(node.key),
         ref: node.ref,
         instance: null,
         rendered: childrenToTree(node.child),
       };
+    }
     case ClassComponent:
       return {
         nodeType: 'class',

--- a/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
+++ b/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
@@ -112,9 +112,16 @@ function toTree(vnode) {
   switch (node.tag) {
     case HostRoot: // 3
       return childrenToTree(node.child);
-    case HostPortal: { // 4
-      return childrenToTree(node.child);
-    }
+    case HostPortal: // 4
+      return {
+        nodeType: 'portal',
+        type: Portal,
+        props: {},
+        key: ensureKeyOrUndefined(node.key),
+        ref: node.ref,
+        instance: null,
+        rendered: childrenToTree(node.child),
+      };
     case ClassComponent:
       return {
         nodeType: 'class',

--- a/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
+++ b/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
@@ -117,16 +117,19 @@ function toTree(vnode) {
   switch (node.tag) {
     case HostRoot: // 3
       return childrenToTree(node.child);
-    case HostPortal: // 4
+    case HostPortal: { // 4
+      const { stateNode: { containerInfo } } = node;
+      const props = { containerInfo };
       return {
         nodeType: 'portal',
         type: Portal,
-        props: {},
+        props,
         key: ensureKeyOrUndefined(node.key),
         ref: node.ref,
         instance: null,
         rendered: childrenToTree(node.child),
       };
+    }
     case ClassComponent:
       return {
         nodeType: 'class',

--- a/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
+++ b/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
@@ -117,9 +117,16 @@ function toTree(vnode) {
   switch (node.tag) {
     case HostRoot: // 3
       return childrenToTree(node.child);
-    case HostPortal: { // 4
-      return childrenToTree(node.child);
-    }
+    case HostPortal: // 4
+      return {
+        nodeType: 'portal',
+        type: Portal,
+        props: {},
+        key: ensureKeyOrUndefined(node.key),
+        ref: node.ref,
+        instance: null,
+        rendered: childrenToTree(node.child),
+      };
     case ClassComponent:
       return {
         nodeType: 'class',

--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -117,16 +117,19 @@ function toTree(vnode) {
   switch (node.tag) {
     case HostRoot: // 3
       return childrenToTree(node.child);
-    case HostPortal: // 4
+    case HostPortal: { // 4
+      const { stateNode: { containerInfo } } = node;
+      const props = { containerInfo };
       return {
         nodeType: 'portal',
         type: Portal,
-        props: {},
+        props,
         key: ensureKeyOrUndefined(node.key),
         ref: node.ref,
         instance: null,
         rendered: childrenToTree(node.child),
       };
+    }
     case ClassComponent:
       return {
         nodeType: 'class',

--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -117,9 +117,16 @@ function toTree(vnode) {
   switch (node.tag) {
     case HostRoot: // 3
       return childrenToTree(node.child);
-    case HostPortal: { // 4
-      return childrenToTree(node.child);
-    }
+    case HostPortal: // 4
+      return {
+        nodeType: 'portal',
+        type: Portal,
+        props: {},
+        key: ensureKeyOrUndefined(node.key),
+        ref: node.ref,
+        instance: null,
+        rendered: childrenToTree(node.child),
+      };
     case ClassComponent:
       return {
         nodeType: 'class',

--- a/packages/enzyme-adapter-utils/package.json
+++ b/packages/enzyme-adapter-utils/package.json
@@ -36,7 +36,8 @@
   "dependencies": {
     "function.prototype.name": "^1.1.0",
     "object.assign": "^4.1.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.6.2",
+    "react-is": "^16.4.2"
   },
   "peerDependencies": {
     "react": "0.13.x || 0.14.x || ^15.0.0-0 || ^16.0.0-0"

--- a/packages/enzyme-adapter-utils/src/Utils.js
+++ b/packages/enzyme-adapter-utils/src/Utils.js
@@ -1,4 +1,7 @@
 import functionName from 'function.prototype.name';
+import {
+  Portal,
+} from 'react-is';
 import createMountWrapper from './createMountWrapper';
 import createRenderWrapper from './createRenderWrapper';
 
@@ -107,6 +110,10 @@ export function displayNameOfNode(node) {
 
   if (!type) return null;
 
+  if (type === Portal) {
+    return 'Portal';
+  }
+
   return type.displayName || (typeof type === 'function' ? functionName(type) : type.name || type);
 }
 
@@ -116,6 +123,9 @@ export function nodeTypeFromType(type) {
   }
   if (type && type.prototype && type.prototype.isReactComponent) {
     return 'class';
+  }
+  if (type && type === Portal) {
+    return 'portal';
   }
   return 'function';
 }

--- a/packages/enzyme-test-suite/test/Adapter-spec.jsx
+++ b/packages/enzyme-test-suite/test/Adapter-spec.jsx
@@ -4,6 +4,9 @@ import jsdom from 'jsdom';
 import { get } from 'enzyme/build/configuration';
 import { configure, shallow } from 'enzyme';
 import inspect from 'object-inspect';
+import {
+  Portal,
+} from 'react-is';
 
 import './_helpers/setupAdapters';
 import Adapter from './_helpers/adapter';
@@ -226,13 +229,21 @@ describe('Adapter', () => {
         ref: null,
         instance: null,
         rendered: {
-          nodeType: 'host',
-          type: 'div',
-          props: { className: 'Foo' },
+          nodeType: 'portal',
+          type: Portal,
+          props: {},
           key: undefined,
           ref: null,
           instance: null,
-          rendered: ['Hello World!'],
+          rendered: {
+            nodeType: 'host',
+            type: 'div',
+            props: { className: 'Foo' },
+            key: undefined,
+            ref: null,
+            instance: null,
+            rendered: ['Hello World!'],
+          },
         },
       }));
     });

--- a/packages/enzyme-test-suite/test/Adapter-spec.jsx
+++ b/packages/enzyme-test-suite/test/Adapter-spec.jsx
@@ -231,7 +231,9 @@ describe('Adapter', () => {
         rendered: {
           nodeType: 'portal',
           type: Portal,
-          props: {},
+          props: {
+            containerInfo: document.body,
+          },
           key: undefined,
           ref: null,
           instance: null,

--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -444,7 +444,7 @@ describeWithDOM('mount', () => {
       const wrapper = mount(<Foo />);
       expect(wrapper.debug()).to.equal(`<Foo>
   <div>
-    <Portal>
+    <Portal containerInfo={{...}}>
       <div className="in-portal">
         InPortal
       </div>
@@ -453,8 +453,9 @@ describeWithDOM('mount', () => {
 </Foo>`);
     });
 
-    it('should show portal container in shallow debug tree', () => {
+    it('should show portal container in debug tree', () => {
       const containerDiv = global.document.createElement('div');
+      containerDiv.setAttribute('data-foo', 'bar');
       const Foo = () => (
         <div className="foo">
           {createPortal(
@@ -467,7 +468,7 @@ describeWithDOM('mount', () => {
       const wrapper = mount(<Foo />);
       expect(wrapper.debug({ verbose: true })).to.equal(`<Foo>
   <div className="foo">
-    <Portal>
+    <Portal containerInfo={<div data-foo="bar">...</div>}>
       <div className="in-portal">
         InPortal
       </div>
@@ -496,7 +497,7 @@ describeWithDOM('mount', () => {
       const wrapper = mount(<Foo />);
       expect(wrapper.debug()).to.equal(`<Foo>
   <div className="foo">
-    <Portal>
+    <Portal containerInfo={{...}}>
       <div className="in-portal">
         <div className="nested-in-portal">
           <Bar />
@@ -516,7 +517,7 @@ describeWithDOM('mount', () => {
 
       const wrapper = mount(<Foo />);
       expect(wrapper.debug()).to.equal(`<Foo>
-  <Portal>
+  <Portal containerInfo={{...}}>
     <div className="in-portal">
       InPortal
     </div>
@@ -1372,7 +1373,7 @@ describeWithDOM('mount', () => {
         );
 
         const wrapper = mount(<Foo />);
-        expect(wrapper.find('Portal').debug()).to.equal(`<Portal>
+        expect(wrapper.find('Portal').debug()).to.equal(`<Portal containerInfo={{...}}>
   <div className="in-portal">
     InPortal
   </div>
@@ -1714,7 +1715,7 @@ describeWithDOM('mount', () => {
 
       const wrapper = mount(<Foo />);
       expect(wrapper.findWhere(node => node.type() === Portal).debug())
-        .to.equal(`<Portal>
+        .to.equal(`<Portal containerInfo={{...}}>
   <div className="in-portal">
     InPortal
   </div>

--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -15,6 +15,9 @@ import {
   sym,
 } from 'enzyme/build/Utils';
 import getAdapter from 'enzyme/build/getAdapter';
+import {
+  Portal,
+} from 'react-is';
 
 import './_helpers/setupAdapters';
 import {
@@ -423,6 +426,102 @@ describeWithDOM('mount', () => {
       expect(children.at(0).props().test).to.equal('123');
       expect(wrapper.find(TestItem)).to.have.lengthOf(3);
       expect(wrapper.find(TestItem).first().props().test).to.equal('123');
+    });
+  });
+
+  describeIf(is('>= 16'), 'portals', () => {
+    it('should show portals in mount debug tree', () => {
+      const containerDiv = global.document.createElement('div');
+      const Foo = () => (
+        <div>
+          {createPortal(
+            <div className="in-portal">InPortal</div>,
+            containerDiv,
+          )}
+        </div>
+      );
+
+      const wrapper = mount(<Foo />);
+      expect(wrapper.debug()).to.equal(`<Foo>
+  <div>
+    <Portal>
+      <div className="in-portal">
+        InPortal
+      </div>
+    </Portal>
+  </div>
+</Foo>`);
+    });
+
+    it('should show portal container in shallow debug tree', () => {
+      const containerDiv = global.document.createElement('div');
+      const Foo = () => (
+        <div className="foo">
+          {createPortal(
+            <div className="in-portal">InPortal</div>,
+            containerDiv,
+          )}
+        </div>
+      );
+
+      const wrapper = mount(<Foo />);
+      expect(wrapper.debug({ verbose: true })).to.equal(`<Foo>
+  <div className="foo">
+    <Portal>
+      <div className="in-portal">
+        InPortal
+      </div>
+    </Portal>
+  </div>
+</Foo>`);
+    });
+
+    it('should show nested portal children in debug tree', () => {
+      const Bar = () => null;
+
+      const containerDiv = global.document.createElement('div');
+      const Foo = () => (
+        <div className="foo">
+          {createPortal(
+            <div className="in-portal">
+              <div className="nested-in-portal">
+                <Bar />
+              </div>
+            </div>,
+            containerDiv,
+          )}
+        </div>
+      );
+
+      const wrapper = mount(<Foo />);
+      expect(wrapper.debug()).to.equal(`<Foo>
+  <div className="foo">
+    <Portal>
+      <div className="in-portal">
+        <div className="nested-in-portal">
+          <Bar />
+        </div>
+      </div>
+    </Portal>
+  </div>
+</Foo>`);
+    });
+
+    it('should have top level portals in debug tree', () => {
+      const containerDiv = global.document.createElement('div');
+      const Foo = () => createPortal(
+        <div className="in-portal">InPortal</div>,
+        containerDiv,
+      );
+
+      const wrapper = mount(<Foo />);
+      expect(wrapper.debug()).to.equal(`<Foo>
+  <Portal>
+    <div className="in-portal">
+      InPortal
+    </div>
+  </Portal>
+</Foo>`);
     });
   });
 
@@ -1260,6 +1359,25 @@ describeWithDOM('mount', () => {
           expect(wrapper.children()).to.have.lengthOf(1);
         });
       });
+
+      itIf(is('>= 16'), 'should find mounted portals by name', () => {
+        const containerDiv = global.document.createElement('div');
+        const Foo = () => (
+          <div>
+            {createPortal(
+              <div className="in-portal">InPortal</div>,
+              containerDiv,
+            )}
+          </div>
+        );
+
+        const wrapper = mount(<Foo />);
+        expect(wrapper.find('Portal').debug()).to.equal(`<Portal>
+  <div className="in-portal">
+    InPortal
+  </div>
+</Portal>`);
+      });
     });
 
   describe('.findWhere(predicate)', () => {
@@ -1581,6 +1699,26 @@ describeWithDOM('mount', () => {
       const spy = sinon.spy(stub);
       wrapper.findWhere(spy);
       expect(spy).to.have.property('callCount', 2);
+    });
+
+    itIf(is('>= 16'), 'should find mounted portals by react-is Portal type', () => {
+      const containerDiv = global.document.createElement('div');
+      const Foo = () => (
+        <div>
+          {createPortal(
+            <div className="in-portal">InPortal</div>,
+            containerDiv,
+          )}
+        </div>
+      );
+
+      const wrapper = mount(<Foo />);
+      expect(wrapper.findWhere(node => node.type() === Portal).debug())
+        .to.equal(`<Portal>
+  <div className="in-portal">
+    InPortal
+  </div>
+</Portal>`);
     });
   });
 


### PR DESCRIPTION
React 16+ adapters `toTree` given a `HostPortal` returns a portal wrapping the child tree, instead of returning the child tree directly. This lets Portals show up in debug output and be found. Added the portal wrapper with a `nodeType` of `'portal'` and a `type` of react-is `Portal`.