### PR TITLE
[Docs] Update clarifying event object passed to .simulate()

### DIFF
--- a/docs/api/ReactWrapper/simulate.md
+++ b/docs/api/ReactWrapper/simulate.md
@@ -46,3 +46,7 @@ expect(wrapper.find('.clicks-0').length).to.equal(1);
 wrapper.find('a').simulate('click');
 expect(wrapper.find('.clicks-1').length).to.equal(1);
 ```
+#### Common Gotchas
+
+- As noted in the function signature above passing a mock event is optional. It is worth noting that `ReactWrapper` will pass a `SyntheticEvent` object to the event handler in your code. Keep in mind that if the code you are testing uses properties that are not included in the `SyntheticEvent`, for instance `event.target.value`, you will need to provide a mock event like so `.simulate("change", { target: { value: "foo" }})` for it to work.
+

--- a/docs/api/ShallowWrapper/simulate.md
+++ b/docs/api/ShallowWrapper/simulate.md
@@ -57,3 +57,4 @@ the event handler set.
 - Even though the name would imply this simulates an actual event, `.simulate()` will in fact
 target the component's prop based on the event you give it. For example, `.simulate('click')` will
 actually get the `onClick` prop and call it.
+- As noted in the function signature above passing a mock event is optional. Keep in mind that if the code you are testing uses the event for something like, calling `event.preventDefault()` or accessing any of its properties you must provide a mock event object with the properties your code requires.


### PR DESCRIPTION
Address issue #1748 and shine some light on how and when to pass a mock event when using .simulate() with ShallowWrapper or ReactWrapper. 