### PR TITLE
[Fix] `shallow`: `.setState()`: stub out `setState` on non-root code paths as well.

### DIFF
--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -5169,5 +5169,32 @@ describeWithDOM('mount', () => {
       expect(wrapper.state('foo')).to.equal('onChange update');
       expect(spy).to.have.property('callCount', 1);
     });
+
+    it('should call `componentDidUpdate` when component’s `setState` is called', () => {
+      class Foo extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            foo: 'init',
+          };
+          this.update = () => this.setState({ foo: 'update' });
+        }
+
+        componentDidMount() {
+          this.update();
+        }
+
+        componentDidUpdate() {}
+
+        render() {
+          return <div>{this.state.foo}</div>;
+        }
+      }
+      const spy = sinon.spy(Foo.prototype, 'componentDidUpdate');
+
+      const wrapper = mount(<Foo />);
+      expect(spy).to.have.property('callCount', 1);
+      expect(wrapper.state('foo')).to.equal('update');
+    });
   });
 });

--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -2317,6 +2317,31 @@ describeWithDOM('mount', () => {
       expect(wrapper.state()).to.eql({ id: 'foo' });
       expect(() => wrapper.setState({ id: 'bar' }, 1)).to.throw(Error);
     });
+
+    it('should preserve the receiver', () => {
+      class Comp extends React.Component {
+        constructor(...args) {
+          super(...args);
+
+          this.state = {
+            key: '',
+          };
+
+          this.instanceFunction = () => this.setState(() => ({ key: 'value' }));
+        }
+
+        componentDidMount() {
+          this.instanceFunction();
+        }
+
+        render() {
+          const { key } = this.state;
+          return key ? null : null;
+        }
+      }
+
+      expect(mount(<Comp />).debug()).to.equal('<Comp />');
+    });
   });
 
   describe('.is(selector)', () => {

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -4967,6 +4967,33 @@ describe('shallow', () => {
         expect(wrapper.state('foo')).to.equal('onChange update');
         expect(spy).to.have.property('callCount', 1);
       });
+
+      it('should call `componentDidUpdate` when component’s `setState` is called', () => {
+        class Foo extends React.Component {
+          constructor(props) {
+            super(props);
+            this.state = {
+              foo: 'init',
+            };
+            this.update = () => this.setState({ foo: 'update' });
+          }
+
+          componentDidMount() {
+            this.update();
+          }
+
+          componentDidUpdate() {}
+
+          render() {
+            return <div>{this.state.foo}</div>;
+          }
+        }
+        const spy = sinon.spy(Foo.prototype, 'componentDidUpdate');
+
+        const wrapper = shallow(<Foo />);
+        expect(spy).to.have.property('callCount', 1);
+        expect(wrapper.state('foo')).to.equal('update');
+      });
     });
 
     describeIf(is('>= 16'), 'support getSnapshotBeforeUpdate', () => {

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -2142,7 +2142,7 @@ describe('shallow', () => {
       expect(wrapper.find('.bar')).to.have.lengthOf(1);
     });
 
-    it.skip('allows setState inside of componentDidMount', () => {
+    it('allows setState inside of componentDidMount', () => {
       class MySharona extends React.Component {
         constructor(props) {
           super(props);
@@ -2232,6 +2232,31 @@ describe('shallow', () => {
       const wrapper = shallow(<Foo />);
       expect(wrapper.state()).to.eql({ id: 'foo' });
       expect(() => wrapper.setState({ id: 'bar' }, 1)).to.throw(Error);
+    });
+
+    it('should preserve the receiver', () => {
+      class Comp extends React.Component {
+        constructor(...args) {
+          super(...args);
+
+          this.state = {
+            key: '',
+          };
+
+          this.instanceFunction = () => this.setState(() => ({ key: 'value' }));
+        }
+
+        componentDidMount() {
+          this.instanceFunction();
+        }
+
+        render() {
+          const { key } = this.state;
+          return key ? null : null;
+        }
+      }
+
+      expect(shallow(<Comp />).debug()).to.equal('');
     });
   });
 

--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -176,15 +176,6 @@ class ShallowWrapper {
       privateSet(this, RENDERER, renderer);
       this[RENDERER].render(nodes, options.context);
       ({ instance } = this[RENDERER].getNode());
-      if (
-        !options.disableLifecycleMethods
-        && instance
-        && typeof instance.componentDidMount === 'function'
-      ) {
-        this[RENDERER].batchedUpdates(() => {
-          instance.componentDidMount();
-        });
-      }
       privateSetNodes(this, getRootNode(this[RENDERER].getNode()));
     } else {
       privateSet(this, ROOT, root);
@@ -201,6 +192,16 @@ class ShallowWrapper {
     if (instance && lifecycles.componentDidUpdate.onSetState && !instance[SET_STATE]) {
       privateSet(instance, SET_STATE, instance.setState);
       instance.setState = (...args) => this.setState(...args);
+    }
+
+    if (
+      !options.disableLifecycleMethods
+      && instance
+      && typeof instance.componentDidMount === 'function'
+    ) {
+      this[RENDERER].batchedUpdates(() => {
+        instance.componentDidMount();
+      });
     }
   }
 


### PR DESCRIPTION
Fixes #1756

cc @koba04 