### PR TITLE
Fix setState regression

### DIFF
--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -399,11 +399,11 @@ class ShallowWrapper {
    * @param {Function} cb - callback function
    * @returns {ShallowWrapper}
    */
-  setProps(props, callback = noop) {
+  setProps(props, callback) {
     if (this[ROOT] !== this) {
       throw new Error('ShallowWrapper::setProps() can only be called on the root');
     }
-    if (typeof callback !== 'function') {
+    if (callback && typeof callback !== 'function') {
       throw new TypeError('ShallowWrapper::setProps() expects a function as its second argument');
     }
     this.rerender(props);
@@ -424,14 +424,14 @@ class ShallowWrapper {
    * @param {Function} cb - callback function
    * @returns {ShallowWrapper}
    */
-  setState(state, callback = undefined) {
+  setState(state, callback) {
     if (this[ROOT] !== this) {
       throw new Error('ShallowWrapper::setState() can only be called on the root');
     }
     if (this.instance() === null || this[RENDERER].getNode().nodeType === 'function') {
       throw new Error('ShallowWrapper::setState() can only be called on class components');
     }
-    if (arguments.length > 1 && typeof callback !== 'function') {
+    if (callback && typeof callback !== 'function') {
       throw new TypeError('ReactWrapper::setState() expects a function as its second argument');
     }
     this.single('setState', () => {


### PR DESCRIPTION
I have noticed the following regression after upgrade to enzyme 3.4.4.

> TypeError: ReactWrapper::setState() expects a function as its second argument

I think that we are closer to how React behaves this way: https://github.com/facebook/react/blob/5031ebf6beddf88cac15f4d2c9e91f8dbb91d59d/packages/react-reconciler/src/ReactFiberClassComponent.js#L77-L92