### PR TITLE
Remove portal specific logic from utils

### DIFF
--- a/packages/enzyme-adapter-utils/package.json
+++ b/packages/enzyme-adapter-utils/package.json
@@ -36,8 +36,7 @@
   "dependencies": {
     "function.prototype.name": "^1.1.0",
     "object.assign": "^4.1.0",
-    "prop-types": "^15.6.2",
-    "react-is": "^16.4.2"
+    "prop-types": "^15.6.2"
   },
   "peerDependencies": {
     "react": "0.13.x || 0.14.x || ^15.0.0-0 || ^16.0.0-0"

--- a/packages/enzyme-adapter-utils/src/Utils.js
+++ b/packages/enzyme-adapter-utils/src/Utils.js
@@ -1,7 +1,4 @@
 import functionName from 'function.prototype.name';
-import {
-  Portal,
-} from 'react-is';
 import createMountWrapper from './createMountWrapper';
 import createRenderWrapper from './createRenderWrapper';
 
@@ -110,10 +107,6 @@ export function displayNameOfNode(node) {
 
   if (!type) return null;
 
-  if (type === Portal) {
-    return 'Portal';
-  }
-
   return type.displayName || (typeof type === 'function' ? functionName(type) : type.name || type);
 }
 
@@ -123,9 +116,6 @@ export function nodeTypeFromType(type) {
   }
   if (type && type.prototype && type.prototype.isReactComponent) {
     return 'class';
-  }
-  if (type && type === Portal) {
-    return 'portal';
   }
   return 'function';
 }


### PR DESCRIPTION
Remove some `Utils` changes that were added in https://github.com/airbnb/enzyme/pull/1760, as this logic is reflected instead in the adapters (added in https://github.com/airbnb/enzyme/pull/1761).

This should have no functional changes