### PR TITLE
Add children to mounted portal props

### DIFF
--- a/packages/enzyme-adapter-react-16.1/src/ReactSixteenOneAdapter.js
+++ b/packages/enzyme-adapter-react-16.1/src/ReactSixteenOneAdapter.js
@@ -94,7 +94,7 @@ function elementToTree(el) {
     type: Portal,
     props,
     key: ensureKeyOrUndefined(el.key),
-    ref: el.ref,
+    ref: el.ref || null,
     instance: null,
     rendered: elementToTree(el.children),
   };
@@ -112,8 +112,11 @@ function toTree(vnode) {
     case HostRoot: // 3
       return childrenToTree(node.child);
     case HostPortal: { // 4
-      const { stateNode: { containerInfo } } = node;
-      const props = { containerInfo };
+      const {
+        stateNode: { containerInfo },
+        memoizedProps: children,
+      } = node;
+      const props = { containerInfo, children };
       return {
         nodeType: 'portal',
         type: Portal,

--- a/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
+++ b/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
@@ -95,7 +95,7 @@ function elementToTree(el) {
     type: Portal,
     props,
     key: ensureKeyOrUndefined(el.key),
-    ref: el.ref,
+    ref: el.ref || null,
     instance: null,
     rendered: elementToTree(el.children),
   };
@@ -113,8 +113,11 @@ function toTree(vnode) {
     case HostRoot: // 3
       return childrenToTree(node.child);
     case HostPortal: { // 4
-      const { stateNode: { containerInfo } } = node;
-      const props = { containerInfo };
+      const {
+        stateNode: { containerInfo },
+        memoizedProps: children,
+      } = node;
+      const props = { containerInfo, children };
       return {
         nodeType: 'portal',
         type: Portal,

--- a/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
+++ b/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
@@ -100,7 +100,7 @@ function elementToTree(el) {
     type: Portal,
     props,
     key: ensureKeyOrUndefined(el.key),
-    ref: el.ref,
+    ref: el.ref || null,
     instance: null,
     rendered: elementToTree(el.children),
   };
@@ -118,8 +118,11 @@ function toTree(vnode) {
     case HostRoot: // 3
       return childrenToTree(node.child);
     case HostPortal: { // 4
-      const { stateNode: { containerInfo } } = node;
-      const props = { containerInfo };
+      const {
+        stateNode: { containerInfo },
+        memoizedProps: children,
+      } = node;
+      const props = { containerInfo, children };
       return {
         nodeType: 'portal',
         type: Portal,

--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -100,7 +100,7 @@ function elementToTree(el) {
     type: Portal,
     props,
     key: ensureKeyOrUndefined(el.key),
-    ref: el.ref,
+    ref: el.ref || null,
     instance: null,
     rendered: elementToTree(el.children),
   };
@@ -118,8 +118,11 @@ function toTree(vnode) {
     case HostRoot: // 3
       return childrenToTree(node.child);
     case HostPortal: { // 4
-      const { stateNode: { containerInfo } } = node;
-      const props = { containerInfo };
+      const {
+        stateNode: { containerInfo },
+        memoizedProps: children,
+      } = node;
+      const props = { containerInfo, children };
       return {
         nodeType: 'portal',
         type: Portal,

--- a/packages/enzyme-test-suite/test/Adapter-spec.jsx
+++ b/packages/enzyme-test-suite/test/Adapter-spec.jsx
@@ -208,9 +208,10 @@ describe('Adapter', () => {
       const document = jsdom.jsdom();
       const options = { mode: 'mount' };
       const renderer = adapter.createRenderer(options);
+      const innerDiv = <div className="Foo">Hello World!</div>;
       const Foo = () => (
         createPortal(
-          <div className="Foo">Hello World!</div>,
+          innerDiv,
           document.body,
         )
       );
@@ -218,6 +219,9 @@ describe('Adapter', () => {
       renderer.render(<Foo />);
 
       const node = renderer.getNode();
+
+      const { rendered: { props: { children } } } = node;
+      expect(children).to.equal(innerDiv);
 
       cleanNode(node);
 
@@ -245,6 +249,56 @@ describe('Adapter', () => {
             ref: null,
             instance: null,
             rendered: ['Hello World!'],
+          },
+        },
+      }));
+    });
+
+    itIf(is('>= 16'), 'shallow renders react portals', () => {
+      const options = { mode: 'shallow' };
+      const renderer = adapter.createRenderer(options);
+      const innerDiv = <div className="Foo">Hello World!</div>;
+      const containerDiv = { nodeType: 1 };
+      const Foo = () => (
+        createPortal(
+          innerDiv,
+          containerDiv,
+        )
+      );
+
+      renderer.render(<Foo />);
+
+      const node = renderer.getNode();
+
+      const { rendered: { props: { children } } } = node;
+      expect(children).to.equal(innerDiv);
+
+      cleanNode(node);
+
+      expect(prettyFormat(node)).to.equal(prettyFormat({
+        nodeType: 'function',
+        type: Foo,
+        props: {},
+        key: undefined,
+        ref: null,
+        instance: null,
+        rendered: {
+          nodeType: 'portal',
+          type: Portal,
+          props: {
+            containerInfo: containerDiv,
+          },
+          key: undefined,
+          ref: null,
+          instance: null,
+          rendered: {
+            nodeType: 'host',
+            type: 'div',
+            props: { className: 'Foo' },
+            key: undefined,
+            ref: null,
+            instance: null,
+            rendered: 'Hello World!',
           },
         },
       }));


### PR DESCRIPTION
Add `children` to mounted portal `props`. This brings the mount results in line with the shallow results and the other element types (which have `props.children`).

Also added the `shallow renders react portals` test. Compared to the `renders react portals` test above, `node.rendered.ref` comes back `undefined` instead of `null` which may be an issue with https://github.com/airbnb/enzyme/blob/master/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js#L103, if a portal can never have refs this might make sense to hard code as `null`. The inner divs `rendered` also comes back ` 'Hello World!'` instead of `['Hello World!']` which seems like the shallow renderer `Utils.elementToTree` is missing the check at https://github.com/airbnb/enzyme/blob/master/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js#L157.