### PR TITLE
[Fix] `shallow`: `.parents`: ensure that one `.find` call does not affect another

### DIFF
--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -3893,6 +3893,55 @@ describeWithDOM('mount', () => {
       const formUp = input.parents('form');
       expect(formUp).to.have.lengthOf(1);
     });
+
+    it('works when called sequentially on two sibling nodes', () => {
+      class Test extends React.Component {
+        render() {
+          return (
+            <div>
+              <div className="a">
+                <div>A child</div>
+              </div>
+              <div className="b">
+                <div>B child</div>
+              </div>
+            </div>
+          );
+        }
+      }
+
+      const wrapper = mount(<Test />);
+
+      const aChild = wrapper.find({ children: 'A child' });
+      expect(aChild.debug()).to.equal(`<div>
+  A child
+</div>`);
+      expect(aChild).to.have.lengthOf(1);
+
+      const bChild = wrapper.find({ children: 'B child' });
+      expect(bChild.debug()).to.equal(`<div>
+  B child
+</div>`);
+      expect(bChild).to.have.lengthOf(1);
+
+      /*
+      const bChildParents = bChild.parents('.b');
+      expect(bChildParents.debug()).to.equal(`<div className="b">
+  <div>
+    B child
+  </div>
+</div>`);
+      expect(bChildParents).to.have.lengthOf(1);
+      */
+
+      const aChildParents = aChild.parents('.a');
+      expect(aChildParents.debug()).to.equal(`<div className="a">
+  <div>
+    A child
+  </div>
+</div>`);
+      expect(aChildParents).to.have.lengthOf(1);
+    });
   });
 
   describe('.parent()', () => {

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -3556,6 +3556,55 @@ describe('shallow', () => {
       expect(parents.at(0).hasClass('foo')).to.equal(true);
       expect(parents.at(1).hasClass('bax')).to.equal(true);
     });
+
+    it('works when called sequentially on two sibling nodes', () => {
+      class Test extends React.Component {
+        render() {
+          return (
+            <div>
+              <div className="a">
+                <div>A child</div>
+              </div>
+              <div className="b">
+                <div>B child</div>
+              </div>
+            </div>
+          );
+        }
+      }
+
+      const wrapper = shallow(<Test />);
+
+      const aChild = wrapper.find({ children: 'A child' });
+      expect(aChild.debug()).to.equal(`<div>
+  A child
+</div>`);
+      expect(aChild).to.have.lengthOf(1);
+
+      const bChild = wrapper.find({ children: 'B child' });
+      expect(bChild.debug()).to.equal(`<div>
+  B child
+</div>`);
+      expect(bChild).to.have.lengthOf(1);
+
+      /*
+      const bChildParents = bChild.parents('.b');
+      expect(bChildParents.debug()).to.equal(`<div className="b">
+  <div>
+    B child
+  </div>
+</div>`);
+      expect(bChildParents).to.have.lengthOf(1);
+      */
+
+      const aChildParents = aChild.parents('.a');
+      expect(aChildParents.debug()).to.equal(`<div className="a">
+  <div>
+    A child
+  </div>
+</div>`);
+      expect(aChildParents).to.have.lengthOf(1);
+    });
   });
 
   describe('.parent()', () => {

--- a/packages/enzyme/src/RSTTraversal.js
+++ b/packages/enzyme/src/RSTTraversal.js
@@ -106,7 +106,7 @@ export function pathToNode(node, root) {
 }
 
 export function parentsOfNode(node, root) {
-  return pathToNode(node, root).reverse();
+  return (pathToNode(node, root) || []).reverse();
 }
 
 export function nodeHasId(node, id) {

--- a/packages/enzyme/src/ReactWrapper.js
+++ b/packages/enzyme/src/ReactWrapper.js
@@ -737,8 +737,10 @@ class ReactWrapper {
    * @returns {ReactWrapper}
    */
   parents(selector) {
-    const allParents = this.wrap(this.single('parents', n => nodeParents(this, n)));
-    return selector ? allParents.filter(selector) : allParents;
+    return this.single('parents', (n) => {
+      const allParents = this.wrap(nodeParents(this, n));
+      return selector ? allParents.filter(selector) : allParents;
+    });
   }
 
   /**

--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -972,8 +972,10 @@ class ShallowWrapper {
    * @returns {ShallowWrapper}
    */
   parents(selector) {
-    const allParents = this.wrap(this.single('parents', n => nodeParents(this, n)));
-    return selector ? allParents.filter(selector) : allParents;
+    return this.single('parents', (n) => {
+      const allParents = this.wrap(nodeParents(this, n));
+      return selector ? allParents.filter(selector) : allParents;
+    });
   }
 
   /**


### PR DESCRIPTION
Fixes #1780.

These tests are failing; anyone who can help by posting a link to their branch would be very appreciated.