### PR TITLE
incorrect title companred to parent link

### DIFF
--- a/docs/guides/jest.md
+++ b/docs/guides/jest.md
@@ -1,4 +1,4 @@
-# Using Jest with enzyme
+# Using enzyme with Jest
 
 ## Configure with Jest
 


### PR DESCRIPTION
while navigating from [Guides](http://airbnb.io/enzyme/docs/guides.html) page.