### PR TITLE
Detect Fiber types to avoid inlining constants

### DIFF
--- a/packages/enzyme-adapter-react-16/package.json
+++ b/packages/enzyme-adapter-react-16/package.json
@@ -40,7 +40,6 @@
     "object.values": "^1.0.4",
     "prop-types": "^15.6.2",
     "react-is": "^16.4.2",
-    "react-reconciler": "^0.7.0",
     "react-test-renderer": "^16.0.0-0"
   },
   "peerDependencies": {

--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -36,7 +36,7 @@ import {
   propsWithKeysAndRef,
   ensureKeyOrUndefined,
 } from 'enzyme-adapter-utils';
-import { findCurrentFiberUsingSlowPath } from 'react-reconciler/reflection';
+import findCurrentFiberUsingSlowPath from './findCurrentFiberUsingSlowPath';
 
 const HostRoot = 3;
 const ClassComponent = 2;

--- a/packages/enzyme-adapter-react-16/src/detectFiberTags.js
+++ b/packages/enzyme-adapter-react-16/src/detectFiberTags.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+function getFiber(element) {
+  const container = global.document.createElement('div');
+  let inst = null;
+  class Tester extends React.Component {
+    render() {
+      inst = this;
+      return element;
+    }
+  }
+  ReactDOM.render(React.createElement(Tester), container);
+  return inst._reactInternalFiber.child;
+}
+
+module.exports = function detectFiberTags() {
+  const supportsMode = typeof React.StrictMode !== 'undefined';
+  const supportsContext = typeof React.createContext !== 'undefined';
+  const supportsForwardRef = typeof React.forwardRef !== 'undefined';
+
+  function Fn() {
+    return null;
+  }
+  // eslint-disable-next-line react/prefer-stateless-function
+  class Cls extends React.Component {
+    render() {
+      return null;
+    }
+  }
+  let Ctx = null;
+  let FwdRef = null;
+  if (supportsContext) {
+    Ctx = React.createContext();
+  }
+  if (supportsForwardRef) {
+    // React will warn if we don't have both arguments.
+    // eslint-disable-next-line no-unused-vars
+    FwdRef = React.forwardRef((props, ref) => null);
+  }
+
+  return {
+    HostRoot: getFiber('test').return.return.tag, // Go two levels above to find the root
+    ClassComponent: getFiber(React.createElement(Cls)).tag,
+    Fragment: getFiber([['nested']]).tag,
+    FunctionalComponent: getFiber(React.createElement(Fn)).tag,
+    HostPortal: getFiber(ReactDOM.createPortal(null, global.document.createElement('div'))).tag,
+    HostComponent: getFiber(React.createElement('span')).tag,
+    HostText: getFiber('text').tag,
+    Mode: supportsMode
+      ? getFiber(React.createElement(React.StrictMode)).tag
+      : -1,
+    ContextConsumer: supportsContext
+      ? getFiber(React.createElement(Ctx.Consumer, null, () => null)).tag
+      : -1,
+    ContextProvider: supportsContext
+      ? getFiber(React.createElement(Ctx.Provider, { value: null })).tag
+      : -1,
+    ForwardRef: supportsForwardRef
+      ? getFiber(React.createElement(FwdRef)).tag
+      : -1,
+  };
+};

--- a/packages/enzyme-adapter-react-16/src/findCurrentFiberUsingSlowPath.js
+++ b/packages/enzyme-adapter-react-16/src/findCurrentFiberUsingSlowPath.js
@@ -1,0 +1,104 @@
+// Extracted from https://github.com/facebook/react/blob/7bdf93b17a35a5d8fcf0ceae0bf48ed5e6b16688/src/renderers/shared/fiber/ReactFiberTreeReflection.js#L104-L228
+function findCurrentFiberUsingSlowPath(fiber) {
+  const { alternate } = fiber;
+  if (!alternate) {
+    return fiber;
+  }
+  // If we have two possible branches, we'll walk backwards up to the root
+  // to see what path the root points to. On the way we may hit one of the
+  // special cases and we'll deal with them.
+  let a = fiber;
+  let b = alternate;
+  while (true) { // eslint-disable-line
+    const parentA = a.return;
+    const parentB = parentA ? parentA.alternate : null;
+    if (!parentA || !parentB) {
+      // We're at the root.
+      break;
+    }
+
+    // If both copies of the parent fiber point to the same child, we can
+    // assume that the child is current. This happens when we bailout on low
+    // priority: the bailed out fiber's child reuses the current child.
+    if (parentA.child === parentB.child) {
+      let { child } = parentA;
+      while (child) {
+        if (child === a) {
+          // We've determined that A is the current branch.
+          return fiber;
+        }
+        if (child === b) {
+          // We've determined that B is the current branch.
+          return alternate;
+        }
+        child = child.sibling;
+      }
+      // We should never have an alternate for any mounting node. So the only
+      // way this could possibly happen is if this was unmounted, if at all.
+      throw new Error('Unable to find node on an unmounted component.');
+    }
+
+    if (a.return !== b.return) {
+      // The return pointer of A and the return pointer of B point to different
+      // fibers. We assume that return pointers never criss-cross, so A must
+      // belong to the child set of A.return, and B must belong to the child
+      // set of B.return.
+      a = parentA;
+      b = parentB;
+    } else {
+      // The return pointers point to the same fiber. We'll have to use the
+      // default, slow path: scan the child sets of each parent alternate to see
+      // which child belongs to which set.
+      //
+      // Search parent A's child set
+      let didFindChild = false;
+      let { child } = parentA;
+      while (child) {
+        if (child === a) {
+          didFindChild = true;
+          a = parentA;
+          b = parentB;
+          break;
+        }
+        if (child === b) {
+          didFindChild = true;
+          b = parentA;
+          a = parentB;
+          break;
+        }
+        child = child.sibling;
+      }
+      if (!didFindChild) {
+        // Search parent B's child set
+        ({ child } = parentB);
+        while (child) {
+          if (child === a) {
+            didFindChild = true;
+            a = parentB;
+            b = parentA;
+            break;
+          }
+          if (child === b) {
+            didFindChild = true;
+            b = parentB;
+            a = parentA;
+            break;
+          }
+          child = child.sibling;
+        }
+        if (!didFindChild) {
+          throw new Error('Child was not found in either parent set. This indicates a bug '
+            + 'in React related to the return pointer. Please file an issue.');
+        }
+      }
+    }
+  }
+  if (a.stateNode.current === a) {
+    // We've determined that A is the current branch.
+    return fiber;
+  }
+  // Otherwise B has to be current branch.
+  return alternate;
+}
+
+module.exports = findCurrentFiberUsingSlowPath;


### PR DESCRIPTION
This removes Enzyme's reliance on internal React reconciler constants which can change between releases (and *are* going to change in 16.4.3 which we plan to cut on Monday).

Instead, we're feature testing to detect the Fiber tags. The fields I'm relying on are relatively stable, and are expected to stay significantly more stable than the constants. The detection is done lazily (because we can't assume the DOM is available until you call `mount`). I've checked that other code paths don't use `FiberTags`.

This should work with all 16.x versions. I did some manual checking with 16.1, 16.2, 16.3, and the master React version (which would break without this). I haven't verified 16.0 but I'd expect it to work as well.

I included the revert of the reconciler dependency. This is because the code in it *does* rely on the constants (which we don't want). The inlined version here doesn't (because those constants are used only for invariants).

Longer term, we should be able to get rid both of this inlined piece, and of the constant detection. Instead we should share the infrastructure with React DevTools. I expect that we'll get to it in the coming months, and when we do, I'll send a PR for that. In the meantime I'm happy to help with bugfixing the React adapter if you discover any problems with my approach.