### PR TITLE
[Docs] setProps accepts a callback as its second argument

### DIFF
--- a/docs/api/ReactWrapper/setContext.md
+++ b/docs/api/ReactWrapper/setContext.md
@@ -51,7 +51,7 @@ that includes a `context` specified in the options argument.
 
 #### Related Methods
 
-- [`.setState(state) => Self`](setState.md)
-- [`.setProps(props) => Self`](setProps.md)
+- [`.setState(state[, callback]) => Self`](setState.md)
+- [`.setProps(props[, callback]) => Self`](setProps.md)
 
 

--- a/docs/api/ReactWrapper/setState.md
+++ b/docs/api/ReactWrapper/setState.md
@@ -54,7 +54,7 @@ expect(wrapper.find('.bar')).to.have.lengthOf(1);
 
 #### Related Methods
 
-- [`.setProps(props) => Self`](setProps.md)
+- [`.setProps(props[, callback]) => Self`](setProps.md)
 - [`.setContext(context) => Self`](setContext.md)
 
 

--- a/docs/api/ShallowWrapper/setContext.md
+++ b/docs/api/ShallowWrapper/setContext.md
@@ -51,7 +51,7 @@ that includes a `context` specified in the options argument.
 
 #### Related Methods
 
-- [`.setState(state) => Self`](setState.md)
-- [`.setProps(props) => Self`](setProps.md)
+- [`.setState(state[, callback]) => Self`](setState.md)
+- [`.setProps(props[, callback]) => Self`](setProps.md)
 
 

--- a/docs/api/ShallowWrapper/setProps.md
+++ b/docs/api/ShallowWrapper/setProps.md
@@ -1,4 +1,4 @@
-# `.setProps(nextProps) => Self`
+# `.setProps(nextProps[, callback]) => Self`
 
 A method that sets the props of the root component, and re-renders. Useful for when you are
 wanting to test how the component behaves over time with changing props. Calling this, for
@@ -13,6 +13,7 @@ NOTE: can only be called on a wrapper instance that is also the root instance.
 #### Arguments
 
 1. `nextProps` (`Object`): An object containing new props to merge in with the current props
+2. `callback` (`Function` [optional]): If provided, the callback function will be executed once setProps has completed
 
 
 

--- a/docs/api/ShallowWrapper/setState.md
+++ b/docs/api/ShallowWrapper/setState.md
@@ -54,7 +54,7 @@ expect(wrapper.find('.bar')).to.have.lengthOf(1);
 
 #### Related Methods
 
-- [`.setProps(props) => Self`](setProps.md)
+- [`.setProps(props[, callback]) => Self`](setProps.md)
 - [`.setContext(context) => Self`](setContext.md)
 
 


### PR DESCRIPTION
This PR addresses issue #1788

---

Update the documentation of ShallowWrapper/setProps to reflect that the method accepts a callback as its second argument. 