### PR TITLE
Show functions and not <Profiler/> with react 16.3

### DIFF
--- a/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
+++ b/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
@@ -417,26 +417,26 @@ class ReactSixteenThreeAdapter extends EnzymeAdapter {
   displayNameOfNode(node) {
     if (!node) return null;
     const { type, $$typeof } = node;
-    
+
     const nodeType = type || $$typeof;
 
     // newer node types may be undefined, so only test if the nodeType exists
     if (nodeType) {
       switch (nodeType) {
-        case AsyncMode: return 'AsyncMode';
-        case Fragment: return 'Fragment';
-        case StrictMode: return 'StrictMode';
-        case Profiler: return 'Profiler';
-        case Portal: return 'Portal';
+        case AsyncMode || NaN: return 'AsyncMode';
+        case Fragment || NaN: return 'Fragment';
+        case StrictMode || NaN: return 'StrictMode';
+        case Profiler || NaN: return 'Profiler';
+        case Portal || NaN: return 'Portal';
       }
     }
 
     const $$typeofType = type && type.$$typeof;
 
     switch ($$typeofType) {
-      case ContextConsumer: return 'ContextConsumer';
-      case ContextProvider: return 'ContextProvider';
-      case ForwardRef: {
+      case ContextConsumer || NaN: return 'ContextConsumer';
+      case ContextProvider || NaN: return 'ContextProvider';
+      case ForwardRef || NaN: {
         const name = type.render.displayName || functionName(type.render);
         return name ? `ForwardRef(${name})` : 'ForwardRef';
       }

--- a/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
+++ b/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
@@ -18,7 +18,6 @@ import {
   ContextProvider,
   StrictMode,
   ForwardRef,
-  Profiler,
   Portal,
 } from 'react-is';
 import { EnzymeAdapter } from 'enzyme';
@@ -426,8 +425,8 @@ class ReactSixteenThreeAdapter extends EnzymeAdapter {
         case AsyncMode || NaN: return 'AsyncMode';
         case Fragment || NaN: return 'Fragment';
         case StrictMode || NaN: return 'StrictMode';
-        case Profiler || NaN: return 'Profiler';
         case Portal || NaN: return 'Portal';
+        default:
       }
     }
 

--- a/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
+++ b/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
@@ -417,27 +417,30 @@ class ReactSixteenThreeAdapter extends EnzymeAdapter {
   displayNameOfNode(node) {
     if (!node) return null;
     const { type, $$typeof } = node;
+    
+    const nodeType = type || $$typeof;
 
-    switch (type || $$typeof) {
-      case AsyncMode: return 'AsyncMode';
-      case Fragment: return 'Fragment';
-      case StrictMode: return 'StrictMode';
-      case Profiler: return 'Profiler';
-      case Portal: return 'Portal';
-
-      default: {
-        const $$typeofType = type && type.$$typeof;
-
-        switch ($$typeofType) {
-          case ContextConsumer: return 'ContextConsumer';
-          case ContextProvider: return 'ContextProvider';
-          case ForwardRef: {
-            const name = type.render.displayName || functionName(type.render);
-            return name ? `ForwardRef(${name})` : 'ForwardRef';
-          }
-          default: return displayNameOfNode(node);
-        }
+    // newer node types may be undefined, so only test if the nodeType exists
+    if (nodeType) {
+      switch (nodeType) {
+        case AsyncMode: return 'AsyncMode';
+        case Fragment: return 'Fragment';
+        case StrictMode: return 'StrictMode';
+        case Profiler: return 'Profiler';
+        case Portal: return 'Portal';
       }
+    }
+
+    const $$typeofType = type && type.$$typeof;
+
+    switch ($$typeofType) {
+      case ContextConsumer: return 'ContextConsumer';
+      case ContextProvider: return 'ContextProvider';
+      case ForwardRef: {
+        const name = type.render.displayName || functionName(type.render);
+        return name ? `ForwardRef(${name})` : 'ForwardRef';
+      }
+      default: return displayNameOfNode(node);
     }
   }
 

--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -417,26 +417,30 @@ class ReactSixteenAdapter extends EnzymeAdapter {
     if (!node) return null;
     const { type, $$typeof } = node;
 
-    switch (type || $$typeof) {
-      case AsyncMode: return 'AsyncMode';
-      case Fragment: return 'Fragment';
-      case StrictMode: return 'StrictMode';
-      case Profiler: return 'Profiler';
-      case Portal: return 'Portal';
+    const nodeType = type || $$typeof;
 
-      default: {
-        const $$typeofType = type && type.$$typeof;
-
-        switch ($$typeofType) {
-          case ContextConsumer: return 'ContextConsumer';
-          case ContextProvider: return 'ContextProvider';
-          case ForwardRef: {
-            const name = type.render.displayName || functionName(type.render);
-            return name ? `ForwardRef(${name})` : 'ForwardRef';
-          }
-          default: return displayNameOfNode(node);
-        }
+    // newer node types may be undefined, so only test if the nodeType exists
+    if (nodeType) {
+      switch (nodeType) {
+        case AsyncMode || NaN: return 'AsyncMode';
+        case Fragment || NaN: return 'Fragment';
+        case StrictMode || NaN: return 'StrictMode';
+        case Profiler || NaN: return 'Profiler';
+        case Portal || NaN: return 'Portal';
+        default:
       }
+    }
+
+    const $$typeofType = type && type.$$typeof;
+
+    switch ($$typeofType) {
+      case ContextConsumer || NaN: return 'ContextConsumer';
+      case ContextProvider || NaN: return 'ContextProvider';
+      case ForwardRef || NaN: {
+        const name = type.render.displayName || functionName(type.render);
+        return name ? `ForwardRef(${name})` : 'ForwardRef';
+      }
+      default: return displayNameOfNode(node);
     }
   }
 


### PR DESCRIPTION
We haven't quite yet upgraded to react 16.4 and with 16.3 Profiler is not defined, meaning that any react nodes without a type (like a function) in shallow get serialized as `<Profiler/>`

Its not that important but I thought it could happen in the future, so I did a small refactor to not match undefined and undefined.