### PR TITLE
Freeze ROOT_NODES for child wrappers

### DIFF
--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -3924,7 +3924,6 @@ describeWithDOM('mount', () => {
 </div>`);
       expect(bChild).to.have.lengthOf(1);
 
-      /*
       const bChildParents = bChild.parents('.b');
       expect(bChildParents.debug()).to.equal(`<div className="b">
   <div>
@@ -3932,7 +3931,6 @@ describeWithDOM('mount', () => {
   </div>
 </div>`);
       expect(bChildParents).to.have.lengthOf(1);
-      */
 
       const aChildParents = aChild.parents('.a');
       expect(aChildParents.debug()).to.equal(`<div className="a">

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -3587,7 +3587,6 @@ describe('shallow', () => {
 </div>`);
       expect(bChild).to.have.lengthOf(1);
 
-      /*
       const bChildParents = bChild.parents('.b');
       expect(bChildParents.debug()).to.equal(`<div className="b">
   <div>
@@ -3595,7 +3594,6 @@ describe('shallow', () => {
   </div>
 </div>`);
       expect(bChildParents).to.have.lengthOf(1);
-      */
 
       const aChildParents = aChild.parents('.a');
       expect(aChildParents.debug()).to.equal(`<div className="a">

--- a/packages/enzyme/src/ReactWrapper.js
+++ b/packages/enzyme/src/ReactWrapper.js
@@ -31,6 +31,7 @@ const RENDERER = sym('__renderer__');
 const UNRENDERED = sym('__unrendered__');
 const ROOT = sym('__root__');
 const OPTIONS = sym('__options__');
+const ROOT_NODES = sym('__rootNodes__');
 
 /**
  * Finds all nodes in the current wrapper nodes' render trees that match the provided predicate
@@ -57,8 +58,18 @@ function filterWhereUnwrapped(wrapper, predicate) {
   return wrapper.wrap(wrapper.getNodesInternal().filter(predicate).filter(Boolean));
 }
 
+function getRootNodeInternal(wrapper) {
+  if (wrapper[ROOT].length !== 1) {
+    throw new Error('getRootNodeInternal(wrapper) can only be called when wrapper wraps one node');
+  }
+  if (wrapper[ROOT] !== wrapper) {
+    return wrapper[ROOT_NODES][0];
+  }
+  return wrapper[ROOT][NODE];
+}
+
 function nodeParents(wrapper, node) {
-  return parentsOfNode(node, wrapper[ROOT].getNodeInternal());
+  return parentsOfNode(node, getRootNodeInternal(wrapper));
 }
 
 function privateSetNodes(wrapper, nodes) {
@@ -102,6 +113,7 @@ class ReactWrapper {
       privateSet(this, RENDERER, root[RENDERER]);
       privateSet(this, ROOT, root);
       privateSetNodes(this, nodes);
+      privateSet(this, ROOT_NODES, root[NODES]);
     }
     privateSet(this, OPTIONS, root ? root[OPTIONS] : options);
   }

--- a/packages/enzyme/src/ReactWrapper.js
+++ b/packages/enzyme/src/ReactWrapper.js
@@ -651,7 +651,7 @@ class ReactWrapper {
         throw new TypeError('your adapter does not support `simulateError`. Try upgrading it!');
       }
 
-      const rootNode = this[ROOT].getNodeInternal();
+      const rootNode = getRootNodeInternal(this);
       const nodeHierarchy = [thisNode].concat(nodeParents(this, thisNode));
       renderer.simulateError(nodeHierarchy, rootNode, error);
 

--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -37,6 +37,8 @@ const UNRENDERED = sym('__unrendered__');
 const ROOT = sym('__root__');
 const OPTIONS = sym('__options__');
 const SET_STATE = sym('__setState__');
+const ROOT_NODES = sym('__rootNodes__');
+
 /**
  * Finds all nodes in the current wrapper nodes' render trees that match the provided predicate
  * function.
@@ -144,6 +146,12 @@ function getRootNode(node) {
 }
 
 function getRootNodeInternal(wrapper) {
+  if (wrapper[ROOT].length !== 1) {
+    throw new Error('getRootNodeInternal(wrapper) can only be called when wrapper wraps one node');
+  }
+  if (wrapper[ROOT] !== wrapper) {
+    return wrapper[ROOT_NODES][0];
+  }
   return wrapper[ROOT][NODE];
 }
 
@@ -219,6 +227,7 @@ class ShallowWrapper {
       privateSet(this, RENDERER, root[RENDERER]);
       privateSetNodes(this, nodes);
       privateSet(this, OPTIONS, root[OPTIONS]);
+      privateSet(this, ROOT_NODES, root[NODES]);
     }
   }
 


### PR DESCRIPTION
Fixes the tests in https://github.com/airbnb/enzyme/pull/1781.

There are a few alternative ways to do fix those tests (and some things wrong with this one)

Solution 1 - This one! Save the original `ROOT` node tree, and use in calls to `parents` etc
- The saved root node tree will not actually match the `ROOT` node tree after root `update`. `update`s will affect the `ROOT` node tree but not the saved tree. This is already sort of the case, currently updates to the `ROOT` (for example setting state) would not affect `childWrapper[NODES]`, but would modify `childWrapper[ROOT][NODES]`. Given that we want child wrappers to be immutable I think this might make the most sense.
- It is possible here for something to still accidentally compare between the old and new tree by using `.root().getNodeInternal()` instead of `getRootNodeInternal()`

Solution 2 - On `update` we swap all child wrappers `ROOT`s to a copy of the old root.
- Calling and methods that update the parent would no longer work after an update. Ie
```js
const child = wrapper.find(Child);
wrapper.find(...) // Or anything that calls update on the wrapper
child.simulate(...) // Would affect the copy, not the real wrapper
```

Solution 3 - Make child wrappers not able to cause `update`s
- Breaking change, makes simulating child events and setting child state etc not possible

Solution 4 - Make child wrappers not immutable and update with component updates
- 🤷‍♂️ 

@ljharb 