### PR TITLE
Add update after simulateError

### DIFF
--- a/packages/enzyme/src/ReactWrapper.js
+++ b/packages/enzyme/src/ReactWrapper.js
@@ -643,6 +643,7 @@ class ReactWrapper {
       const nodeHierarchy = [thisNode].concat(nodeParents(this, thisNode));
       renderer.simulateError(nodeHierarchy, rootNode, error);
 
+      this[ROOT].update();
       return this;
     });
   }


### PR DESCRIPTION
Fixes https://github.com/airbnb/enzyme/issues/1809

Note that
```js
it('rerenders on an error during render', () => {
  const wrapper = mount(<ErrorBoundary spy={sinon.stub()} />);

  expect(wrapper.find({ children: 'HasThrown' })).to.have.lengthOf(0);
  expect(wrapper.find({ children: 'HasNotThrown' })).to.have.lengthOf(1);

  return new Promise((resolve) => {
    wrapper.setState({ throws: true }, () => {
      expect(wrapper.find({ children: 'HasThrown' })).to.have.lengthOf(1);
      expect(wrapper.find({ children: 'HasNotThrown' })).to.have.lengthOf(0);
      resolve();
    });
  });
});
```
Will still fail, I will fix that separately.

@ljharb 