### PR TITLE
[enzyme-adapter-react-{16,16.3}] [fix] `forwardRef`: respect `.displayName`

### DIFF
--- a/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
+++ b/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
@@ -461,6 +461,9 @@ class ReactSixteenThreeAdapter extends EnzymeAdapter {
       case ContextConsumer || NaN: return 'ContextConsumer';
       case ContextProvider || NaN: return 'ContextProvider';
       case ForwardRef || NaN: {
+        if (type.displayName) {
+          return type.displayName;
+        }
         const name = type.render.displayName || functionName(type.render);
         return name ? `ForwardRef(${name})` : 'ForwardRef';
       }

--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -463,6 +463,9 @@ class ReactSixteenAdapter extends EnzymeAdapter {
       case ContextConsumer || NaN: return 'ContextConsumer';
       case ContextProvider || NaN: return 'ContextProvider';
       case ForwardRef || NaN: {
+        if (type.displayName) {
+          return type.displayName;
+        }
         const name = type.render.displayName || functionName(type.render);
         return name ? `ForwardRef(${name})` : 'ForwardRef';
       }

--- a/packages/enzyme-test-suite/test/Debug-spec.jsx
+++ b/packages/enzyme-test-suite/test/Debug-spec.jsx
@@ -849,7 +849,9 @@ describe('debug', () => {
 
   describeIf(is('>= 16.3'), 'forwarded ref Components', () => {
     let Parent;
+    let ParentOfNamed;
     let SomeComponent;
+    let NamedComponent;
     beforeEach(() => {
       SomeComponent = forwardRef((props, ref) => (
         <div ref={ref}>
@@ -857,6 +859,10 @@ describe('debug', () => {
         </div>
       ));
       Parent = () => <span><SomeComponent foo="hello" /></span>;
+
+      NamedComponent = forwardRef((props, ref) => (<div />));
+      NamedComponent.displayName = 'a named forward ref!';
+      ParentOfNamed = () => <NamedComponent />;
     });
 
     it('works with a `mount` wrapper', () => {
@@ -883,6 +889,24 @@ describe('debug', () => {
     <span className="child1" />
   </div>
 </ForwardRef>`
+      ));
+    });
+
+    it('works with a displayName with shallow', () => {
+      const wrapper = shallow(<ParentOfNamed />);
+      expect(wrapper.debug()).to.equal((
+        `<${NamedComponent.displayName} />`
+      ));
+    });
+
+    it('works with a displayName with mount', () => {
+      const wrapper = mount(<ParentOfNamed />);
+      expect(wrapper.debug()).to.equal((
+        `<ParentOfNamed>
+  <${NamedComponent.displayName}>
+    <div />
+  </${NamedComponent.displayName}>
+</ParentOfNamed>`
       ));
     });
   });


### PR DESCRIPTION
Fixes #1810.