### PR TITLE
Add getDOMNode to Table Of Contents

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -97,6 +97,7 @@
     * [first()](/docs/api/ReactWrapper/first.md)
     * [forEach(fn)](/docs/api/ReactWrapper/forEach.md)
     * [get(index)](/docs/api/ReactWrapper/get.md)
+    * [getDOMNode()](/docs/api/ReactWrapper/getDOMNode.md)
     * [hasClass(className)](/docs/api/ReactWrapper/hasClass.md)
     * [hostNodes()](/docs/api/ReactWrapper/hostNodes.md)
     * [html()](/docs/api/ReactWrapper/html.md)


### PR DESCRIPTION
Adding it to the Full DOM Rendering section in Summary this time.