### PR TITLE
Update docs for setting up with jest

### DIFF
--- a/docs/guides/jest.md
+++ b/docs/guides/jest.md
@@ -2,7 +2,7 @@
 
 ## Configure with Jest
 
-To run the setup file to configure Enzyme and the Adapter with Jest direct `setupTestFrameworkScriptFile` in your config file (check [Jest's documentation](http://jestjs.io/docs/en/configuration) for the possible locations of that config file) to literally the string `<rootDir>` and the path to your setup file.
+To run the setup file to configure Enzyme and the Adapter (as shown in the [Installation docs](http://airbnb.io/enzyme/docs/installation/)) with Jest, set `setupTestFrameworkScriptFile` in your config file (check [Jest's documentation](http://jestjs.io/docs/en/configuration) for the possible locations of that config file) to literally the string `<rootDir>` and the path to your setup file.
 
 ```json
 {


### PR DESCRIPTION
Update the doc to add reference link to the setup files. It might not be clear as to what `setup file` means if readers read the jest section before the installation section.

Also propose a minor wording change.