### PR TITLE
Add renderProp to ShallowWrapper

### DIFF
--- a/docs/api/ReactWrapper/renderProp.md
+++ b/docs/api/ReactWrapper/renderProp.md
@@ -1,0 +1,85 @@
+# `.renderProp(propName, ...args) => ReactWrapper`
+
+Calls the current wrapper's property with name `propName` and the `args` provided.
+Returns the result in a new wrapper.
+
+NOTE: can only be called on wrapper of a single non-DOM component element node.
+
+#### Arguments
+
+1.  `propName` (`String`):
+1.  `...args` (`Array<Any>`):
+
+This essentially calls `wrapper.prop(propName)(...args)`.
+
+#### Returns
+
+`ReactWrapper`: A new wrapper that wraps the node returned from the render prop.
+
+#### Examples
+
+##### Test Setup
+
+```jsx
+class Mouse extends React.Component {
+  constructor() {
+    super();
+    this.state = { x: 0, y: 0 };
+  }
+
+  render() {
+    const { render } = this.props;
+    return (
+      <div
+        style={{ height: '100%' }}
+        onMouseMove={(event) => {
+          this.setState({
+            x: event.clientX,
+            y: event.clientY,
+          });
+        }}
+      >
+        {render(this.state)}
+      </div>
+    );
+  }
+}
+
+Mouse.propTypes = {
+  render: PropTypes.func.isRequired,
+};
+```
+
+```jsx
+const App = () => (
+  <div style={{ height: '100%' }}>
+    <Mouse
+      render={(x = 0, y = 0) => (
+        <h1>
+          The mouse position is ({x}, {y})
+        </h1>
+      )}
+    />
+  </div>
+);
+```
+
+##### Testing with no arguments
+
+```jsx
+const wrapper = mount(<App />)
+  .find(Mouse)
+  .renderProp('render');
+
+expect(wrapper.equals(<h1>The mouse position is 0, 0</h1>)).to.equal(true);
+```
+
+##### Testing with multiple arguments
+
+```jsx
+const wrapper = mount(<App />)
+  .find(Mouse)
+  .renderProp('render', [10, 20]);
+
+expect(wrapper.equals(<h1>The mouse position is 10, 20</h1>)).to.equal(true);
+```

--- a/docs/api/ShallowWrapper/renderProp.md
+++ b/docs/api/ShallowWrapper/renderProp.md
@@ -1,0 +1,85 @@
+# `.renderProp(propName, ...args) => ShallowWrapper`
+
+Calls the current wrapper's property with name `propName` and the `args` provided.
+Returns the result in a new wrapper.
+
+NOTE: can only be called on wrapper of a single non-DOM component element node.
+
+#### Arguments
+
+1.  `propName` (`String`):
+1.  `...args` (`Array<Any>`):
+
+This essentially calls `wrapper.prop(propName)(...args)`.
+
+#### Returns
+
+`ShallowWrapper`: A new wrapper that wraps the node returned from the render prop.
+
+#### Examples
+
+##### Test Setup
+
+```jsx
+class Mouse extends React.Component {
+  constructor() {
+    super();
+    this.state = { x: 0, y: 0 };
+  }
+
+  render() {
+    const { render } = this.props;
+    return (
+      <div
+        style={{ height: '100%' }}
+        onMouseMove={(event) => {
+          this.setState({
+            x: event.clientX,
+            y: event.clientY,
+          });
+        }}
+      >
+        {render(this.state)}
+      </div>
+    );
+  }
+}
+
+Mouse.propTypes = {
+  render: PropTypes.func.isRequired,
+};
+```
+
+```jsx
+const App = () => (
+  <div style={{ height: '100%' }}>
+    <Mouse
+      render={(x = 0, y = 0) => (
+        <h1>
+          The mouse position is ({x}, {y})
+        </h1>
+      )}
+    />
+  </div>
+);
+```
+
+##### Testing with no arguments
+
+```jsx
+const wrapper = shallow(<App />)
+  .find(Mouse)
+  .renderProp('render');
+
+expect(wrapper.equals(<h1>The mouse position is 0, 0</h1>)).to.equal(true);
+```
+
+##### Testing with multiple arguments
+
+```jsx
+const wrapper = shallow(<App />)
+  .find(Mouse)
+  .renderProp('render', [10, 20]);
+
+expect(wrapper.equals(<h1>The mouse position is 10, 20</h1>)).to.equal(true);
+```

--- a/docs/api/mount.md
+++ b/docs/api/mount.md
@@ -120,6 +120,9 @@ Get a wrapper with the first ancestor of the current node to match the provided 
 #### [`.render() => CheerioWrapper`](ReactWrapper/render.md)
 Returns a CheerioWrapper of the current node's subtree.
 
+#### [`.renderProp(key) => ReactWrapper`](ReactWrapper/renderProp.md)
+Returns a wrapper of the node rendered by the provided render prop.
+
 #### [`.text() => String`](ReactWrapper/text.md)
 Returns a string representation of the text nodes in the current render tree.
 

--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -130,6 +130,9 @@ Shallow renders the current node and returns a shallow wrapper around it.
 #### [`.render() => CheerioWrapper`](ShallowWrapper/render.md)
 Returns a CheerioWrapper of the current node's subtree.
 
+#### [`.renderProp(key) => ShallowWrapper`](ShallowWrapper/renderProp.md)
+Returns a wrapper of the node rendered by the provided render prop.
+
 #### [`.unmount() => ShallowWrapper`](ShallowWrapper/unmount.md)
 A method that un-mounts the component.
 

--- a/packages/enzyme-adapter-react-13/src/ReactThirteenAdapter.js
+++ b/packages/enzyme-adapter-react-13/src/ReactThirteenAdapter.js
@@ -14,6 +14,7 @@ import {
   createMountWrapper,
   propsWithKeysAndRef,
   ensureKeyOrUndefined,
+  wrap,
 } from 'enzyme-adapter-utils';
 import mapNativeEventNames from './ReactThirteenMapNativeEventNames';
 import elementToTree from './ReactThirteenElementToTree';
@@ -240,6 +241,10 @@ class ReactThirteenAdapter extends EnzymeAdapter {
       default:
         throw new Error(`Enzyme Internal Error: Unrecognized mode: ${options.mode}`);
     }
+  }
+
+  wrap(element) {
+    return wrap(element);
   }
 
   // converts an RSTNode to the corresponding JSX Pragma Element. This will be needed

--- a/packages/enzyme-adapter-react-14/src/ReactFourteenAdapter.js
+++ b/packages/enzyme-adapter-react-14/src/ReactFourteenAdapter.js
@@ -18,6 +18,7 @@ import {
   createMountWrapper,
   propsWithKeysAndRef,
   ensureKeyOrUndefined,
+  wrap,
 } from 'enzyme-adapter-utils';
 
 function typeToNodeType(type) {
@@ -212,6 +213,10 @@ class ReactFourteenAdapter extends EnzymeAdapter {
       default:
         throw new Error(`Enzyme Internal Error: Unrecognized mode: ${options.mode}`);
     }
+  }
+
+  wrap(element) {
+    return wrap(element);
   }
 
   // converts an RSTNode to the corresponding JSX Pragma Element. This will be needed

--- a/packages/enzyme-adapter-react-15.4/src/ReactFifteenFourAdapter.js
+++ b/packages/enzyme-adapter-react-15.4/src/ReactFifteenFourAdapter.js
@@ -18,6 +18,7 @@ import {
   createMountWrapper,
   propsWithKeysAndRef,
   ensureKeyOrUndefined,
+  wrap,
 } from 'enzyme-adapter-utils';
 import ifReact from 'enzyme-adapter-react-helper/build/ifReact';
 
@@ -247,6 +248,10 @@ class ReactFifteenFourAdapter extends EnzymeAdapter {
       default:
         throw new Error(`Enzyme Internal Error: Unrecognized mode: ${options.mode}`);
     }
+  }
+
+  wrap(element) {
+    return wrap(element);
   }
 
   // converts an RSTNode to the corresponding JSX Pragma Element. This will be needed

--- a/packages/enzyme-adapter-react-15/src/ReactFifteenAdapter.js
+++ b/packages/enzyme-adapter-react-15/src/ReactFifteenAdapter.js
@@ -20,6 +20,7 @@ import {
   createMountWrapper,
   propsWithKeysAndRef,
   ensureKeyOrUndefined,
+  wrap,
 } from 'enzyme-adapter-utils';
 
 function compositeTypeToNodeType(type) {
@@ -247,6 +248,10 @@ class ReactFifteenAdapter extends EnzymeAdapter {
       default:
         throw new Error(`Enzyme Internal Error: Unrecognized mode: ${options.mode}`);
     }
+  }
+
+  wrap(element) {
+    return wrap(element);
   }
 
   // converts an RSTNode to the corresponding JSX Pragma Element. This will be needed

--- a/packages/enzyme-adapter-react-16.1/src/ReactSixteenOneAdapter.js
+++ b/packages/enzyme-adapter-react-16.1/src/ReactSixteenOneAdapter.js
@@ -28,6 +28,7 @@ import {
   propsWithKeysAndRef,
   ensureKeyOrUndefined,
   simulateError,
+  wrap,
 } from 'enzyme-adapter-utils';
 import { findCurrentFiberUsingSlowPath } from 'react-reconciler/reflection';
 
@@ -438,6 +439,10 @@ class ReactSixteenOneAdapter extends EnzymeAdapter {
       default:
         throw new Error(`Enzyme Internal Error: Unrecognized mode: ${options.mode}`);
     }
+  }
+
+  wrap(element) {
+    return wrap(element);
   }
 
   // converts an RSTNode to the corresponding JSX Pragma Element. This will be needed

--- a/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
+++ b/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
@@ -29,6 +29,7 @@ import {
   propsWithKeysAndRef,
   ensureKeyOrUndefined,
   simulateError,
+  wrap,
 } from 'enzyme-adapter-utils';
 import { findCurrentFiberUsingSlowPath } from 'react-reconciler/reflection';
 
@@ -440,6 +441,10 @@ class ReactSixteenTwoAdapter extends EnzymeAdapter {
       default:
         throw new Error(`Enzyme Internal Error: Unrecognized mode: ${options.mode}`);
     }
+  }
+
+  wrap(element) {
+    return wrap(element);
   }
 
   // converts an RSTNode to the corresponding JSX Pragma Element. This will be needed

--- a/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
+++ b/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
@@ -36,6 +36,7 @@ import {
   propsWithKeysAndRef,
   ensureKeyOrUndefined,
   simulateError,
+  wrap,
 } from 'enzyme-adapter-utils';
 import { findCurrentFiberUsingSlowPath } from 'react-reconciler/reflection';
 
@@ -420,6 +421,10 @@ class ReactSixteenThreeAdapter extends EnzymeAdapter {
       default:
         throw new Error(`Enzyme Internal Error: Unrecognized mode: ${options.mode}`);
     }
+  }
+
+  wrap(element) {
+    return wrap(element);
   }
 
   // converts an RSTNode to the corresponding JSX Pragma Element. This will be needed

--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -38,6 +38,7 @@ import {
   propsWithKeysAndRef,
   ensureKeyOrUndefined,
   simulateError,
+  wrap,
 } from 'enzyme-adapter-utils';
 import findCurrentFiberUsingSlowPath from './findCurrentFiberUsingSlowPath';
 import detectFiberTags from './detectFiberTags';
@@ -466,6 +467,10 @@ class ReactSixteenAdapter extends EnzymeAdapter {
       default:
         throw new Error(`Enzyme Internal Error: Unrecognized mode: ${options.mode}`);
     }
+  }
+
+  wrap(element) {
+    return wrap(element);
   }
 
   // converts an RSTNode to the corresponding JSX Pragma Element. This will be needed

--- a/packages/enzyme-adapter-utils/package.json
+++ b/packages/enzyme-adapter-utils/package.json
@@ -36,7 +36,8 @@
   "dependencies": {
     "function.prototype.name": "^1.1.0",
     "object.assign": "^4.1.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.6.2",
+    "semver": "^5.6.0"
   },
   "peerDependencies": {
     "react": "0.13.x || 0.14.x || ^15.0.0-0 || ^16.0.0-0"

--- a/packages/enzyme-adapter-utils/src/Utils.js
+++ b/packages/enzyme-adapter-utils/src/Utils.js
@@ -1,8 +1,9 @@
 import functionName from 'function.prototype.name';
 import createMountWrapper from './createMountWrapper';
 import createRenderWrapper from './createRenderWrapper';
+import wrap from './wrapWithSimpleWrapper';
 
-export { createMountWrapper, createRenderWrapper };
+export { createMountWrapper, createRenderWrapper, wrap };
 
 export function mapNativeEventNames(event, {
   animation = false, // should be true for React 15+

--- a/packages/enzyme-adapter-utils/src/wrapWithSimpleWrapper.jsx
+++ b/packages/enzyme-adapter-utils/src/wrapWithSimpleWrapper.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { intersects } from 'semver';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+  children: PropTypes.element.isRequired,
+};
+
+const Wrapper = (intersects('>= 0.14', React.version)
+  // eslint-disable-next-line prefer-arrow-callback
+  ? () => Object.assign(function SimpleSFCWrapper({ children }) {
+    return children;
+  }, { propTypes })
+  : () => {
+    class SimpleClassWrapper extends React.Component {
+      render() {
+        const { children } = this.props;
+        return children;
+      }
+    }
+    SimpleClassWrapper.propTypes = propTypes;
+    return SimpleClassWrapper;
+  }
+)();
+
+export default function wrap(element) {
+  console.log(React.version, Wrapper);
+  return <Wrapper>{element}</Wrapper>;
+}

--- a/packages/enzyme-test-suite/test/Adapter-spec.jsx
+++ b/packages/enzyme-test-suite/test/Adapter-spec.jsx
@@ -1019,4 +1019,18 @@ describe('Adapter', () => {
       expect(adapter.isFragment(<div />)).to.equal(false);
     });
   });
+
+  describe('.wrap()', () => {
+    it('returns a valid element', () => {
+      const element = <div a="b" c="d" />;
+      const wrapped = adapter.wrap(element);
+      expect(adapter.isValidElement(wrapped)).to.equal(true);
+    });
+
+    it('renders the children provided', () => {
+      const element = <div a="b" c="d" />;
+      const wrapped = adapter.wrap(element);
+      expect(wrapped.props).to.contain.keys({ children: element });
+    });
+  });
 });

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -4743,6 +4743,68 @@ describe('shallow', () => {
     });
   });
 
+  describe('.renderProp()', () => {
+    it('returns a wrapper around the node returned from the render prop', () => {
+      class Foo extends React.Component {
+        render() {
+          return <div className="in-foo" />;
+        }
+      }
+      class Bar extends React.Component {
+        render() {
+          const { render: r } = this.props;
+          return <div className="in-bar">{r()}</div>;
+        }
+      }
+
+      const wrapperA = shallow(<div><Bar render={() => <div><Foo /></div>} /></div>);
+      const renderPropWrapperA = wrapperA.find(Bar).renderProp('render');
+      expect(renderPropWrapperA.find(Foo)).to.have.lengthOf(1);
+
+      const wrapperB = shallow(<div><Bar render={() => <Foo />} /></div>);
+      const renderPropWrapperB = wrapperB.find(Bar).renderProp('render');
+      expect(renderPropWrapperB.find(Foo)).to.have.lengthOf(1);
+
+      const stub = sinon.stub().returns(<div />);
+      const wrapperC = shallow(<div><Bar render={stub} /></div>);
+      stub.resetHistory();
+      wrapperC.find(Bar).renderProp('render', 'one', 'two');
+      expect(stub.args).to.deep.equal([['one', 'two']]);
+    });
+
+    it('throws on host elements', () => {
+      class Div extends React.Component {
+        render() {
+          const { children } = this.props;
+          return <div>{children}</div>;
+        }
+      }
+
+      const wrapper = shallow(<Div />);
+      expect(wrapper.is('div')).to.equal(true);
+      expect(() => wrapper.renderProp('foo')).to.throw();
+    });
+
+    wrap()
+      .withOverride(() => getAdapter(), 'wrap', () => undefined)
+      .it('throws with a react adapter that lacks a `.wrap`', () => {
+        class Foo extends React.Component {
+          render() {
+            return <div className="in-foo" />;
+          }
+        }
+        class Bar extends React.Component {
+          render() {
+            const { render: r } = this.props;
+            return <div className="in-bar">{r()}</div>;
+          }
+        }
+
+        const wrapper = shallow(<div><Bar render={() => <div><Foo /></div>} /></div>);
+        expect(() => wrapper.find(Bar).renderProp('render')).to.throw(RangeError);
+      });
+  });
+
   describe('lifecycle methods', () => {
     describe('disableLifecycleMethods option', () => {
       describe('validation', () => {

--- a/packages/enzyme/src/ReactWrapper.js
+++ b/packages/enzyme/src/ReactWrapper.js
@@ -1,5 +1,6 @@
 import cheerio from 'cheerio';
 import flat from 'array.prototype.flat';
+import has from 'has';
 
 import {
   containsChildrenSubArray,
@@ -777,6 +778,40 @@ class ReactWrapper {
    */
   prop(propName) {
     return this.props()[propName];
+  }
+
+  /**
+   * Returns a wrapper of the node rendered by the provided render prop.
+   *
+   * @param {String} propName
+   * @returns {ReactWrapper}
+   */
+  renderProp(propName, ...args) {
+    const adapter = getAdapter(this[OPTIONS]);
+    if (typeof adapter.wrap !== 'function') {
+      throw new RangeError('your adapter does not support `wrap`. Try upgrading it!');
+    }
+
+    return this.single('renderProp', (n) => {
+      if (n.nodeType === 'host') {
+        throw new TypeError('ReactWrapper::renderProp() can only be called on custom components');
+      }
+      if (typeof propName !== 'string') {
+        throw new TypeError('`propName` must be a string');
+      }
+      const props = this.props();
+      if (!has(props, propName)) {
+        throw new Error(`no prop called “${propName}“ found`);
+      }
+      const propValue = props[propName];
+      if (typeof propValue !== 'function') {
+        throw new TypeError(`expected prop “${propName}“ to contain a function, but it holds “${typeof prop}“`);
+      }
+
+      const element = propValue(...args);
+      const wrapped = adapter.wrap(element);
+      return this.wrap(wrapped, null, this[OPTIONS]);
+    });
   }
 
   /**


### PR DESCRIPTION
Adds a `renderProp` method to `ShallowWrapper`s to ease testing render props.

This PR basically extracts `renderProp`  out of [@commercetools/enzyme-extensions](https://github.com/commercetools/enzyme-extensions). We would deprecate and drop it there if `renderProp` makes it into `enzyme` itself.

I wrote [this article](https://medium.com/@dferber90/test-a-render-prop-6a44e02f4c39) a while ago detailing how to use `renderProp` and why.

I'm curious for feedback of whether you'd want to accept it or not after some interest was shown in https://github.com/commercetools/enzyme-extensions/issues/8.

---

Thanks to @tdeekens who helped set up and bounce ideas back&forth with for `renderProp` in `enzyme-extensions`!

Closes #1444. Related to #1856.