### PR TITLE
Documentation update for testing React Native using jsdom

### DIFF
--- a/docs/guides/jsdom.md
+++ b/docs/guides/jsdom.md
@@ -22,13 +22,10 @@ const jsdom = new JSDOM('<!doctype html><html><body></body></html>');
 const { window } = jsdom;
 
 function copyProps(src, target) {
-  const props = Object.getOwnPropertyNames(src)
-    .filter(prop => typeof target[prop] === 'undefined')
-    .reduce((result, prop) => ({
-      ...result,
-      [prop]: Object.getOwnPropertyDescriptor(src, prop),
-    }), {});
-  Object.defineProperties(target, props);
+  Object.defineProperties(target, {
+    ...Object.getOwnPropertyDescriptors(src),
+    ...Object.getOwnPropertyDescriptors(target),
+  });
 }
 
 global.window = window;

--- a/packages/enzyme-example-mocha/test/.setup.js
+++ b/packages/enzyme-example-mocha/test/.setup.js
@@ -4,10 +4,10 @@ const jsdom = new JSDOM('<!doctype html><html><body></body></html>');
 const { window } = jsdom;
 
 function copyProps(src, target) {
-  const props = Object.getOwnPropertyNames(src)
-    .filter(prop => typeof target[prop] === 'undefined')
-    .map(prop => Object.getOwnPropertyDescriptor(src, prop));
-  Object.defineProperties(target, props);
+  Object.defineProperties(target, {
+    ...Object.getOwnPropertyDescriptors(src),
+    ...Object.getOwnPropertyDescriptors(target),
+  });
 }
 
 global.expect = expect;


### PR DESCRIPTION
As discussed in #1375, I was also unable to get React Native testing working with Jest/Enzyme with the current documentation instructions.

I see that a React Native adapter is still being discussed in #1436, but I found that some users have had success with jsdom. I was able to get both react-native-mock-renderer and jsdom working, but react-native-mock-renderer didn't result in very clear snapshots when using Jest snapshot testing.

I have therefore provided some instructions here for how I was able to get React Native testing working with jsdom, and I added some examples from the [React Native boilerplate project](https://github.com/ProminentEdge/mobile-boilerplate) where it is currently working. I decided to leave in a few helpful tips of other issues I encountered along the way as well.