### PR TITLE
Change renderProp API

### DIFF
--- a/docs/api/ReactWrapper/renderProp.md
+++ b/docs/api/ReactWrapper/renderProp.md
@@ -1,7 +1,6 @@
-# `.renderProp(propName, ...args) => ReactWrapper`
+# `.renderProp(propName)(...args) => ReactWrapper`
 
-Calls the current wrapper's property with name `propName` and the `args` provided.
-Returns the result in a new wrapper.
+Returns a function that, when called with arguments `args`, will return a new wrapper based on the render prop in the original wrapper's prop `propName`.
 
 NOTE: can only be called on wrapper of a single non-DOM component element node.
 
@@ -69,7 +68,7 @@ const App = () => (
 ```jsx
 const wrapper = mount(<App />)
   .find(Mouse)
-  .renderProp('render');
+  .renderProp('render')();
 
 expect(wrapper.equals(<h1>The mouse position is 0, 0</h1>)).to.equal(true);
 ```
@@ -79,7 +78,7 @@ expect(wrapper.equals(<h1>The mouse position is 0, 0</h1>)).to.equal(true);
 ```jsx
 const wrapper = mount(<App />)
   .find(Mouse)
-  .renderProp('render', 10, 20);
+  .renderProp('render')(10, 20);
 
 expect(wrapper.equals(<h1>The mouse position is 10, 20</h1>)).to.equal(true);
 ```

--- a/docs/api/ShallowWrapper/renderProp.md
+++ b/docs/api/ShallowWrapper/renderProp.md
@@ -1,7 +1,6 @@
-# `.renderProp(propName, ...args) => ShallowWrapper`
+# `.renderProp(propName)(...args) => ShallowWrapper`
 
-Calls the current wrapper's property with name `propName` and the `args` provided.
-Returns the result in a new wrapper.
+Returns a function that, when called with arguments `args`, will return a new wrapper based on the render prop in the original wrapper's prop `propName`.
 
 NOTE: can only be called on wrapper of a single non-DOM component element node.
 
@@ -69,7 +68,7 @@ const App = () => (
 ```jsx
 const wrapper = shallow(<App />)
   .find(Mouse)
-  .renderProp('render');
+  .renderProp('render')();
 
 expect(wrapper.equals(<h1>The mouse position is 0, 0</h1>)).to.equal(true);
 ```
@@ -79,7 +78,7 @@ expect(wrapper.equals(<h1>The mouse position is 0, 0</h1>)).to.equal(true);
 ```jsx
 const wrapper = shallow(<App />)
   .find(Mouse)
-  .renderProp('render', 10, 20);
+  .renderProp('render')(10, 20);
 
 expect(wrapper.equals(<h1>The mouse position is 10, 20</h1>)).to.equal(true);
 ```

--- a/docs/api/mount.md
+++ b/docs/api/mount.md
@@ -120,7 +120,7 @@ Get a wrapper with the first ancestor of the current node to match the provided 
 #### [`.render() => CheerioWrapper`](ReactWrapper/render.md)
 Returns a CheerioWrapper of the current node's subtree.
 
-#### [`.renderProp(key) => ReactWrapper`](ReactWrapper/renderProp.md)
+#### [`.renderProp(key)() => ReactWrapper`](ReactWrapper/renderProp.md)
 Returns a wrapper of the node rendered by the provided render prop.
 
 #### [`.text() => String`](ReactWrapper/text.md)

--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -130,7 +130,7 @@ Shallow renders the current node and returns a shallow wrapper around it.
 #### [`.render() => CheerioWrapper`](ShallowWrapper/render.md)
 Returns a CheerioWrapper of the current node's subtree.
 
-#### [`.renderProp(key) => ShallowWrapper`](ShallowWrapper/renderProp.md)
+#### [`.renderProp(key)() => ShallowWrapper`](ShallowWrapper/renderProp.md)
 Returns a wrapper of the node rendered by the provided render prop.
 
 #### [`.unmount() => ShallowWrapper`](ShallowWrapper/unmount.md)

--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -4974,17 +4974,17 @@ describeWithDOM('mount', () => {
       }
 
       const wrapperA = mount(<div><Bar render={() => <div><Foo /></div>} /></div>);
-      const renderPropWrapperA = wrapperA.find(Bar).renderProp('render');
+      const renderPropWrapperA = wrapperA.find(Bar).renderProp('render')();
       expect(renderPropWrapperA.find(Foo)).to.have.lengthOf(1);
 
       const wrapperB = mount(<div><Bar render={() => <Foo />} /></div>);
-      const renderPropWrapperB = wrapperB.find(Bar).renderProp('render');
+      const renderPropWrapperB = wrapperB.find(Bar).renderProp('render')();
       expect(renderPropWrapperB.find(Foo)).to.have.lengthOf(1);
 
       const stub = sinon.stub().returns(<div />);
       const wrapperC = mount(<div><Bar render={stub} /></div>);
       stub.resetHistory();
-      wrapperC.find(Bar).renderProp('render', 'one', 'two');
+      wrapperC.find(Bar).renderProp('render')('one', 'two');
       expect(stub.args).to.deep.equal([['one', 'two']]);
     });
 

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -4758,17 +4758,17 @@ describe('shallow', () => {
       }
 
       const wrapperA = shallow(<div><Bar render={() => <div><Foo /></div>} /></div>);
-      const renderPropWrapperA = wrapperA.find(Bar).renderProp('render');
+      const renderPropWrapperA = wrapperA.find(Bar).renderProp('render')();
       expect(renderPropWrapperA.find(Foo)).to.have.lengthOf(1);
 
       const wrapperB = shallow(<div><Bar render={() => <Foo />} /></div>);
-      const renderPropWrapperB = wrapperB.find(Bar).renderProp('render');
+      const renderPropWrapperB = wrapperB.find(Bar).renderProp('render')();
       expect(renderPropWrapperB.find(Foo)).to.have.lengthOf(1);
 
       const stub = sinon.stub().returns(<div />);
       const wrapperC = shallow(<div><Bar render={stub} /></div>);
       stub.resetHistory();
-      wrapperC.find(Bar).renderProp('render', 'one', 'two');
+      wrapperC.find(Bar).renderProp('render')('one', 'two');
       expect(stub.args).to.deep.equal([['one', 'two']]);
     });
 

--- a/packages/enzyme/src/ReactWrapper.js
+++ b/packages/enzyme/src/ReactWrapper.js
@@ -784,9 +784,9 @@ class ReactWrapper {
    * Returns a wrapper of the node rendered by the provided render prop.
    *
    * @param {String} propName
-   * @returns {ReactWrapper}
+   * @returns {Function}
    */
-  renderProp(propName, ...args) {
+  renderProp(propName) {
     const adapter = getAdapter(this[OPTIONS]);
     if (typeof adapter.wrap !== 'function') {
       throw new RangeError('your adapter does not support `wrap`. Try upgrading it!');
@@ -808,9 +808,11 @@ class ReactWrapper {
         throw new TypeError(`expected prop “${propName}“ to contain a function, but it holds “${typeof prop}“`);
       }
 
-      const element = propValue(...args);
-      const wrapped = adapter.wrap(element);
-      return this.wrap(wrapped, null, this[OPTIONS]);
+      return (...args) => {
+        const element = propValue(...args);
+        const wrapped = adapter.wrap(element);
+        return this.wrap(wrapped, null, this[OPTIONS]);
+      };
     });
   }
 

--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -1038,9 +1038,9 @@ class ShallowWrapper {
    * Returns a wrapper of the node rendered by the provided render prop.
    *
    * @param {String} propName
-   * @returns {ShallowWrapper}
+   * @returns {Function}
    */
-  renderProp(propName, ...args) {
+  renderProp(propName) {
     const adapter = getAdapter(this[OPTIONS]);
     if (typeof adapter.wrap !== 'function') {
       throw new RangeError('your adapter does not support `wrap`. Try upgrading it!');
@@ -1062,9 +1062,11 @@ class ShallowWrapper {
         throw new TypeError(`expected prop “${propName}“ to contain a function, but it holds “${typeof prop}“`);
       }
 
-      const element = propValue(...args);
-      const wrapped = adapter.wrap(element);
-      return this.wrap(wrapped, null, this[OPTIONS]);
+      return (...args) => {
+        const element = propValue(...args);
+        const wrapped = adapter.wrap(element);
+        return this.wrap(wrapped, null, this[OPTIONS]);
+      };
     });
   }
 


### PR DESCRIPTION
This PR changes the `renderProp` API as described in https://github.com/airbnb/enzyme/pull/1863#issuecomment-436175166.

This is merely a suggestion at the moment and I'm happy to close it again if we settle on another approach or even keep the current one.

The motivation for "returning a function" is that the arguments to enzyme's `renderProp` won't get mixed with the arguments to the render prop function itself. This allows us to eventually add more options (like context) which we can apply to the newly created wrapper.

An example usage (formatted with Prettier) would look like this:

```jsx
const wrapper = shallow(<App />)
  .find(Mouse)
  .renderProp("render")(10, 20)
  .find(Mouse)
  .renderProp("foo")(3, {
    long: {
      yeah: true
    }
  })
  .find(Bar)
  .renderProp("x")();
```


### Sidenote

At this point, one might wonder what the advantage of `wrapper.find(Foo).renderProp('render')()` over `wrapper.find(Foo).prop('render')()` is, and that's a fair question.

When using `renderProp`, the render props' return value gets nested into a new wrapper which enables this convenient chaining shown above - whereas `wrapper.find(Foo).prop('render')()` simply returns the React element without an enzyme wrapper. More about this is hinted at in [this article](https://medium.com/@dferber90/test-a-render-prop-6a44e02f4c39).