### PR TITLE
Add tape example project link

### DIFF
--- a/docs/guides/tape-ava.md
+++ b/docs/guides/tape-ava.md
@@ -58,4 +58,5 @@ test('mount', (t) => {
 
 ## Example Projects
 
+- [enzyme-example-tape](https://github.com/TaeKimJR/enzyme-example-tape)
 - [enzyme-example-ava](https://github.com/mikenikles/enzyme-example-ava)


### PR DESCRIPTION
This PR adds a link to a runnable enzyme + tape project.
Fixes #1886 