### PR TITLE
Zero-node specs and warning message

### DIFF
--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -7339,6 +7339,11 @@ describeWithDOM('mount', () => {
         );
       }
     }
+    class TestZero extends React.Component {
+      render() {
+        return <div />;
+      }
+    }
 
     it('returns the outermost DOMComponent of the root wrapper', () => {
       const wrapper = mount(<Test />);
@@ -7354,7 +7359,23 @@ describeWithDOM('mount', () => {
       const wrapper = mount(<Test />).find('span');
       expect(() => wrapper.getDOMNode()).to.throw(
         Error,
-        'Method “getDOMNode” is only meant to be run on a single node. 2 found instead.',
+        'Method “getDOMNode” is meant to be run on 1 node. 2 found instead.',
+      );
+    });
+
+    it('throws when wrapping zero elements', () => {
+      const wrapper = mount(<TestZero />).find('span');
+      expect(() => wrapper.getDOMNode()).to.throw(
+        Error,
+        'Method “getDOMNode” is meant to be run on 1 node. 0 found instead.',
+      );
+    });
+
+    it('throws when wrapping zero elements', () => {
+      const wrapper = mount(<TestZero />).find('span');
+      expect(() => wrapper.getDOMNode()).to.throw(
+        Error,
+        'Method “getDOMNode” is meant to be run on 1 node. 0 found instead.',
       );
     });
 
@@ -7382,7 +7403,7 @@ describeWithDOM('mount', () => {
         const wrapper = mount(<SFC />).find('span');
         expect(() => wrapper.getDOMNode()).to.throw(
           Error,
-          'Method “getDOMNode” is only meant to be run on a single node. 2 found instead.',
+          'Method “getDOMNode” is meant to be run on 1 node. 2 found instead.',
         );
       });
     });
@@ -7400,7 +7421,7 @@ describeWithDOM('mount', () => {
       expect(wrapper).to.have.lengthOf(2);
       expect(() => wrapper.single('name!')).to.throw(
         Error,
-        'Method “name!” is only meant to be run on a single node. 2 found instead.',
+        'Method “name!” is meant to be run on 1 node. 2 found instead.',
       );
     });
 

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -6968,6 +6968,11 @@ describe('shallow', () => {
         );
       }
     }
+    class RendersZero extends React.Component {
+      render() {
+        return <div />;
+      }
+    }
     class WrapsRendersDOM extends React.Component {
       render() {
         return <RendersDOM />;
@@ -7010,7 +7015,23 @@ describe('shallow', () => {
       const wrapper = shallow(<RendersMultiple />).find('div').children();
       expect(() => { wrapper.dive(); }).to.throw(
         Error,
-        'Method “dive” is only meant to be run on a single node. 2 found instead.',
+        'Method “dive” is meant to be run on 1 node. 2 found instead.',
+      );
+    });
+
+    it('throws on zero children found', () => {
+      const wrapper = shallow(<RendersZero />).find('div').children();
+      expect(() => { wrapper.dive(); }).to.throw(
+        Error,
+        'Method “dive” is meant to be run on 1 node. 0 found instead.',
+      );
+    });
+
+    it('throws on zero children found', () => {
+      const wrapper = shallow(<RendersZero />).find('div').children();
+      expect(() => { wrapper.dive(); }).to.throw(
+        Error,
+        'Method “dive” is meant to be run on 1 node. 0 found instead.',
       );
     });
 
@@ -7306,7 +7327,25 @@ describe('shallow', () => {
       expect(wrapper).to.have.lengthOf(2);
       expect(() => wrapper.single('name!')).to.throw(
         Error,
-        'Method “name!” is only meant to be run on a single node. 2 found instead.',
+        'Method “name!” is meant to be run on 1 node. 2 found instead.',
+      );
+    });
+
+    it('throws if run on zero nodes', () => {
+      const wrapper = shallow(<div />).children();
+      expect(wrapper).to.have.lengthOf(0);
+      expect(() => wrapper.single('name!')).to.throw(
+        Error,
+        'Method “name!” is meant to be run on 1 node. 0 found instead.',
+      );
+    });
+
+    it('throws if run on zero nodes', () => {
+      const wrapper = shallow(<div />).children();
+      expect(wrapper).to.have.lengthOf(0);
+      expect(() => wrapper.single('name!')).to.throw(
+        Error,
+        'Method “name!” is meant to be run on 1 node. 0 found instead.',
       );
     });
 

--- a/packages/enzyme/src/ReactWrapper.js
+++ b/packages/enzyme/src/ReactWrapper.js
@@ -1095,7 +1095,7 @@ class ReactWrapper {
     const fnName = typeof name === 'string' ? name : 'unknown';
     const callback = typeof fn === 'function' ? fn : name;
     if (this.length !== 1) {
-      throw new Error(`Method “${fnName}” is only meant to be run on a single node. ${this.length} found instead.`);
+      throw new Error(`Method “${fnName}” is meant to be run on 1 node. ${this.length} found instead.`);
     }
     return callback.call(this, this.getNodeInternal());
   }

--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -1351,7 +1351,7 @@ class ShallowWrapper {
     const fnName = typeof name === 'string' ? name : 'unknown';
     const callback = typeof fn === 'function' ? fn : name;
     if (this.length !== 1) {
-      throw new Error(`Method “${fnName}” is only meant to be run on a single node. ${this.length} found instead.`);
+      throw new Error(`Method “${fnName}” is meant to be run on 1 node. ${this.length} found instead.`);
     }
     return callback.call(this, this.getNodeInternal());
   }


### PR DESCRIPTION
- Adds specs for wrapping zero nodes with `getDOMNode`, `dive`, and `name!`.
- Modifies the warning language to better accommodate zero nodes:
```
Method x is only meant to be run on a single node. 2 found instead.
Method x is only meant to be run on a single node. 0 found instead.
```
becomes
```
Method x is meant to be run on 1 node. 2 found instead.
Method x is meant to be run on 1 node. 0 found instead.
```