### PR TITLE
[Docs] Add a NOTE line in docs of `.dive()` about it would throw error

### DIFF
--- a/docs/api/ShallowWrapper/dive.md
+++ b/docs/api/ShallowWrapper/dive.md
@@ -2,7 +2,7 @@
 
 Shallow render the one non-DOM child of the current wrapper, and return a wrapper around the result.
 
-NOTE: can only be called on wrapper of a single non-DOM component element node.
+NOTE: can only be called on a wrapper of a single non-DOM component element node, otherwise it will throw an error. If you have to shallow-wrap a wrapper with multiple child nodes, use [.shallow()](ShallowWrapper/shallow.md).
 
 
 #### Arguments


### PR DESCRIPTION
Add a NOTE line in docs of `.dive()` about it would throw error under some cases.

See #1798