### PR TITLE
Updated broken link for “.hostNodes()” in migration guide

### DIFF
--- a/docs/guides/migration-from-2-to-3.md
+++ b/docs/guides/migration-from-2-to-3.md
@@ -178,7 +178,7 @@ console.log(wrapper.find('.bar').length); // 2
 
 Since `<Foo/>` has the className `bar` it is returned as the _hostNode_. As expected the `<div>` with the className `bar` is also returned
 
-To avoid this you can explicity query for the DOM node: `wrapper.find('div.bar')`. Alternatively if you would like to only find host nodes use [hostNodes()](http://airbnb.io/enzyme/docs/api/ShallowWrapper/hostNodes.md#hostnodes--shallowwrapper)
+To avoid this you can explicity query for the DOM node: `wrapper.find('div.bar')`. Alternatively if you would like to only find host nodes use [hostNodes()](https://airbnb.io/enzyme/docs/api/ShallowWrapper/hostNodes.html)
 
 ## For `mount`, updates are sometimes required when they weren't before
 


### PR DESCRIPTION
Hi there,

In my team, we are currently going through your migration guide to update from Enzyme 2 to 3 (very handy btw 👍) and we noticed one of the links is broken for `.hostNodes()`.

We have opened a PR fix for this to distract us away from the pain we are going through with other packages for not upgrading sooner 🙈 

Cheers.
Jack