### PR TITLE
[Docs] ShallowWrapper#get: fixed wrong `props()` usage

### DIFF
--- a/docs/api/ShallowWrapper/get.md
+++ b/docs/api/ShallowWrapper/get.md
@@ -19,7 +19,7 @@ Returns the node at a given index of the current wrapper.
 
 ```jsx
 const wrapper = shallow(<MyComponent />);
-expect(wrapper.find(Foo).get(0).props().foo).to.equal('bar');
+expect(wrapper.find(Foo).get(0).props.foo).to.equal('bar');
 ```
 
 


### PR DESCRIPTION
Thank you all guys for all this awesome work. ✌️

This Pull Request fixes a small issue I've just noticed. Since `ShallowWrapper#get` returns a `ReactElement`, we should be using `props` rather than `props()` on the demo. 