### PR TITLE
Docs ab

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Enzyme
 [![npm Version](https://img.shields.io/npm/v/enzyme.svg)](https://www.npmjs.com/package/enzyme) [![License](https://img.shields.io/npm/l/enzyme.svg)](https://www.npmjs.com/package/enzyme) [![Build Status](https://travis-ci.org/airbnb/enzyme.svg)](https://travis-ci.org/airbnb/enzyme) [![Coverage Status](https://coveralls.io/repos/airbnb/enzyme/badge.svg?branch=master&service=github)](https://coveralls.io/github/airbnb/enzyme?branch=master)
 
 
-Enzyme is a JavaScript Testing utility for React that makes it easier to assert, manipulate,
-and traverse your React Components' output.
+Enzyme is a JavaScript Testing utility for React that makes it easier to test your React Components' output.
+You can also manipulate, traverse, and in some ways simulate runtime given the output.
 
 Enzyme's API is meant to be intuitive and flexible by mimicking jQuery's API for DOM manipulation
 and traversal.

--- a/docs/api/ReactWrapper/at.md
+++ b/docs/api/ReactWrapper/at.md
@@ -26,4 +26,6 @@ expect(wrapper.find(Foo).at(0).props().foo).to.equal('bar');
 
 #### Related Methods
 
-- [`.get(index) => ReactElement`](get.md)
+- [`.get(index) => ReactElement`](get.md) - same, but returns the React node itself, with no wrapper.
+- [`.first() => ReactWrapper`](first.md) - same as at(0)
+- [`.last() => ReactWrapper`](last.md)

--- a/docs/api/ReactWrapper/closest.md
+++ b/docs/api/ReactWrapper/closest.md
@@ -1,9 +1,7 @@
 # `.closest(selector) => ReactWrapper`
 
 Returns a wrapper of the first element that matches the selector by traversing up through the
-current node's ancestors in the tree, starting with itself.
-
-Note: can only be called on a wrapper of a single node.
+wrapped node's ancestors in the tree, starting with itself. It must be a single-node wrapper.
 
 
 #### Returns

--- a/docs/api/ReactWrapper/containsAllMatchingElements.md
+++ b/docs/api/ReactWrapper/containsAllMatchingElements.md
@@ -1,21 +1,18 @@
-# `.containsAllMatchingElements(nodes) => Boolean`
+# `.containsAllMatchingElements(patternNodes) => Boolean`
 
-Returns whether or not one of the given react elements are all matching one element in the render tree.
-It will determine if an element in the wrapper __looks like__ one of the expected element by checking if all props of the expected element are present on the wrappers element and equals to each other.
+Returns whether or not all of the given react elements in `patternNodes` match an element in the wrapper's render tree. Every single element of `patternNodes` must be matched one or more times. Matching follows the rules for `containsMatchingElement`.
 
 
 #### Arguments
 
-1. `nodes` (`Array<ReactElement>`): The array of nodes whose presence you are detecting in the current instance's
+1. `patternNodes` (`Array<ReactElement>`): The array of nodes whose presence you are detecting in the current instance's
 render tree.
-
 
 
 #### Returns
 
 `Boolean`: whether or not the current wrapper has nodes anywhere in its render tree that looks
 like the nodes passed in.
-
 
 
 #### Example
@@ -44,3 +41,10 @@ expect(wrapper.containsAllMatchingElements([
 when you are calling it you are calling it with an array of ReactElement or a JSX expression.
 - Keep in mind that this method determines matching based on the matching of the node's children as
 well.
+
+
+#### Related Methods
+
+- [`.matchesElement() => ReactWrapper`](matchesElement.md) - rules for matching each node
+- [`.containsMatchingElement() => ReactWrapper`](containsMatchingElement.md) - rules for matching whole wrapper
+- [`.containsAnyMatchingElements() => ReactWrapper`](containsAnyMatchingElements.md) - must match at least one in patternNodes

--- a/docs/api/ReactWrapper/containsAnyMatchingElements.md
+++ b/docs/api/ReactWrapper/containsAnyMatchingElements.md
@@ -1,21 +1,18 @@
-# `.containsAnyMatchingElements(nodes) => Boolean`
+# `.containsAnyMatchingElements(patternNodes) => Boolean`
 
-Returns whether or not one of the given react elements is matching on element in the render tree.
-It will determine if an element in the wrapper __looks like__ one of the expected element by checking if all props of the expected element are present on the wrappers element and equals to each other.
+Returns whether or not at least one of the given react elements in `patternNodes` matches an element in the wrapper's render tree. One or more elements of `patternNodes` must be matched one or more times. Matching follows the rules for `containsMatchingElement`.
 
 
 #### Arguments
 
-1. `nodes` (`Array<ReactElement>`): The array of nodes whose presence you are detecting in the current instance's
+1. `patternNodes` (`Array<ReactElement>`): The array of nodes whose presence you are detecting in the current instance's
 render tree.
-
 
 
 #### Returns
 
 `Boolean`: whether or not the current wrapper has a node anywhere in its render tree that looks
 like one of the array passed in.
-
 
 
 #### Example
@@ -44,3 +41,10 @@ expect(wrapper.containsAnyMatchingElements([
 when you are calling it you are calling it with an array ReactElement or a JSX expression.
 - Keep in mind that this method determines equality based on the equality of the node's children as
 well.
+
+
+#### Related Methods
+
+- [`.matchesElement() => ReactWrapper`](matchesElement.md) - rules for matching each node
+- [`.containsMatchingElement() => ReactWrapper`](containsMatchingElement.md) - rules for matching whole wrapper
+- [`.containsAllMatchingElements() => ReactWrapper`](containsAllMatchingElements.md) - must match all nodes in patternNodes

--- a/docs/api/ReactWrapper/containsMatchingElement.md
+++ b/docs/api/ReactWrapper/containsMatchingElement.md
@@ -1,14 +1,16 @@
-# `.containsMatchingElement(node) => Boolean`
+# `.containsMatchingElement(patternNode) => Boolean`
 
-Returns whether or not a given react element matches one element in the render tree.
-It will determine if an element in the wrapper matches the expected element by checking if all props of the expected element are present on the wrapper's element and equals to each other.
+Returns whether or not a `patternNode` react element matches any element in the render tree.
+* the matches can happen anywhere in the wrapper's contents
+* the wrapper can contain more than one node; all are searched
+
+Otherwise, the match follows the same rules as `matchesElement`.
 
 
 #### Arguments
 
-1. `node` (`ReactElement`): The node whose presence you are detecting in the current instance's
+1. `patternNode` (`ReactElement`): The node whose presence you are detecting in the current instance's
 render tree.
-
 
 
 #### Returns
@@ -42,3 +44,9 @@ expect(wrapper.containsMatchingElement(<div data-foo="foo" data-bar="bar" />)).t
 when you are calling it you are calling it with a ReactElement or a JSX expression.
 - Keep in mind that this method determines equality based on the equality of the node's children as
 well.
+
+
+#### Related Methods
+
+- [`.containsAllMatchingElements() => ReactWrapper`](containsAllMatchingElements.md) - must match all nodes in patternNodes
+- [`.containsAnyMatchingElements() => ReactWrapper`](containsAnyMatchingElements.md) - must match at least one in patternNodes

--- a/docs/api/ReactWrapper/detach.md
+++ b/docs/api/ReactWrapper/detach.md
@@ -9,7 +9,7 @@ The method is intentionally not "fluent" (in that it doesn't return `this`) beca
 not be doing anything with this wrapper after this method is called.
 
 Using `attachTo`/`hydrateIn` is not generally recommended unless it is absolutely necessary to test
-something.  It is your responsibility to clean up after yourself at the end of the test if you do
+something. It is your responsibility to clean up after yourself at the end of the test if you do
 decide to use it, though.
 
 

--- a/docs/api/ReactWrapper/exists.md
+++ b/docs/api/ReactWrapper/exists.md
@@ -1,6 +1,6 @@
 # `.exists([selector]) => Boolean`
 
-Returns whether or not the current node exists. Or, if a selector is passed in, whether that selector has any matching results.
+Returns whether or not any nodes exist in the wrapper. Or, if a selector is passed in, whether that selector has any matches in the wrapper.
 
 
 
@@ -12,7 +12,7 @@ Returns whether or not the current node exists. Or, if a selector is passed in, 
 
 #### Returns
 
-`Boolean`: whether or not the current node exists, or the selector had any results.
+`Boolean`: whether or not any nodes are on the list, or the selector had any matches.
 
 
 

--- a/docs/api/ReactWrapper/first.md
+++ b/docs/api/ReactWrapper/first.md
@@ -1,13 +1,11 @@
 # `.first() => ReactWrapper`
 
-Reduce the set of matched nodes to the first in the set.
-
+Reduce the set of matched nodes to the first in the set, just like `.at(0)`.
 
 
 #### Returns
 
 `ReactWrapper`: A new wrapper that wraps the first node in the set.
-
 
 
 #### Examples
@@ -16,3 +14,9 @@ Reduce the set of matched nodes to the first in the set.
 const wrapper = mount(<MyComponent />);
 expect(wrapper.find(Foo).first().props().foo).to.equal('bar');
 ```
+
+
+#### Related Methods
+
+- [`.at(index) => ReactWrapper`](at.md) - retrieve any wrapper node
+- [`.last() => ReactWrapper`](last.md)

--- a/docs/api/ReactWrapper/get.md
+++ b/docs/api/ReactWrapper/get.md
@@ -8,11 +8,9 @@ Returns the node at a given index of the current wrapper.
 1. `index` (`Number`): A zero-based integer indicating which node to retrieve.
 
 
-
 #### Returns
 
 `ReactElement`: The retrieved node.
-
 
 
 #### Examples
@@ -23,7 +21,6 @@ expect(wrapper.find(Foo).get(0).props.foo).to.equal('bar');
 ```
 
 
-
 #### Related Methods
 
-- [`.at(index) => ReactWrapper`](at.md)
+- [`.at(index) => ReactWrapper`](at.md) - same, but returns the React node in a single-node wrapper.

--- a/docs/api/ReactWrapper/hasClass.md
+++ b/docs/api/ReactWrapper/hasClass.md
@@ -1,6 +1,6 @@
 # `.hasClass(className) => Boolean`
 
-Returns whether or not the current node has a `className` prop including the passed in class name.
+Returns whether or not the wrapped node has a `className` prop including the passed in class name. It must be a single-node wrapper.
 
 
 #### Arguments
@@ -8,11 +8,9 @@ Returns whether or not the current node has a `className` prop including the pas
 1. `className` (`String`): A single class name.
 
 
-
 #### Returns
 
-`Boolean`: whether or not the current node has the class.
-
+`Boolean`: whether or not the wrapped node has the class.
 
 
 #### Example

--- a/docs/api/ReactWrapper/hostNodes.md
+++ b/docs/api/ReactWrapper/hostNodes.md
@@ -1,7 +1,7 @@
 # `.hostNodes() => ReactWrapper`
 
 Returns a new wrapper with only host nodes.
-
+When using `react-dom`, host nodes are HTML elements rather than custom React components, e.g. `<div>` versus `<MyComponent>`.
 
 
 #### Returns
@@ -9,10 +9,17 @@ Returns a new wrapper with only host nodes.
 `ReactWrapper`: A new wrapper that wraps the filtered nodes.
 
 
-
 #### Examples
 
+The following code takes a wrapper with two nodes, one a `<MyComponent>` React component, and the other a `<span>`, and filters out the React component.
+
 ```jsx
-const wrapper = mount(<div><MyComponent className="foo" /><div className="foo" /></div>);
-expect(wrapper.find('.foo').hostNodes()).to.have.lengthOf(1);
+const wrapper = mount((
+  <div>
+    <MyComponent className="foo" />
+    <span className="foo" />
+  </div>
+));
+const twoNodes = wrapper.find('.foo');
+expect(twoNodes.hostNodes()).to.have.lengthOf(1);
 ```

--- a/docs/api/ReactWrapper/instance.md
+++ b/docs/api/ReactWrapper/instance.md
@@ -1,7 +1,8 @@
 # `.instance() => ReactComponent`
 
-Returns the wrapper's underlying instance.
+Returns the single-node wrapper's node's underlying class instance; `this` in its methods. It must be a single-node wrapper.
 
+NOTE: With React `16` and above, `instance()` returns `null` for stateless functional components.
 
 
 #### Returns
@@ -9,11 +10,51 @@ Returns the wrapper's underlying instance.
 `ReactComponent|DOMComponent`: The retrieved instance.
 
 
-
 #### Example
 
+<!-- eslint react/prop-types: 0, react/prefer-stateless-function: 0 -->
 ```jsx
-const wrapper = mount(<MyComponent />);
-const inst = wrapper.instance();
-expect(inst).to.be.instanceOf(MyComponent);
+function Stateless() {
+  return <div>Stateless</div>;
+}
+
+class Stateful extends React.Component {
+  render() {
+    return <div>Stateful</div>;
+  }
+}
+```
+
+#### React 16.x
+```jsx
+test('shallow wrapper instance should be null', () => {
+  const wrapper = mount(<Stateless />);
+  const instance = wrapper.instance();
+
+  expect(instance).to.equal(null);
+});
+
+test('shallow wrapper instance should not be null', () => {
+  const wrapper = mount(<Stateful />);
+  const instance = wrapper.instance();
+
+  expect(instance).to.be.instanceOf(Stateful);
+});
+```
+
+#### React 15.x
+```jsx
+test('shallow wrapper instance should not be null', () => {
+  const wrapper = mount(<Stateless />);
+  const instance = wrapper.instance();
+
+  expect(instance).to.be.instanceOf(Stateless);
+});
+
+test('shallow wrapper instance should not be null', () => {
+  const wrapper = mount(<Stateful />);
+  const instance = wrapper.instance();
+
+  expect(instance).to.be.instanceOf(Stateful);
+});
 ```

--- a/docs/api/ReactWrapper/is.md
+++ b/docs/api/ReactWrapper/is.md
@@ -1,6 +1,6 @@
 # `.is(selector) => Boolean`
 
-Returns whether or not the current node matches a provided selector.
+Returns whether or not the single wrapped node matches the provided selector. It must be a single-node wrapper.
 
 
 #### Arguments
@@ -8,11 +8,9 @@ Returns whether or not the current node matches a provided selector.
 1. `selector` ([`EnzymeSelector`](../selector.md)): The selector to match.
 
 
-
 #### Returns
 
-`Boolean`: whether or not the current node matches a provided selector.
-
+`Boolean`: whether or not the wrapped node matches the provided selector.
 
 
 #### Example
@@ -22,4 +20,3 @@ Returns whether or not the current node matches a provided selector.
 const wrapper = mount(<div className="some-class other-class" />);
 expect(wrapper.is('.some-class')).to.equal(true);
 ```
-

--- a/docs/api/ReactWrapper/isEmpty.md
+++ b/docs/api/ReactWrapper/isEmpty.md
@@ -1,13 +1,12 @@
 # `.isEmpty() => Boolean`
 **Deprecated**: Use [.exists()](exists.md) instead.
 
-Returns whether or not the current node is empty.
+Returns whether or not the wrapper is empty.
 
 
 #### Returns
 
-`Boolean`: whether or not the current node is empty.
-
+`Boolean`: whether or not the wrapper is empty.
 
 
 #### Example

--- a/docs/api/ReactWrapper/isEmptyRender.md
+++ b/docs/api/ReactWrapper/isEmptyRender.md
@@ -1,6 +1,6 @@
 # `.isEmptyRender() => Boolean`
 
-Returns whether or not the current component returns one of the allowed falsy values: `false` or `null`.
+Returns whether or not the wrapper would ultimately render only the allowed falsy values: `false` or `null`.
 
 #### Returns
 

--- a/docs/api/ReactWrapper/key.md
+++ b/docs/api/ReactWrapper/key.md
@@ -1,8 +1,6 @@
 # `.key() => String`
 
-Returns the key value for the node of the current wrapper.
-
-NOTE: can only be called on a wrapper of a single node.
+Returns the key value for the node of the current wrapper. It must be a single-node wrapper.
 
 #### Example
 

--- a/docs/api/ReactWrapper/last.md
+++ b/docs/api/ReactWrapper/last.md
@@ -1,13 +1,11 @@
 # `.last() => ReactWrapper`
 
-Reduce the set of matched nodes to the last in the set.
-
+Reduce the set of matched nodes to the last in the set, just like `.at(length - 1)`.
 
 
 #### Returns
 
 `ReactWrapper`: A new wrapper that wraps the last node in the set.
-
 
 
 #### Examples
@@ -16,3 +14,9 @@ Reduce the set of matched nodes to the last in the set.
 const wrapper = mount(<MyComponent />);
 expect(wrapper.find(Foo).last().props().foo).to.equal('bar');
 ```
+
+
+#### Related Methods
+
+- [`.at(index) => ReactWrapper`](at.md) - retrieve a wrapper node by index
+- [`.first() => ReactWrapper`](first.md)

--- a/docs/api/ReactWrapper/matchesElement.md
+++ b/docs/api/ReactWrapper/matchesElement.md
@@ -1,20 +1,22 @@
-# `.matchesElement(node) => Boolean`
+# `.matchesElement(patternNode) => Boolean`
 
-Returns whether or not a given react element matches the current render tree.
-It will determine if the the wrapper root node __looks like__ the expected element by checking if all the props supplied in the expected element are present on the wrapper root node and equal to each other. Props present on the wrapper root node but not supplied in the expected element will be ignored.
+Returns whether or not a given react element `patternNode` matches the wrapper's render tree. It must be a single-node wrapper, and only the root node is checked.
+
+The `patternNode` acts like a wildcard. For it to match a node in the wrapper:
+* tag names must match
+* contents must match:  In text nodes, leading and trailing spaces are ignored, but not space in the middle. Child elements must match according to these rules, recursively.
+* `patternNode` props (attributes) must appear in the wrapper's nodes, but not the other way around. Their values must match if they do appear.
+* `patternNode` style CSS properties must appear in the wrapper's node's style, but not the other way around. Their values must match if they do appear.
 
 
 #### Arguments
 
-1. `node` (`ReactElement`): The node whose presence you are detecting in the current instance's
-render tree.
-
+1. `patternNode` (`ReactElement`): The node whose presence you are detecting in the wrapper's single node.
 
 
 #### Returns
 
 `Boolean`: whether or not the current wrapper match the one passed in.
-
 
 
 #### Example
@@ -28,7 +30,7 @@ class MyComponent extends React.Component {
   }
 
   handleClick() {
-    /* ... */
+    // ...
   }
 
   render() {
@@ -39,8 +41,8 @@ class MyComponent extends React.Component {
 }
 
 const wrapper = mount(<MyComponent />);
-expect(wrapper.children().matchesElement(<button>Hello</button>)).to.equal(true);
-expect(wrapper.children().matchesElement(<button className="foo bar">Hello</button>)).to.equal(true);
+expect(wrapper.matchesElement(<button>Hello</button>)).to.equal(true);
+expect(wrapper.matchesElement(<button className="foo bar">Hello</button>)).to.equal(true);
 ```
 
 
@@ -50,3 +52,8 @@ expect(wrapper.children().matchesElement(<button className="foo bar">Hello</butt
 when you are calling it you are calling it with a ReactElement or a JSX expression.
 - Keep in mind that this method determines matching based on the matching of the node's children as
 well.
+
+
+#### Related Methods
+
+- [`.containsMatchingElement() => ReactWrapper`](containsMatchingElement.md) - searches all nodes in the wrapper, and searches their entire depth

--- a/docs/api/ReactWrapper/mount.md
+++ b/docs/api/ReactWrapper/mount.md
@@ -3,10 +3,11 @@
 A method that re-mounts the component, if it is not currently mounted. This can be used to simulate a component going through
 an unmount/mount lifecycle.
 
+No equivalent for ShallowWrappers.
+
 #### Returns
 
 `ReactWrapper`: Returns itself.
-
 
 
 #### Example

--- a/docs/api/ReactWrapper/parent.md
+++ b/docs/api/ReactWrapper/parent.md
@@ -8,7 +8,6 @@ Returns a wrapper with the direct parent of the node in the current wrapper.
 `ReactWrapper`: A new wrapper that wraps the resulting nodes.
 
 
-
 #### Examples
 
 ```jsx

--- a/docs/api/ReactWrapper/parents.md
+++ b/docs/api/ReactWrapper/parents.md
@@ -1,10 +1,7 @@
 # `.parents([selector]) => ReactWrapper`
 
-Returns a wrapper around all of the parents/ancestors of the wrapper. Does not include the node
-in the current wrapper. Optionally, a selector can be provided and it will filter the parents by
-this selector
-
-Note: can only be called on a wrapper of a single node.
+Returns a wrapper around all of the parents/ancestors of the single node in the wrapper. Does not include the node itself.
+Optionally, a selector can be provided and it will filter the parents by this selector. It must be a single-node wrapper.
 
 
 #### Arguments
@@ -15,7 +12,6 @@ Note: can only be called on a wrapper of a single node.
 #### Returns
 
 `ReactWrapper`: A new wrapper that wraps the resulting nodes.
-
 
 
 #### Examples

--- a/docs/api/ReactWrapper/prop.md
+++ b/docs/api/ReactWrapper/prop.md
@@ -1,14 +1,10 @@
 # `.prop(key) => Any`
 
-Returns the prop value for the node of the current wrapper with the provided key.
-
-NOTE: can only be called on a wrapper of a single node.
+Returns the prop value for the root node of the wrapper with the provided key. It must be a single-node wrapper.
 
 #### Arguments
 
-1. `key` (`String`): The prop name such that this will return value will be the `this.props[key]`
-of the component instance.
-
+1. `key` (`String`): The prop name, that is, `this.props[key]` or `props[key]` for the root node of the wrapper.
 
 
 #### Example

--- a/docs/api/ReactWrapper/props.md
+++ b/docs/api/ReactWrapper/props.md
@@ -1,10 +1,8 @@
 # `.props() => Object`
 
-Returns the props hash for the root node of the wrapper.
+Returns the props object for the root node of the wrapper. It must be a single-node wrapper.
 
-NOTE: can only be called on a wrapper of a single node.
-
-To return the props for the entire React component, use `wrapper.instance().props`. This is valid for stateful or stateless components in React `15.*`. But, `wrapper.instance()` will return `null` for stateless React component in React `16.*`, so `wrapper.instance().props` will cause an error in this case. See [`.instance() => ReactComponent`](instance.md)
+This method is a reliable way of accessing the props of a node; `wrapper.instance().props` will work as well, but in React 16+, stateless functional components do not have an instance. See [`.instance() => ReactComponent`](instance.md)
 
 
 #### Example
@@ -38,7 +36,6 @@ console.log(wrapper.instance().props); // React 15.x - working as expected
 console.log(wrapper.instance().props);
 // React 16.* - Uncaught TypeError: Cannot read property 'props' of null
 ```
-
 
 #### Related Methods
 

--- a/docs/api/ReactWrapper/reduce.md
+++ b/docs/api/ReactWrapper/reduce.md
@@ -9,17 +9,15 @@ Each node is passed in as a `ReactWrapper`, and is processed from left to right.
 1. `fn` (`Function`): A reducing function to be run for every node in the collection, with the
 following arguments:
   - `value` (`T`): The value returned by the previous invocation of this function
-  - `node` (`ReactWrapper`): A wrapper around the current node being processed
-  - `index` (`Number`): The index of the current node being processed
+  - `node` (`ReactWrapper`): A wrapper around the node being processed
+  - `index` (`Number`): The index of the node being processed
 
 2. `initialValue` (`T` [optional]): If provided, this will be passed in as the first argument to the first invocation of the reducing function. If omitted, the first `node` will be provided and the iteration will begin on the second node in the collection.
-
 
 
 #### Returns
 
 `T`: Returns an array of the returned values from the mapping function...
-
 
 
 #### Example

--- a/docs/api/ReactWrapper/reduceRight.md
+++ b/docs/api/ReactWrapper/reduceRight.md
@@ -9,17 +9,15 @@ Each node is passed in as a `ReactWrapper`, and is processed from right to left.
 1. `fn` (`Function`): A reducing function to be run for every node in the collection, with the
 following arguments:
   - `value` (`T`): The value returned by the previous invocation of this function
-  - `node` (`ReactWrapper`): A wrapper around the current node being processed
-  - `index` (`Number`): The index of the current node being processed
+  - `node` (`ReactWrapper`): A single-node wrapper around the node being processed
+  - `index` (`Number`): The index of the node being processed
 
 2. `initialValue` (`T` [optional]): If provided, this will be passed in as the first argument to the first invocation of the reducing function. If omitted, the first `node` will be provided and the iteration will begin on the second node in the collection.
-
 
 
 #### Returns
 
 `T`: Returns an array of the returned values from the mapping function...
-
 
 
 #### Example

--- a/docs/api/ReactWrapper/ref.md
+++ b/docs/api/ReactWrapper/ref.md
@@ -15,7 +15,6 @@ NOTE: can only be called on a wrapper instance that is also the root instance.
 `ReactComponent | HTMLElement`: The node that matches the provided reference name. This can be a react component instance, or an HTML element instance.
 
 
-
 #### Examples
 
 <!-- eslint react/no-string-refs: 1 -->

--- a/docs/api/ReactWrapper/render.md
+++ b/docs/api/ReactWrapper/render.md
@@ -1,14 +1,12 @@
 # `.render() => CheerioWrapper`
 
-Returns a CheerioWrapper around the rendered HTML of the current node's subtree.
-
-Note: can only be called on a wrapper of a single node.
+Returns a CheerioWrapper around the rendered HTML of the single node's subtree.
+It must be a single-node wrapper.
 
 
 #### Returns
 
-`String`: The resulting HTML string
-
+`CheerioWrapper`: The resulting Cheerio object
 
 
 #### Examples

--- a/docs/api/ReactWrapper/renderProp.md
+++ b/docs/api/ReactWrapper/renderProp.md
@@ -6,8 +6,8 @@ NOTE: can only be called on wrapper of a single non-DOM component element node.
 
 #### Arguments
 
-1.  `propName` (`String`):
-1.  `...args` (`Array<Any>`):
+1. `propName` (`String`):
+1. `...args` (`Array<Any>`):
 
 This essentially calls `wrapper.prop(propName)(...args)`.
 

--- a/docs/api/ReactWrapper/setProps.md
+++ b/docs/api/ReactWrapper/setProps.md
@@ -21,7 +21,6 @@ NOTE: can only be called on a wrapper instance that is also the root instance.
 `ReactWrapper`: Returns itself.
 
 
-
 #### Example
 
 ```jsx
@@ -58,13 +57,7 @@ expect(spy).to.have.property('callCount', 1);
 ```
 
 
-#### Common Gotchas
-
-
-
 #### Related Methods
 
 - [`.setState(state) => Self`](setState.md)
 - [`.setContext(context) => Self`](setContext.md)
-
-

--- a/docs/api/ReactWrapper/setState.md
+++ b/docs/api/ReactWrapper/setState.md
@@ -1,10 +1,11 @@
 # `.setState(nextState[, callback]) => Self`
 
-A method to invoke `setState()` on the root component instance similar to how you might in the
-definition of the component, and re-renders.  This method is useful for testing your component
-in hard to achieve states, however should be used sparingly. If possible, you should utilize
-your component's external API in order to get it into whatever state you want to test, in order
-to be as accurate of a test as possible. This is not always practical, however.
+A method to invoke `setState()` on the root component instance, similar to how you might in the
+methods of the component, and re-renders. This method is useful for testing your component
+in hard-to-achieve states, however should be used sparingly. If possible, you should utilize
+your component's external API (which is often accessible via [`.instance()`](instance.md)) in order
+to get it into whatever state you want to test, in order to be as accurate of a test as possible.
+This is not always practical, however.
 
 NOTE: can only be called on a wrapper instance that is also the root instance.
 
@@ -18,7 +19,6 @@ NOTE: can only be called on a wrapper instance that is also the root instance.
 #### Returns
 
 `ReactWrapper`: Returns itself.
-
 
 
 #### Example
@@ -48,13 +48,7 @@ expect(wrapper.find('.bar')).to.have.lengthOf(1);
 ```
 
 
-#### Common Gotchas
-
-
-
 #### Related Methods
 
 - [`.setProps(props[, callback]) => Self`](setProps.md)
 - [`.setContext(context) => Self`](setContext.md)
-
-

--- a/docs/api/ReactWrapper/simulate.md
+++ b/docs/api/ReactWrapper/simulate.md
@@ -1,6 +1,6 @@
 # `.simulate(event[, mock]) => Self`
 
-Simulate events
+Simulate events on the root node in the wrapper. It must be a single-node wrapper.
 
 
 #### Arguments
@@ -9,11 +9,9 @@ Simulate events
 2. `mock` (`Object` [optional]): A mock event object that will be merged with the event object passed to the handlers.
 
 
-
 #### Returns
 
 `ReactWrapper`: Returns itself.
-
 
 
 #### Example
@@ -46,6 +44,9 @@ expect(wrapper.find('.clicks-0').length).to.equal(1);
 wrapper.find('a').simulate('click');
 expect(wrapper.find('.clicks-1').length).to.equal(1);
 ```
+
+
+
 #### Common Gotchas
 
 - As noted in the function signature above passing a mock event is optional. It is worth noting that `ReactWrapper` will pass a `SyntheticEvent` object to the event handler in your code. Keep in mind that if the code you are testing uses properties that are not included in the `SyntheticEvent`, for instance `event.target.value`, you will need to provide a mock event like so `.simulate("change", { target: { value: "foo" }})` for it to work.

--- a/docs/api/ReactWrapper/text.md
+++ b/docs/api/ReactWrapper/text.md
@@ -1,6 +1,6 @@
 # `.text() => String`
 
-Returns a string of the rendered text of the current render tree.  This function should be
+Returns a string of the rendered text of the current render tree. This function should be
 looked at with skepticism if being used to test what the actual HTML output of the component
 will be. If that is what you would like to test, use enzyme's `render` function instead.
 
@@ -10,7 +10,6 @@ Note: can only be called on a wrapper of a single node.
 #### Returns
 
 `String`: The resulting string
-
 
 
 #### Examples
@@ -28,7 +27,6 @@ function Foo() {
 const wrapper = mount(<div><Foo /> <b>really</b> important</div>);
 expect(wrapper.text()).to.equal('This is really important');
 ```
-
 
 
 #### Related Methods

--- a/docs/api/ReactWrapper/type.md
+++ b/docs/api/ReactWrapper/type.md
@@ -1,15 +1,14 @@
-# `.type() => String|Function|null`
+# `.type() => String | Function | null`
 
-Returns the type of the current node of this wrapper. If it's a composite component, this will be
-the component constructor. If it's a native DOM node, it will be a string of the tag name. If it's `null`, it will be `null`.
-
-Note: can only be called on a wrapper of a single node.
+Returns the type of the only node of this wrapper.
+If it's a React component, this will be the component constructor.
+If it's a native DOM node, it will be a string with the tag name.
+If it's `null`, it will be `null`. It must be a single-node wrapper.
 
 
 #### Returns
 
-`String|Function|null`: The type of the current node
-
+`String | Function | null`: The type of the node
 
 
 #### Examples

--- a/docs/api/ShallowWrapper/at.md
+++ b/docs/api/ShallowWrapper/at.md
@@ -26,4 +26,6 @@ expect(wrapper.find(Foo).at(0).props().foo).to.equal('bar');
 
 #### Related Methods
 
-- [`.get(index) => ReactElement`](get.md)
+- [`.get(index) => ReactElement`](get.md) - same, but returns the React node itself, with no wrapper.
+- [`.first() => ShallowWrapper`](first.md) - same as at(0)
+- [`.last() => ShallowWrapper`](last.md)

--- a/docs/api/ShallowWrapper/closest.md
+++ b/docs/api/ShallowWrapper/closest.md
@@ -1,9 +1,7 @@
 # `.closest(selector) => ShallowWrapper`
 
 Returns a wrapper of the first element that matches the selector by traversing up through the
-current node's ancestors in the tree, starting with itself.
-
-Note: can only be called on a wrapper of a single node.
+wrapped node's ancestors in the tree, starting with itself. It must be a single-node wrapper.
 
 
 #### Returns

--- a/docs/api/ShallowWrapper/containsAllMatchingElements.md
+++ b/docs/api/ShallowWrapper/containsAllMatchingElements.md
@@ -1,23 +1,18 @@
-# `.containsAllMatchingElements(nodes) => Boolean`
+# `.containsAllMatchingElements(patternNodes) => Boolean`
 
-Returns whether or not one of the given react elements are all matching one element in the shallow render tree.
-It will determine if the wrapper contains elements which __look like__ each of the expected elements by checking if all props of each expected element are present on the wrapper's elements and equal to each other. Props present on the wrapper elements but not supplied in the expected elements will be ignored.
-
-
+Returns whether or not all of the given react elements in `patternNodes` match an element in the wrapper's render tree. Every single element of `patternNodes` must be matched one or more times. Matching follows the rules for `containsMatchingElement`.
 
 
 #### Arguments
 
-1. `nodes` (`Array<ReactElement>`): The array of nodes whose presence you are detecting in the current instance's
+1. `patternNodes` (`Array<ReactElement>`): The array of nodes whose presence you are detecting in the current instance's
 render tree.
-
 
 
 #### Returns
 
 `Boolean`: whether or not the current wrapper has nodes anywhere in its render tree that looks
 like the nodes passed in.
-
 
 
 #### Example
@@ -46,3 +41,10 @@ expect(wrapper.containsAllMatchingElements([
 when you are calling it you are calling it with an array of ReactElement or a JSX expression.
 - Keep in mind that this method determines matching based on the matching of the node's children as
 well.
+
+
+#### Related Methods
+
+- [`.matchesElement() => ShallowWrapper`](matchesElement.md) - rules for matching each node
+- [`.containsMatchingElement() => ShallowWrapper`](containsMatchingElement.md) - rules for matching whole wrapper
+- [`.containsAnyMatchingElements() => ShallowWrapper`](containsAnyMatchingElements.md) - must match at least one in patternNodes

--- a/docs/api/ShallowWrapper/containsAnyMatchingElements.md
+++ b/docs/api/ShallowWrapper/containsAnyMatchingElements.md
@@ -1,21 +1,18 @@
-# `.containsAnyMatchingElements(nodes) => Boolean`
+# `.containsAnyMatchingElements(patternNodes) => Boolean`
 
-Returns whether or not one of the given react elements is matching an element in the shallow render tree.
-It will determine if an element in the wrapper __looks like__ one of the expected elements by checking if all props of the expected element are present on the wrappers element and equal to each other. Props present on the wrapper root node but not supplied in the expected element will be ignored.
+Returns whether or not at least one of the given react elements in `patternNodes` matches an element in the wrapper's render tree. One or more elements of `patternNodes` must be matched one or more times. Matching follows the rules for `containsMatchingElement`.
 
 
 #### Arguments
 
-1. `nodes` (`Array<ReactElement>`): The array of nodes whose presence you are detecting in the current instance's
+1. `patternNodes` (`Array<ReactElement>`): The array of nodes whose presence you are detecting in the current instance's
 render tree.
-
 
 
 #### Returns
 
 `Boolean`: whether or not the current wrapper has a node anywhere in its render tree that looks
 like one of the array passed in.
-
 
 
 #### Example
@@ -44,3 +41,10 @@ expect(wrapper.containsAnyMatchingElements([
 when you are calling it you are calling it with an array ReactElement or a JSX expression.
 - Keep in mind that this method determines equality based on the equality of the node's children as
 well.
+
+
+#### Related Methods
+
+- [`.matchesElement() => ShallowWrapper`](matchesElement.md) - rules for matching each node
+- [`.containsMatchingElement() => ShallowWrapper`](containsMatchingElement.md) - rules for matching whole wrapper
+- [`.containsAllMatchingElements() => ShallowWrapper`](containsAllMatchingElements.md) - must match all nodes in patternNodes

--- a/docs/api/ShallowWrapper/containsMatchingElement.md
+++ b/docs/api/ShallowWrapper/containsMatchingElement.md
@@ -1,14 +1,16 @@
-# `.containsMatchingElement(node) => Boolean`
+# `.containsMatchingElement(patternNode) => Boolean`
 
-Returns whether or not a given react element matches one element in the render tree.
-It will determine if an element in the wrapper matches the expected element by checking if all props supplied in the expected element are present on the wrapper's element and equal to each other. Props present on the wrapper element but not supplied in the expected element will be ignored.
+Returns whether or not a `patternNode` react element matches any element in the render tree.
+* the matches can happen anywhere in the wrapper's contents
+* the wrapper can contain more than one node; all are searched
+
+Otherwise, the match follows the same rules as `matchesElement`.
 
 
 #### Arguments
 
-1. `node` (`ReactElement`): The node whose presence you are detecting in the current instance's
+1. `patternNode` (`ReactElement`): The node whose presence you are detecting in the current instance's
 render tree.
-
 
 
 #### Returns
@@ -42,3 +44,9 @@ expect(wrapper.containsMatchingElement(<div data-foo="foo" data-bar="bar" />)).t
 when you are calling it you are calling it with a ReactElement or a JSX expression.
 - Keep in mind that this method determines equality based on the equality of the node's children as
 well.
+
+
+#### Related Methods
+
+- [`.containsAllMatchingElements() => ShallowWrapper`](containsAllMatchingElements.md) - must match all nodes in patternNodes
+- [`.containsAnyMatchingElements() => ShallowWrapper`](containsAnyMatchingElements.md) - must match at least one in patternNodes

--- a/docs/api/ShallowWrapper/dive.md
+++ b/docs/api/ShallowWrapper/dive.md
@@ -1,6 +1,8 @@
 # `.dive([options]) => ShallowWrapper`
 
-Shallow render the one non-DOM child of the current wrapper, and return a wrapper around the result.
+Shallow render the one non-DOM child of the current wrapper, and return a wrapper around the result. It must be a single-node wrapper, and the node must be a React component.
+
+There is no corresponding `dive` method for ReactWrappers.
 
 NOTE: can only be called on a wrapper of a single non-DOM component element node, otherwise it will throw an error. If you have to shallow-wrap a wrapper with multiple child nodes, use [.shallow()](shallow.md).
 
@@ -11,11 +13,9 @@ NOTE: can only be called on a wrapper of a single non-DOM component element node
 - `options.context`: (`Object` [optional]): Context to be passed into the component
 
 
-
 #### Returns
 
 `ShallowWrapper`: A new wrapper that wraps the current node after it's been shallow rendered.
-
 
 
 #### Examples

--- a/docs/api/ShallowWrapper/exists.md
+++ b/docs/api/ShallowWrapper/exists.md
@@ -1,6 +1,6 @@
 # `.exists([selector]) => Boolean`
 
-Returns whether or not the current node exists. Or, if a selector is passed in, whether that selector has any matching results.
+Returns whether or not any nodes exist in the wrapper. Or, if a selector is passed in, whether that selector has any matches in the wrapper.
 
 
 
@@ -12,7 +12,7 @@ Returns whether or not the current node exists. Or, if a selector is passed in, 
 
 #### Returns
 
-`Boolean`: whether or not the current node exists, or the selector had any results.
+`Boolean`: whether or not any nodes are on the list, or the selector had any matches.
 
 
 

--- a/docs/api/ShallowWrapper/first.md
+++ b/docs/api/ShallowWrapper/first.md
@@ -1,13 +1,11 @@
 # `.first() => ShallowWrapper`
 
-Reduce the set of matched nodes to the first in the set.
-
+Reduce the set of matched nodes to the first in the set, just like `.at(0)`.
 
 
 #### Returns
 
 `ShallowWrapper`: A new wrapper that wraps the first node in the set.
-
 
 
 #### Examples
@@ -16,3 +14,9 @@ Reduce the set of matched nodes to the first in the set.
 const wrapper = shallow(<MyComponent />);
 expect(wrapper.find(Foo).first().props().foo).to.equal('bar');
 ```
+
+
+#### Related Methods
+
+- [`.at(index) => ShallowWrapper`](at.md) - retrieve any wrapper node
+- [`.last() => ShallowWrapper`](last.md)

--- a/docs/api/ShallowWrapper/get.md
+++ b/docs/api/ShallowWrapper/get.md
@@ -8,11 +8,9 @@ Returns the node at a given index of the current wrapper.
 1. `index` (`Number`): A zero-based integer indicating which node to retrieve.
 
 
-
 #### Returns
 
 `ReactElement`: The retrieved node.
-
 
 
 #### Examples
@@ -23,7 +21,6 @@ expect(wrapper.find(Foo).get(0).props.foo).to.equal('bar');
 ```
 
 
-
 #### Related Methods
 
-- [`.at(index) => ShallowWrapper`](at.md)
+- [`.at(index) => ShallowWrapper`](at.md) - same, but returns the React node in a single-node wrapper.

--- a/docs/api/ShallowWrapper/hasClass.md
+++ b/docs/api/ShallowWrapper/hasClass.md
@@ -1,6 +1,6 @@
 # `.hasClass(className) => Boolean`
 
-Returns whether or not the current node has a `className` prop including the passed in class name.
+Returns whether or not the wrapped node has a `className` prop including the passed in class name. It must be a single-node wrapper.
 
 
 #### Arguments
@@ -8,11 +8,9 @@ Returns whether or not the current node has a `className` prop including the pas
 1. `className` (`String`): A single class name.
 
 
-
 #### Returns
 
-`Boolean`: whether or not the current node has the class or not.
-
+`Boolean`: whether or not the wrapped node has the class.
 
 
 #### Example

--- a/docs/api/ShallowWrapper/hostNodes.md
+++ b/docs/api/ShallowWrapper/hostNodes.md
@@ -1,7 +1,7 @@
 # `.hostNodes() => ShallowWrapper`
 
 Returns a new wrapper with only host nodes.
-
+When using `react-dom`, host nodes are HTML elements rather than custom React components, e.g. `<div>` versus `<MyComponent>`.
 
 
 #### Returns
@@ -9,10 +9,17 @@ Returns a new wrapper with only host nodes.
 `ShallowWrapper`: A new wrapper that wraps the filtered nodes.
 
 
-
 #### Examples
 
+The following code takes a wrapper with two nodes, one a `<MyComponent>` React component, and the other a `<span>`, and filters out the React component.
+
 ```jsx
-const wrapper = shallow(<div><MyComponent className="foo" /><div className="foo" /></div>);
-expect(wrapper.find('.foo').hostNodes()).to.have.lengthOf(1);
+const wrapper = shallow((
+  <div>
+    <MyComponent className="foo" />
+    <span className="foo" />
+  </div>
+));
+const twoNodes = wrapper.find('.foo');
+expect(twoNodes.hostNodes()).to.have.lengthOf(1);
 ```

--- a/docs/api/ShallowWrapper/instance.md
+++ b/docs/api/ShallowWrapper/instance.md
@@ -1,21 +1,17 @@
 # `.instance() => ReactComponent`
 
-Gets the instance of the component being rendered as the root node passed into `shallow()`.
+Returns the single-node wrapper's node's underlying class instance; `this` in its methods.
 
-NOTE: can only be called on a wrapper instance that is also the root instance. With React `16.x`, `instance()` returns `null` for stateless React component/stateless functional components. See example:
+NOTE: can only be called on a wrapper instance that is also the root instance. With React `16` and above, `instance()` returns `null` for stateless functional components.
 
-#### Returns (React 16.x)
 
-- `ReactComponent`: The stateful React component instance.
-- `null`: If stateless React component was wrapped.
+#### Returns
 
-#### Returns (React 15.x)
+`ReactComponent|DOMComponent`: The retrieved instance.
 
-- `ReactComponent`: The component instance.
 
 #### Example
 
-#### Preconditions
 <!-- eslint react/prop-types: 0, react/prefer-stateless-function: 0 -->
 ```jsx
 function Stateless() {
@@ -28,13 +24,14 @@ class Stateful extends React.Component {
   }
 }
 ```
+
 #### React 16.x
 ```jsx
 test('shallow wrapper instance should be null', () => {
   const wrapper = shallow(<Stateless />);
   const instance = wrapper.instance();
 
-  expect(instance).not.to.be.instanceOf(Stateless);
+  expect(instance).to.equal(null);
 });
 
 test('shallow wrapper instance should not be null', () => {
@@ -44,6 +41,7 @@ test('shallow wrapper instance should not be null', () => {
   expect(instance).to.be.instanceOf(Stateful);
 });
 ```
+
 #### React 15.x
 ```jsx
 test('shallow wrapper instance should not be null', () => {
@@ -60,4 +58,3 @@ test('shallow wrapper instance should not be null', () => {
   expect(instance).to.be.instanceOf(Stateful);
 });
 ```
-

--- a/docs/api/ShallowWrapper/is.md
+++ b/docs/api/ShallowWrapper/is.md
@@ -1,6 +1,6 @@
 # `.is(selector) => Boolean`
 
-Returns whether or not the current node matches a provided selector.
+Returns whether or not the single wrapped node matches the provided selector. It must be a single-node wrapper.
 
 
 #### Arguments
@@ -8,11 +8,9 @@ Returns whether or not the current node matches a provided selector.
 1. `selector` ([`EnzymeSelector`](../selector.md)): The selector to match.
 
 
-
 #### Returns
 
-`Boolean`: whether or not the current node matches a provided selector.
-
+`Boolean`: whether or not the wrapped node matches the provided selector.
 
 
 #### Example
@@ -22,4 +20,3 @@ Returns whether or not the current node matches a provided selector.
 const wrapper = shallow(<div className="some-class other-class" />);
 expect(wrapper.is('.some-class')).to.equal(true);
 ```
-

--- a/docs/api/ShallowWrapper/isEmpty.md
+++ b/docs/api/ShallowWrapper/isEmpty.md
@@ -1,13 +1,12 @@
 # `.isEmpty() => Boolean`
 **Deprecated**: Use [.exists()](exists.md) instead.
 
-Returns whether or not the current node is empty.
+Returns whether or not the wrapper is empty.
 
 
 #### Returns
 
-`Boolean`: whether or not the current node is empty.
-
+`Boolean`: whether or not the wrapper is empty.
 
 
 #### Example

--- a/docs/api/ShallowWrapper/isEmptyRender.md
+++ b/docs/api/ShallowWrapper/isEmptyRender.md
@@ -1,6 +1,6 @@
 # `.isEmptyRender() => Boolean`
 
-Returns whether or not the current component returns one of the allowed falsy values: `false` or `null`.
+Returns whether or not the wrapper would ultimately render only the allowed falsy values: `false` or `null`.
 
 #### Returns
 

--- a/docs/api/ShallowWrapper/key.md
+++ b/docs/api/ShallowWrapper/key.md
@@ -1,8 +1,6 @@
 # `.key() => String`
 
-Returns the key value for the node of the current wrapper.
-
-NOTE: can only be called on a wrapper of a single node.
+Returns the key value for the node of the current wrapper. It must be a single-node wrapper.
 
 #### Example
 

--- a/docs/api/ShallowWrapper/last.md
+++ b/docs/api/ShallowWrapper/last.md
@@ -1,13 +1,11 @@
 # `.last() => ShallowWrapper`
 
-Reduce the set of matched nodes to the last in the set.
-
+Reduce the set of matched nodes to the last in the set, just like `.at(length - 1)`.
 
 
 #### Returns
 
 `ShallowWrapper`: A new wrapper that wraps the last node in the set.
-
 
 
 #### Examples
@@ -20,4 +18,5 @@ expect(wrapper.find(Foo).last().props().foo).to.equal('bar');
 
 #### Related Methods
 
+- [`.at(index) => ShallowWrapper`](at.md) - retrieve a wrapper node by index
 - [`.first() => ShallowWrapper`](first.md)

--- a/docs/api/ShallowWrapper/matchesElement.md
+++ b/docs/api/ShallowWrapper/matchesElement.md
@@ -1,20 +1,22 @@
-# `.matchesElement(node) => Boolean`
+# `.matchesElement(patternNode) => Boolean`
 
-Returns whether or not a given react element matches the shallow render tree.
-It will determine if the wrapper root node __looks like__ the expected element by checking if all props of the expected element are present on the wrapper root node and equals to each other.
+Returns whether or not a given react element `patternNode` matches the wrapper's render tree. It must be a single-node wrapper, and only the root node is checked.
+
+The `patternNode` acts like a wildcard. For it to match a node in the wrapper:
+* tag names must match
+* contents must match:  In text nodes, leading and trailing spaces are ignored, but not space in the middle. Child elements must match according to these rules, recursively.
+* `patternNode` props (attributes) must appear in the wrapper's nodes, but not the other way around. Their values must match if they do appear.
+* `patternNode` style CSS properties must appear in the wrapper's node's style, but not the other way around. Their values must match if they do appear.
 
 
 #### Arguments
 
-1. `node` (`ReactElement`): The node whose presence you are detecting in the current instance's
-render tree.
-
+1. `patternNode` (`ReactElement`): The node whose presence you are detecting in the wrapper's single node.
 
 
 #### Returns
 
 `Boolean`: whether or not the current wrapper match the one passed in.
-
 
 
 #### Example
@@ -50,3 +52,8 @@ expect(wrapper.matchesElement(<button className="foo bar">Hello</button>)).to.eq
 when you are calling it you are calling it with a ReactElement or a JSX expression.
 - Keep in mind that this method determines matching based on the matching of the node's children as
 well.
+
+
+#### Related Methods
+
+- [`.containsMatchingElement() => ShallowWrapper`](containsMatchingElement.md) - searches all nodes in the wrapper, and searches their entire depth

--- a/docs/api/ShallowWrapper/parent.md
+++ b/docs/api/ShallowWrapper/parent.md
@@ -2,9 +2,11 @@
 
 Returns a wrapper with the direct parent of the node in the current wrapper.
 
+
 #### Returns
 
 `ShallowWrapper`: A new wrapper that wraps the resulting nodes.
+
 
 #### Examples
 

--- a/docs/api/ShallowWrapper/parents.md
+++ b/docs/api/ShallowWrapper/parents.md
@@ -1,10 +1,7 @@
 # `.parents([selector]) => ShallowWrapper`
 
-Returns a wrapper around all of the parents/ancestors of the wrapper. Does not include the node
-in the current wrapper. Optionally, a selector can be provided and it will filter the parents by
-this selector.
-
-Note: can only be called on a wrapper of a single node.
+Returns a wrapper around all of the parents/ancestors of the single node in the wrapper. Does not include the node itself.
+Optionally, a selector can be provided and it will filter the parents by this selector. It must be a single-node wrapper.
 
 
 #### Arguments
@@ -15,7 +12,6 @@ Note: can only be called on a wrapper of a single node.
 #### Returns
 
 `ShallowWrapper`: A new wrapper that wraps the resulting nodes.
-
 
 
 #### Examples

--- a/docs/api/ShallowWrapper/prop.md
+++ b/docs/api/ShallowWrapper/prop.md
@@ -1,7 +1,6 @@
 # `.prop(key) => Any`
 
-Returns the prop value for the root node of the wrapper with the provided key.
-`.prop(key)` can only be called on a wrapper of a single node.
+Returns the prop value for the root node of the wrapper with the provided key. It must be a single-node wrapper.
 
 NOTE: When called on a shallow wrapper, `.prop(key)` will return values for
 props on the root node that the component *renders*, not the component itself.
@@ -10,9 +9,7 @@ See [`.instance() => ReactComponent`](instance.md)
 
 #### Arguments
 
-1. `key` (`String`): The prop name such that this will return value will be the `this.props[key]`
-of the root node of the component.
-
+1. `key` (`String`): The prop name, that is, `this.props[key]` or `props[key]` for the root node of the wrapper.
 
 
 #### Example

--- a/docs/api/ShallowWrapper/props.md
+++ b/docs/api/ShallowWrapper/props.md
@@ -1,12 +1,10 @@
 # `.props() => Object`
 
-Returns the props hash for the root node of the wrapper.
-
-NOTE: can only be called on a wrapper of a single node.
+Returns the props object for the root node of the wrapper. It must be a single-node wrapper.
 
 NOTE: When called on a shallow wrapper, `.props()` will return values for props on the root node that the component *renders*, not the component itself.
 
-To return the props for the entire React component, use `wrapper.instance().props`. This is valid for stateful or stateless components in React `15.*`. But, `wrapper.instance()` will return `null` for stateless React component in React `16.*`, so `wrapper.instance().props` will cause an error in this case. See [`.instance() => ReactComponent`](instance.md)
+This method is a reliable way of accessing the props of a node; `wrapper.instance().props` will work as well, but in React 16+, stateless functional components do not have an instance. See [`.instance() => ReactComponent`](instance.md)
 
 
 #### Example

--- a/docs/api/ShallowWrapper/reduce.md
+++ b/docs/api/ShallowWrapper/reduce.md
@@ -9,17 +9,15 @@ Each node is passed in as a `ShallowWrapper`, and is processed from left to righ
 1. `fn` (`Function`): A reducing function to be run for every node in the collection, with the
 following arguments:
   - `value` (`T`): The value returned by the previous invocation of this function
-  - `node` (`ShallowWrapper`): A wrapper around the current node being processed
-  - `index` (`Number`): The index of the current node being processed
+  - `node` (`ShallowWrapper`): A wrapper around the node being processed
+  - `index` (`Number`): The index of the node being processed
 
 2. `initialValue` (`T` [optional]): If provided, this will be passed in as the first argument to the first invocation of the reducing function. If omitted, the first `node` will be provided and the iteration will begin on the second node in the collection.
-
 
 
 #### Returns
 
 `T`: Returns an array of the returned values from the mapping function...
-
 
 
 #### Example

--- a/docs/api/ShallowWrapper/reduceRight.md
+++ b/docs/api/ShallowWrapper/reduceRight.md
@@ -9,17 +9,15 @@ Each node is passed in as a `ShallowWrapper`, and is processed from right to lef
 1. `fn` (`Function`): A reducing function to be run for every node in the collection, with the
 following arguments:
   - `value` (`T`): The value returned by the previous invocation of this function
-  - `node` (`ShallowWrapper`): A wrapper around the current node being processed
-  - `index` (`Number`): The index of the current node being processed
+  - `node` (`ShallowWrapper`): A single-node wrapper around the node being processed
+  - `index` (`Number`): The index of the node being processed
 
 2. `initialValue` (`T` [optional]): If provided, this will be passed in as the first argument to the first invocation of the reducing function. If omitted, the first `node` will be provided and the iteration will begin on the second node in the collection.
-
 
 
 #### Returns
 
 `T`: Returns an array of the returned values from the mapping function...
-
 
 
 #### Example

--- a/docs/api/ShallowWrapper/render.md
+++ b/docs/api/ShallowWrapper/render.md
@@ -1,14 +1,12 @@
 # `.render() => CheerioWrapper`
 
-Returns a CheerioWrapper around the rendered HTML of the current node's subtree.
-
-Note: can only be called on a wrapper of a single node.
+Returns a CheerioWrapper around the rendered HTML of the single node's subtree.
+It must be a single-node wrapper.
 
 
 #### Returns
 
 `CheerioWrapper`: The resulting Cheerio object
-
 
 
 #### Examples

--- a/docs/api/ShallowWrapper/renderProp.md
+++ b/docs/api/ShallowWrapper/renderProp.md
@@ -6,8 +6,8 @@ NOTE: can only be called on wrapper of a single non-DOM component element node.
 
 #### Arguments
 
-1.  `propName` (`String`):
-1.  `...args` (`Array<Any>`):
+1. `propName` (`String`):
+1. `...args` (`Array<Any>`):
 
 This essentially calls `wrapper.prop(propName)(...args)`.
 

--- a/docs/api/ShallowWrapper/setProps.md
+++ b/docs/api/ShallowWrapper/setProps.md
@@ -16,11 +16,9 @@ NOTE: can only be called on a wrapper instance that is also the root instance.
 2. `callback` (`Function` [optional]): If provided, the callback function will be executed once setProps has completed
 
 
-
 #### Returns
 
 `ShallowWrapper`: Returns itself.
-
 
 
 #### Example
@@ -63,5 +61,3 @@ expect(spy).to.have.property('callCount', 1);
 
 - [`.setState(state) => Self`](setState.md)
 - [`.setContext(context) => Self`](setContext.md)
-
-

--- a/docs/api/ShallowWrapper/setState.md
+++ b/docs/api/ShallowWrapper/setState.md
@@ -1,10 +1,11 @@
 # `.setState(nextState[, callback]) => Self`
 
-A method to invoke `setState()` on the root component instance similar to how you might in the
-definition of the component, and re-renders.  This method is useful for testing your component
-in hard to achieve states, however should be used sparingly. If possible, you should utilize
-your component's external API (which is [accessible via `.instance()`](http://airbnb.io/enzyme/docs/api/ShallowWrapper/instance.html)) in order to get it into whatever state you want to test, in order
-to be as accurate of a test as possible. This is not always practical, however.
+A method to invoke `setState()` on the root component instance, similar to how you might in the
+methods of the component, and re-renders. This method is useful for testing your component
+in hard-to-achieve states, however should be used sparingly. If possible, you should utilize
+your component's external API (which is often accessible via [`.instance()`](instance.md)) in order
+to get it into whatever state you want to test, in order to be as accurate of a test as possible.
+This is not always practical, however.
 
 NOTE: can only be called on a wrapper instance that is also the root instance.
 
@@ -18,7 +19,6 @@ NOTE: can only be called on a wrapper instance that is also the root instance.
 #### Returns
 
 `ShallowWrapper`: Returns itself.
-
 
 
 #### Example
@@ -48,13 +48,7 @@ expect(wrapper.find('.bar')).to.have.lengthOf(1);
 ```
 
 
-#### Common Gotchas
-
-
-
 #### Related Methods
 
 - [`.setProps(props[, callback]) => Self`](setProps.md)
 - [`.setContext(context) => Self`](setContext.md)
-
-

--- a/docs/api/ShallowWrapper/shallow.md
+++ b/docs/api/ShallowWrapper/shallow.md
@@ -1,8 +1,7 @@
 # `.shallow([options]) => ShallowWrapper`
 
-Shallow renders the current node and returns a shallow wrapper around it.
-
-NOTE: can only be called on wrapper of a single node.
+Shallow renders the root node and returns a shallow wrapper around it.
+It must be a single-node wrapper.
 
 
 #### Arguments
@@ -14,11 +13,9 @@ is not called on the component, and `componentDidUpdate` is not called after
 [`setProps`](ShallowWrapper/setProps.md) and [`setContext`](ShallowWrapper/setContext.md). Default to `false`.
 
 
-
 #### Returns
 
-`ShallowWrapper`: A new wrapper that wraps the current node after it's been shallow rendered.
-
+`ShallowWrapper`: A new wrapper that wraps the node after it's been shallow rendered.
 
 
 #### Examples

--- a/docs/api/ShallowWrapper/simulate.md
+++ b/docs/api/ShallowWrapper/simulate.md
@@ -1,20 +1,17 @@
 # `.simulate(event[, ...args]) => Self`
 
-Simulate events
+Simulate events on the root node in the wrapper. It must be a single-node wrapper.
 
 
 #### Arguments
 
 1. `event` (`String`): The event name to be simulated
-2. `...args` (`Any` [optional]): A mock event object that will get passed through to the event
-handlers.
-
+2. `...args` (`Any` [optional]): A mock event object that will get passed through to the event handlers.
 
 
 #### Returns
 
 `ShallowWrapper`: Returns itself.
-
 
 
 #### Example

--- a/docs/api/ShallowWrapper/text.md
+++ b/docs/api/ShallowWrapper/text.md
@@ -1,6 +1,6 @@
 # `.text() => String`
 
-Returns a string of the rendered text of the current render tree.  This function should be
+Returns a string of the rendered text of the current render tree. This function should be
 looked at with skepticism if being used to test what the actual HTML output of the component
 will be. If that is what you would like to test, use enzyme's `render` function instead.
 
@@ -10,7 +10,6 @@ Note: can only be called on a wrapper of a single node.
 #### Returns
 
 `String`: The resulting string
-
 
 
 #### Examples
@@ -24,7 +23,6 @@ expect(wrapper.text()).to.equal('important');
 const wrapper = shallow(<div><Foo /><b>important</b></div>);
 expect(wrapper.text()).to.equal('<Foo />important');
 ```
-
 
 
 #### Related Methods

--- a/docs/api/ShallowWrapper/type.md
+++ b/docs/api/ShallowWrapper/type.md
@@ -1,15 +1,14 @@
-# `.type() => String|Function|null`
+# `.type() => String | Function | null`
 
-Returns the type of the current node of this wrapper. If it's a composite component, this will be
-the component constructor. If it's a native DOM node, it will be a string of the tag name. If it's `null`, it will be `null`.
-
-Note: can only be called on a wrapper of a single node.
+Returns the type of the only node of this wrapper.
+If it's a React component, this will be the component constructor.
+If it's a native DOM node, it will be a string with the tag name.
+If it's `null`, it will be `null`. It must be a single-node wrapper.
 
 
 #### Returns
 
-`String|Function|null`: The type of the current node
-
+`String | Function | null`: The type of the node
 
 
 #### Examples

--- a/docs/api/render.md
+++ b/docs/api/render.md
@@ -1,7 +1,6 @@
 # Static Rendering API
 
-enzyme's `render` function is used to render react components to static HTML and analyze the
-resulting HTML structure.
+Use enzyme's `render` function to generate HTML from your React tree, and analyze the resulting HTML structure.
 
 `render` returns a wrapper very similar to the other renderers in enzyme, [`mount`](mount.md) and
 [`shallow`](shallow.md); however, `render` uses a third party HTML parsing and traversal library

--- a/docs/api/selector.md
+++ b/docs/api/selector.md
@@ -1,9 +1,7 @@
 # enzyme Selectors
 
-Many methods in enzyme’s API accept a *selector* as an argument. Selectors in enzyme can fall into
-one of the following five categories:
-
-
+Many methods in enzyme’s API accept a *selector* as an argument.
+You can select several different ways:
 
 ### 1. A Valid CSS Selector
 
@@ -11,22 +9,29 @@ enzyme supports a subset of valid CSS selectors to find nodes inside a render tr
 follows:
 
 - class syntax (`.foo`, `.foo-bar`, etc.)
-- element syntax (`input`, `div`, `span`, etc.)
+- element tag name syntax (`input`, `div`, `span`, etc.)
 - id syntax (`#foo`, `#foo-bar`, etc.)
 - attribute syntax (`[href="foo"]`, `[type="text"]`, and the other attribute selectors listed [here](https://developer.mozilla.org/en-US/docs/Learn/CSS/Introduction_to_CSS/Attribute_selectors).)
 
-Further, enzyme supports combining any of those supported syntaxes together to uniquely identify a
-single node. For instance:
+The attribute syntax also works by value, rather than by string. Strings, numbers, and boolean property values are supported. Example:
+
+```js
+const wrapper = mount((
+  <div>
+    <span anum={3} abool={false} />
+    <span anum="3" abool="false" />
+  </div>
+));
+```
+
+The selector `[anum=3]` will select the first <span> but not the second, because there's no quotes surrounding the 3. The selector `[anum="3"]` will select the second, because it's explicitly looking for a string because of the quotes surrounding 3. The same goes for the boolean; [abool=false] will select the first but not the second, etc.
+
+Further, enzyme supports combining any of those supported syntaxes together, as with CSS:
 
 ```css
 div.foo.bar
 input#input-name
 a[href="foo"]
-```
-
-enzyme also gives support for the following contextual selectors
-
-```css
 .foo .bar
 .foo > .bar
 .foo + .bar
@@ -34,39 +39,23 @@ enzyme also gives support for the following contextual selectors
 .foo input
 ```
 
+**The Key and Ref Props**
+
+While in most cases, any React prop can be used, there are exceptions.
+The `key` and `ref` props will never work; React uses these props internally.
+
+
 **Want more CSS support?**
 
 PRs implementing more support for CSS selectors will be accepted and is an area of development for
 enzyme that will likely be focused on in the future.
 
 
+### 2. A React Component Constructor
 
-### 2. Prop Selector
-
-In addition to traditional CSS selectors, enzyme supports using a React prop like an Attribute Selector as if it were an HTML attribute. Strings, Numbers, and Boolean property values are supported.
-
-```js
-const wrapper = mount((
-  <div>
-    <span foo={3} bar={false} title="baz" />
-  </div>
-));
-
-wrapper.find('[foo=3]');
-wrapper.find('[bar=false]');
-wrapper.find('[title="baz"]');
-```
-
-**The Key and Ref Prop**
-
-While in most cases, any React prop can be used, there are exceptions. The `key` and `ref` props will never work. This decision comes from how React uses these props internally, which means they should not be relied upon.
-
-
-
-### 3. A React Component Constructor
-
-enzyme allows you to find components based on their constructor. You can pass in the reference to
-the component’s constructor:
+enzyme allows you to find React components based on their constructor. You can pass in the reference to
+the component’s constructor.
+Of course, this kind of selector only checks the component type; it ignores props and children.
 
 ```jsx
 function MyComponent() {
@@ -78,12 +67,11 @@ const myComponents = wrapper.find(MyComponent);
 ```
 
 
-
-### 4. A React Component’s displayName
+### 3. A React Component’s displayName
 
 enzyme allows you to find components based on a component’s `displayName`. If a component exists
 in a render tree where its `displayName` is set and has its first character as a capital letter,
-a string can be used to find it:
+you can use a string to find it:
 
 
 ```jsx
@@ -97,13 +85,13 @@ const myComponents = wrapper.find('My Component');
 ```
 
 NOTE: This will *only* work if the selector (and thus the component’s `displayName`) is a string
-starting with a capital letter. Strings starting with lower case letters will assume it is a CSS
+starting with a capital letter. Strings starting with lower case letters will be assumed to be a CSS
+selector (therefore a tag name).
+
 Selecting a HOC-wrapped component, or a component with a custom `displayName`, even with lowercase letters (for example, `withHOC(MyComponent)`) will work as well.
-selector using the tag syntax.
 
 
-
-### 5. Object Property Selector
+### 4. Object Property Selector
 
 enzyme allows you to find components and nodes based on a subset of their properties:
 

--- a/docs/guides/migration-from-2-to-3.md
+++ b/docs/guides/migration-from-2-to-3.md
@@ -401,7 +401,7 @@ const refWrapper = wrapper.findWhere(n => n.instance() === wrapper.ref('abc'));
 ## With `mount`, `.instance()` can be called at any level of the tree
 
 enzyme now allows for you to grab the `instance()` of a wrapper at any level of the render tree,
-not just at the root.  This means that you can `.find(...)` a specific component, then grab its
+not just at the root. This means that you can `.find(...)` a specific component, then grab its
 instance and call `.setState(...)` or any other methods on the instance that you'd like.
 
 


### PR DESCRIPTION
Overhaul to a lot of ReactWrapper and ShallowWrapper method files, plus others.
- Defined 'solo' as a wrapper with one node, and used that terminology throughout.  Removed the term 'current node' as applied to a wrapper, and changed each to better wording.
- rewrote sections for functions matchesElement, containsMatchingElement, containsAllMatchingElements, containsAnyMatchingElements; each refer to containsMatchIngElement and matchesElement for matching rules.  Renamed the matcher node to 'patternNode' to avoid confusion.
- compared Shallow and React wrapper methods, corrected a few discrepancies
- added some notes for methods in React or Shallow that are not in the other
- added .length to both the React and Shallow directories.

Closes #1919.