### PR TITLE
Fixes confusing test description on React 16.x

### DIFF
--- a/docs/api/ShallowWrapper/instance.md
+++ b/docs/api/ShallowWrapper/instance.md
@@ -30,7 +30,7 @@ class Stateful extends React.Component {
 ```
 #### React 16.x
 ```jsx
-test('shallow wrapper instance should not be null', () => {
+test('shallow wrapper instance should be null', () => {
   const wrapper = shallow(<Stateless />);
   const instance = wrapper.instance();
 


### PR DESCRIPTION
According to [docs](https://airbnb.io/enzyme/docs/api/ShallowWrapper/instance.html#), calling `instance()` on a wrapped stateless component should return null (if using React 16.x)