### PR TITLE
support :focus pseudo selector in mount

### DIFF
--- a/packages/enzyme-test-suite/test/selector-spec.jsx
+++ b/packages/enzyme-test-suite/test/selector-spec.jsx
@@ -6,7 +6,7 @@ import {
 } from 'enzyme';
 
 import './_helpers/setupAdapters';
-import { describeWithDOM } from './_helpers';
+import { describeWithDOM, describeIf } from './_helpers';
 
 const tests = [
   {
@@ -281,6 +281,72 @@ describe('selectors', () => {
           </div>
         ));
         expect(wrapper.find('span:last-child').text()).to.equal('last');
+      });
+
+      describeIf(name === 'mount', ':focus pseudo selector', () => {
+        it('works in mount with directly focused DOM node', () => {
+          const wrapper = renderMethod((
+            <input type="text" />
+          ));
+          const inputNode = wrapper.find('input');
+
+          expect(inputNode.is(':focus')).to.equal(false);
+
+          const inputDOMNode = wrapper.getDOMNode();
+          inputDOMNode.focus();
+
+          expect(inputNode.is(':focus')).to.equal(true);
+        });
+
+        it('works on component in mount', () => {
+          class ClassComponent extends React.Component {
+            render() {
+              return (
+                <input type="text" />
+              );
+            }
+          }
+
+          const wrapper = renderMethod((
+            <ClassComponent />
+          ));
+
+          expect(wrapper.find('ClassComponent:focus')).to.have.lengthOf(0);
+
+          const inputDOMNode = wrapper.getDOMNode();
+          inputDOMNode.focus();
+
+          expect(wrapper.find('ClassComponent:focus')).to.have.lengthOf(1);
+        });
+
+        it('works on nested component in mount', () => {
+          class InnerComponent extends React.Component {
+            render() {
+              return (
+                <input type="text" />
+              );
+            }
+          }
+          class WrapComponent extends React.Component {
+            render() {
+              return <InnerComponent />;
+            }
+          }
+          const wrapper = renderMethod((
+            <WrapComponent />
+          ));
+
+          expect(wrapper.find('InnerComponent:focus')).to.have.lengthOf(0);
+          expect(wrapper.find('WrapComponent:focus')).to.have.lengthOf(0);
+          expect(wrapper.find('input:focus')).to.have.lengthOf(0);
+
+          const inputDOMNode = wrapper.getDOMNode();
+          inputDOMNode.focus();
+
+          expect(wrapper.find('InnerComponent:focus')).to.have.lengthOf(1);
+          expect(wrapper.find('WrapComponent:focus')).to.have.lengthOf(1);
+          expect(wrapper.find('input:focus')).to.have.lengthOf(1);
+        });
       });
 
       it('throws for complex selectors in simple selector methods', () => {

--- a/packages/enzyme/src/selectors.js
+++ b/packages/enzyme/src/selectors.js
@@ -160,6 +160,14 @@ function matchPseudoSelector(node, token, root) {
     const { rendered } = findParentNode(root, node);
     return rendered[rendered.length - 1] === node;
   }
+  if (name === 'focus') {
+    if (typeof document === 'undefined') {
+      throw new Error('Enzyme::Selector does not support the ":focus" pseudo-element without a global `document`.');
+    }
+    const adapter = getAdapter();
+    /* eslint-env browser */
+    return document.activeElement && adapter.nodeToHostNode(node) === document.activeElement;
+  }
 
   throw new TypeError(`Enzyme::Selector does not support the "${token.name}" pseudo-element or pseudo-class selectors.`);
 }


### PR DESCRIPTION
Try to implement #1709 by compare `document.activeElement` and host DOM node of rst node. Work with DOMElement and component element.

Note that this only works with `mount`, not works with `shallow`. Also it won't work with simulate:

```javascript

const wrapper = mount(<input type="text" />)
wrapper.simulate('focus')
// will print false
console.log(wrapper.is(":focus"))

```

I've tested this with jsdom@6 (in test suite), 13 and 12.