### PR TITLE
Add ability to dive() and shallow-render-as-root Consumers and Providers

### DIFF
--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -18,6 +18,8 @@ import {
   Element,
   ForwardRef,
   Fragment,
+  isContextConsumer,
+  isContextProvider,
   isElement,
   isForwardRef,
   isMemo,
@@ -303,6 +305,21 @@ function wrapAct(fn) {
   return returnVal;
 }
 
+function getProviderDefaultValue(Provider) {
+  // React stores references to the Provider's defaultValue differently across versions.
+  if ('_defaultValue' in Provider._context) {
+    return Provider._context._defaultValue;
+  }
+  if ('_currentValue' in Provider._context) {
+    return Provider._context._currentValue;
+  }
+  throw new Error('Enzyme Internal Error: can’t figure out how to get Provider’s default value');
+}
+
+function makeFakeElement(type) {
+  return { $$typeof: Element, type };
+}
+
 class ReactSixteenAdapter extends EnzymeAdapter {
   constructor() {
     super();
@@ -454,11 +471,30 @@ class ReactSixteenAdapter extends EnzymeAdapter {
     };
 
     return {
-      render(el, unmaskedContext) {
+      render(el, unmaskedContext, {
+        providerValues = new Map(),
+      } = {}) {
         cachedNode = el;
         /* eslint consistent-return: 0 */
         if (typeof el.type === 'string') {
           isDOM = true;
+        } else if (isContextProvider(el)) {
+          providerValues.set(el.type, el.props.value);
+          const MockProvider = Object.assign(
+            props => props.children,
+            el.type,
+          );
+          return withSetStateAllowed(() => renderer.render({ ...el, type: MockProvider }));
+        } else if (isContextConsumer(el)) {
+          const Provider = adapter.getProviderFromConsumer(el.type);
+          const value = providerValues.has(Provider)
+            ? providerValues.get(Provider)
+            : getProviderDefaultValue(Provider);
+          const MockConsumer = Object.assign(
+            props => props.children(value),
+            el.type,
+          );
+          return withSetStateAllowed(() => renderer.render({ ...el, type: MockConsumer }));
         } else {
           isDOM = false;
           const { type: Component } = el;
@@ -673,11 +709,17 @@ class ReactSixteenAdapter extends EnzymeAdapter {
   }
 
   isCustomComponent(type) {
-    const fakeElement = { $$typeof: Element, type };
+    const fakeElement = makeFakeElement(type);
     return !!type && (
       typeof type === 'function'
       || isForwardRef(fakeElement)
+      || isContextProvider(fakeElement)
+      || isContextConsumer(fakeElement)
     );
+  }
+
+  isContextConsumer(type) {
+    return !!type && isContextConsumer(makeFakeElement(type));
   }
 
   isCustomComponentElement(inst) {
@@ -685,6 +727,22 @@ class ReactSixteenAdapter extends EnzymeAdapter {
       return false;
     }
     return this.isCustomComponent(inst.type);
+  }
+
+  getProviderFromConsumer(Consumer) {
+    // React stores references to the Provider on a Consumer differently across versions.
+    if (Consumer) {
+      let Provider;
+      if (Consumer.Provider) {
+        ({ Provider } = Consumer);
+      } else if (Consumer._context) {
+        ({ Provider } = Consumer._context);
+      }
+      if (Provider) {
+        return Provider;
+      }
+    }
+    throw new Error('Enzyme Internal Error: can’t figure out how to get Provider from Consumer');
   }
 
   createElement(...args) {

--- a/packages/enzyme-test-suite/test/Adapter-spec.jsx
+++ b/packages/enzyme-test-suite/test/Adapter-spec.jsx
@@ -1169,7 +1169,40 @@ Warning: Failed Adapter-spec type: Invalid Adapter-spec \`foo\` of type \`string
     });
 
     itIf(is('>=16.3'), 'returns true for forward refs', () => {
-      expect(adapter.isCustomComponent(React.forwardRef(() => null))).to.equal(true);
+      expect(adapter.isCustomComponent(forwardRef(() => null))).to.equal(true);
+    });
+  });
+
+  describeIf(is('>= 16.3'), 'isContextConsumer(type)', () => {
+    it('returns true for createContext() Consumers', () => {
+      expect(adapter.isContextConsumer(createContext().Consumer)).to.equal(true);
+    });
+
+    it('returns false for everything else', () => {
+      expect(adapter.isContextConsumer(null)).to.equal(false);
+      expect(adapter.isContextConsumer(true)).to.equal(false);
+      expect(adapter.isContextConsumer(undefined)).to.equal(false);
+      expect(adapter.isContextConsumer(false)).to.equal(false);
+      expect(adapter.isContextConsumer(() => <div />)).to.equal(false);
+      expect(adapter.isContextConsumer(forwardRef(() => null))).to.equal(false);
+      expect(adapter.isContextConsumer(createContext().Provider)).to.equal(false);
+    });
+  });
+
+  describeIf(is('>= 16.3'), 'getProviderFromConsumer(Consumer)', () => {
+    it('gets a createContext() Provider from a Consumer', () => {
+      const Context = createContext();
+
+      expect(adapter.getProviderFromConsumer(Context.Consumer)).to.equal(Context.Provider);
+    });
+
+    it('throws an internal error if something that is not a Consumer is passed', () => {
+      expect(() => adapter.getProviderFromConsumer(null)).to.throw(
+        'Enzyme Internal Error: can’t figure out how to get Provider from Consumer',
+      );
+      expect(() => adapter.getProviderFromConsumer({})).to.throw(
+        'Enzyme Internal Error: can’t figure out how to get Provider from Consumer',
+      );
     });
   });
 });

--- a/packages/enzyme-test-suite/test/shared/methods/getWrappingComponent.jsx
+++ b/packages/enzyme-test-suite/test/shared/methods/getWrappingComponent.jsx
@@ -183,6 +183,31 @@ export default function describeGetWrappingComponent({
       }
     });
 
+    itIf(is('>= 16.3'), 'updates a <Provider /> if it is rendered as root', () => {
+      const Context = React.createContext();
+      function WrappingComponent(props) {
+        const { value, children } = props;
+        return (
+          <Context.Provider value={value}>
+            {children}
+          </Context.Provider>
+        );
+      }
+      const wrapper = Wrap((
+        <Context.Consumer>
+          {value => <div>{value}</div>}
+        </Context.Consumer>
+      ), {
+        wrappingComponent: WrappingComponent,
+        wrappingComponentProps: { value: 'hello!' },
+      });
+      const wrappingComponent = wrapper.getWrappingComponent();
+      expect(wrapper.text()).to.equal('hello!');
+
+      wrappingComponent.setProps({ value: 'goodbye!' });
+      expect(wrapper.text()).to.equal('goodbye!');
+    });
+
     itIf(!isShallow, 'handles a partial prop update', () => {
       const wrapper = Wrap(<MyComponent />, {
         wrappingComponent: MyWrappingComponent,


### PR DESCRIPTION
Fixes #1958
Fixes #1908
Fixes #1647

I think the most controversial choice I've made here is only collecting context when a `<Provider />` is the root (either because it is `.dive()ed` or passed directly to `shallow(<Provider />)`).

If we wanted to reliably make a `<Consumer />`'s `value` be that of the closest `<Provider />`, we'd need to recursively `.dive()` from the top until we find that `<Provider />`. I don't like that idea because we could end up rendering components that the end user did not want rendered.

I think, if the user _does_ want all their `<Provider />`s' values to be automatically collected, that's where `wrappingComponent` (from #1960) will come into play.