### PR TITLE
Filter legacy context on childContextTypes when necessary

### DIFF
--- a/packages/enzyme-adapter-react-16.1/src/ReactSixteenOneAdapter.js
+++ b/packages/enzyme-adapter-react-16.1/src/ReactSixteenOneAdapter.js
@@ -29,6 +29,7 @@ import {
   ensureKeyOrUndefined,
   simulateError,
   wrap,
+  getMaskedContext,
 } from 'enzyme-adapter-utils';
 import { findCurrentFiberUsingSlowPath } from 'react-reconciler/reflection';
 
@@ -315,7 +316,7 @@ class ReactSixteenOneAdapter extends EnzymeAdapter {
     let isDOM = false;
     let cachedNode = null;
     return {
-      render(el, context) {
+      render(el, unmaskedContext) {
         cachedNode = el;
         /* eslint consistent-return: 0 */
         if (typeof el.type === 'string') {
@@ -328,6 +329,7 @@ class ReactSixteenOneAdapter extends EnzymeAdapter {
             Component.prototype.isReactComponent
             || Array.isArray(Component.__reactAutoBindPairs) // fallback for createClass components
           );
+          const context = getMaskedContext(Component.contextTypes, unmaskedContext);
 
           if (!isStateful && typeof Component === 'function') {
             const wrappedEl = Object.assign(

--- a/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
+++ b/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
@@ -30,6 +30,7 @@ import {
   ensureKeyOrUndefined,
   simulateError,
   wrap,
+  getMaskedContext,
 } from 'enzyme-adapter-utils';
 import { findCurrentFiberUsingSlowPath } from 'react-reconciler/reflection';
 
@@ -317,7 +318,7 @@ class ReactSixteenTwoAdapter extends EnzymeAdapter {
     let isDOM = false;
     let cachedNode = null;
     return {
-      render(el, context) {
+      render(el, unmaskedContext) {
         cachedNode = el;
         /* eslint consistent-return: 0 */
         if (typeof el.type === 'string') {
@@ -330,6 +331,7 @@ class ReactSixteenTwoAdapter extends EnzymeAdapter {
             Component.prototype.isReactComponent
             || Array.isArray(Component.__reactAutoBindPairs) // fallback for createClass components
           );
+          const context = getMaskedContext(Component.contextTypes, unmaskedContext);
 
           if (!isStateful && typeof Component === 'function') {
             const wrappedEl = Object.assign(

--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -39,6 +39,7 @@ import {
   ensureKeyOrUndefined,
   simulateError,
   wrap,
+  getMaskedContext,
 } from 'enzyme-adapter-utils';
 import findCurrentFiberUsingSlowPath from './findCurrentFiberUsingSlowPath';
 import detectFiberTags from './detectFiberTags';
@@ -343,7 +344,7 @@ class ReactSixteenAdapter extends EnzymeAdapter {
     let isDOM = false;
     let cachedNode = null;
     return {
-      render(el, context) {
+      render(el, unmaskedContext) {
         cachedNode = el;
         /* eslint consistent-return: 0 */
         if (typeof el.type === 'string') {
@@ -357,6 +358,7 @@ class ReactSixteenAdapter extends EnzymeAdapter {
             || Array.isArray(Component.__reactAutoBindPairs) // fallback for createClass components
           );
 
+          const context = getMaskedContext(Component.contextTypes, unmaskedContext);
           if (!isStateful && typeof Component === 'function') {
             const wrappedEl = Object.assign(
               (...args) => Component(...args), // eslint-disable-line new-cap

--- a/packages/enzyme-adapter-utils/package.json
+++ b/packages/enzyme-adapter-utils/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "function.prototype.name": "^1.1.0",
     "object.assign": "^4.1.0",
+    "object.fromentries": "^2.0.0",
     "prop-types": "^15.6.2",
     "semver": "^5.6.0"
   },

--- a/packages/enzyme-adapter-utils/src/Utils.js
+++ b/packages/enzyme-adapter-utils/src/Utils.js
@@ -1,4 +1,5 @@
 import functionName from 'function.prototype.name';
+import fromEntries from 'object.fromentries';
 import createMountWrapper from './createMountWrapper';
 import createRenderWrapper from './createRenderWrapper';
 import wrap from './wrapWithSimpleWrapper';
@@ -278,4 +279,11 @@ export function simulateError(
   );
 
   componentDidCatch.call(catchingInstance, error, { componentStack });
+}
+
+export function getMaskedContext(contextTypes, unmaskedContext) {
+  if (!contextTypes || !unmaskedContext) {
+    return {};
+  }
+  return fromEntries(Object.keys(contextTypes).map(key => [key, unmaskedContext[key]]));
 }

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -4480,6 +4480,30 @@ describe('shallow', () => {
         expect(wrapper.context().name).to.equal(context.name);
         expect(wrapper.context('name')).to.equal(context.name);
       });
+
+      it('filters context to childContextTypes', () => {
+        class Bar extends React.Component {
+          render() {
+            return <div />;
+          }
+        }
+        Bar.contextTypes = {
+          name: PropTypes.string,
+        };
+        class Foo extends React.Component {
+          render() {
+            return (
+              <div>
+                <Bar />
+              </div>
+            );
+          }
+        }
+
+        const context = { name: 'foo', hello: 'world' };
+        const wrapper = shallow(<Foo />, { context });
+        expect(wrapper.find(Bar).dive().context()).to.eql({ name: 'foo' });
+      });
     });
 
     describeIf(is('> 0.13'), 'stateless function components', () => {

--- a/packages/enzyme-test-suite/test/adapter-utils-spec.jsx
+++ b/packages/enzyme-test-suite/test/adapter-utils-spec.jsx
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import {
   displayNameOfNode,
   ensureKeyOrUndefined,
+  getMaskedContext,
 } from 'enzyme-adapter-utils';
 
 import './_helpers/setupAdapters';
@@ -79,6 +80,38 @@ describe('enzyme-adapter-utils', () => {
     describe('given a DOM node', () => {
       it('returns the type', () => {
         expect(displayNameOfNode(<div />)).to.equal('div');
+      });
+    });
+  });
+
+  describe('getMaskedContext', () => {
+    const contextTypes = {
+      a() {},
+      c() {},
+    };
+    const unmaskedContext = {
+      a: 1,
+      b: 2,
+      c: 3,
+    };
+    const falsies = [undefined, null, false, '', NaN, 0];
+
+    it('returns an empty object with falsy `contextTypes`', () => {
+      falsies.forEach((falsy) => {
+        expect(getMaskedContext(falsy, unmaskedContext)).to.eql({});
+      });
+    });
+
+    it('returns an empty object with falsy `unmaskedContext`', () => {
+      falsies.forEach((falsy) => {
+        expect(getMaskedContext(contextTypes, falsy)).to.eql({});
+      });
+    });
+
+    it('filters `unmaskedContext` down to `contextTypes`', () => {
+      expect(getMaskedContext(contextTypes, unmaskedContext)).to.eql({
+        a: unmaskedContext.a,
+        c: unmaskedContext.c,
       });
     });
   });


### PR DESCRIPTION
Fixes #1590 

In `react-test-renderer@16.0 - 16.2` there's an issue where `context` is not filtered to a component's `childContextTypes`. This issue is not present in `react-test-renderer@<16` or `react-test-renderer@>=16.3`. This PR implements the same fix as `react-test-renderer@16.3` for enzyme adapters using `react-test-renderer` that have the issue.