### PR TITLE
Support getChildContext() in shallow render

### DIFF
--- a/packages/enzyme-adapter-react-13/src/ReactThirteenAdapter.js
+++ b/packages/enzyme-adapter-react-13/src/ReactThirteenAdapter.js
@@ -106,6 +106,7 @@ class ReactThirteenAdapter extends EnzymeAdapter {
     this.options = {
       ...this.options,
       supportPrevContextArgumentOfComponentDidUpdate: true, // TODO: remove, semver-major
+      legacyContextMode: 'owner',
       lifecycles: {
         ...lifecycles,
         componentDidUpdate: {

--- a/packages/enzyme-adapter-react-14/src/ReactFourteenAdapter.js
+++ b/packages/enzyme-adapter-react-14/src/ReactFourteenAdapter.js
@@ -79,10 +79,14 @@ class ReactFourteenAdapter extends EnzymeAdapter {
     this.options = {
       ...this.options,
       supportPrevContextArgumentOfComponentDidUpdate: true, // TODO: remove, semver-major
+      legacyContextMode: 'parent',
       lifecycles: {
         ...lifecycles,
         componentDidUpdate: {
           prevContext: true,
+        },
+        getChildContext: {
+          calledByRenderer: true,
         },
       },
     };

--- a/packages/enzyme-adapter-react-15.4/src/ReactFifteenFourAdapter.js
+++ b/packages/enzyme-adapter-react-15.4/src/ReactFifteenFourAdapter.js
@@ -114,10 +114,14 @@ class ReactFifteenFourAdapter extends EnzymeAdapter {
     this.options = {
       ...this.options,
       supportPrevContextArgumentOfComponentDidUpdate: true, // TODO: remove, semver-major
+      legacyContextMode: 'parent',
       lifecycles: {
         ...lifecycles,
         componentDidUpdate: {
           prevContext: true,
+        },
+        getChildContext: {
+          calledByRenderer: true,
         },
       },
     };

--- a/packages/enzyme-adapter-react-15/src/ReactFifteenAdapter.js
+++ b/packages/enzyme-adapter-react-15/src/ReactFifteenAdapter.js
@@ -114,10 +114,14 @@ class ReactFifteenAdapter extends EnzymeAdapter {
     this.options = {
       ...this.options,
       supportPrevContextArgumentOfComponentDidUpdate: true, // TODO: remove, semver-major
+      legacyContextMode: 'parent',
       lifecycles: {
         ...lifecycles,
         componentDidUpdate: {
           prevContext: true,
+        },
+        getChildContext: {
+          calledByRenderer: true,
         },
       },
     };

--- a/packages/enzyme-adapter-react-16.1/src/ReactSixteenOneAdapter.js
+++ b/packages/enzyme-adapter-react-16.1/src/ReactSixteenOneAdapter.js
@@ -7,6 +7,7 @@ import ReactDOMServer from 'react-dom/server';
 import ShallowRenderer from 'react-test-renderer/shallow';
 // eslint-disable-next-line import/no-unresolved
 import TestUtils from 'react-dom/test-utils';
+import checkPropTypes from 'prop-types/checkPropTypes';
 import {
   isElement,
   isPortal,
@@ -30,6 +31,7 @@ import {
   simulateError,
   wrap,
   getMaskedContext,
+  getComponentStack,
 } from 'enzyme-adapter-utils';
 import { findCurrentFiberUsingSlowPath } from 'react-reconciler/reflection';
 
@@ -414,6 +416,15 @@ class ReactSixteenOneAdapter extends EnzymeAdapter {
       batchedUpdates(fn) {
         return fn();
         // return ReactDOM.unstable_batchedUpdates(fn);
+      },
+      checkPropTypes(typeSpecs, values, location, hierarchy) {
+        return checkPropTypes(
+          typeSpecs,
+          values,
+          location,
+          displayNameOfNode(cachedNode),
+          () => getComponentStack(hierarchy.concat([cachedNode])),
+        );
       },
     };
   }

--- a/packages/enzyme-adapter-react-16.1/src/ReactSixteenOneAdapter.js
+++ b/packages/enzyme-adapter-react-16.1/src/ReactSixteenOneAdapter.js
@@ -234,6 +234,7 @@ class ReactSixteenOneAdapter extends EnzymeAdapter {
     const { lifecycles } = this.options;
     this.options = {
       ...this.options,
+      legacyContextMode: 'parent',
       lifecycles: {
         ...lifecycles,
         componentDidUpdate: {
@@ -241,6 +242,9 @@ class ReactSixteenOneAdapter extends EnzymeAdapter {
         },
         setState: {
           skipsComponentDidUpdateOnNullish: true,
+        },
+        getChildContext: {
+          calledByRenderer: false,
         },
       },
     };

--- a/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
+++ b/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
@@ -7,6 +7,7 @@ import ReactDOMServer from 'react-dom/server';
 import ShallowRenderer from 'react-test-renderer/shallow';
 // eslint-disable-next-line import/no-unresolved
 import TestUtils from 'react-dom/test-utils';
+import checkPropTypes from 'prop-types/checkPropTypes';
 import {
   isElement,
   isPortal,
@@ -31,6 +32,7 @@ import {
   simulateError,
   wrap,
   getMaskedContext,
+  getComponentStack,
 } from 'enzyme-adapter-utils';
 import { findCurrentFiberUsingSlowPath } from 'react-reconciler/reflection';
 
@@ -416,6 +418,15 @@ class ReactSixteenTwoAdapter extends EnzymeAdapter {
       batchedUpdates(fn) {
         return fn();
         // return ReactDOM.unstable_batchedUpdates(fn);
+      },
+      checkPropTypes(typeSpecs, values, location, hierarchy) {
+        return checkPropTypes(
+          typeSpecs,
+          values,
+          location,
+          displayNameOfNode(cachedNode),
+          () => getComponentStack(hierarchy.concat([cachedNode])),
+        );
       },
     };
   }

--- a/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
+++ b/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
@@ -236,6 +236,7 @@ class ReactSixteenTwoAdapter extends EnzymeAdapter {
     this.options = {
       ...this.options,
       enableComponentDidUpdateOnSetState: true, // TODO: remove, semver-major
+      legacyContextMode: 'parent',
       lifecycles: {
         ...lifecycles,
         componentDidUpdate: {
@@ -243,6 +244,9 @@ class ReactSixteenTwoAdapter extends EnzymeAdapter {
         },
         setState: {
           skipsComponentDidUpdateOnNullish: true,
+        },
+        getChildContext: {
+          calledByRenderer: false,
         },
       },
     };

--- a/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
+++ b/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
@@ -237,6 +237,7 @@ class ReactSixteenThreeAdapter extends EnzymeAdapter {
     this.options = {
       ...this.options,
       enableComponentDidUpdateOnSetState: true, // TODO: remove, semver-major
+      legacyContextMode: 'parent',
       lifecycles: {
         ...lifecycles,
         componentDidUpdate: {
@@ -246,6 +247,9 @@ class ReactSixteenThreeAdapter extends EnzymeAdapter {
         getSnapshotBeforeUpdate: true,
         setState: {
           skipsComponentDidUpdateOnNullish: true,
+        },
+        getChildContext: {
+          calledByRenderer: false,
         },
       },
     };

--- a/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
+++ b/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
@@ -8,6 +8,7 @@ import ReactDOMServer from 'react-dom/server';
 import ShallowRenderer from 'react-test-renderer/shallow';
 // eslint-disable-next-line import/no-unresolved
 import TestUtils from 'react-dom/test-utils';
+import checkPropTypes from 'prop-types/checkPropTypes';
 import {
   isElement,
   isPortal,
@@ -37,6 +38,7 @@ import {
   ensureKeyOrUndefined,
   simulateError,
   wrap,
+  getComponentStack,
 } from 'enzyme-adapter-utils';
 import { findCurrentFiberUsingSlowPath } from 'react-reconciler/reflection';
 
@@ -394,6 +396,15 @@ class ReactSixteenThreeAdapter extends EnzymeAdapter {
       batchedUpdates(fn) {
         return fn();
         // return ReactDOM.unstable_batchedUpdates(fn);
+      },
+      checkPropTypes(typeSpecs, values, location, hierarchy) {
+        return checkPropTypes(
+          typeSpecs,
+          values,
+          location,
+          displayNameOfNode(cachedNode),
+          () => getComponentStack(hierarchy.concat([cachedNode])),
+        );
       },
     };
   }

--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -257,6 +257,7 @@ class ReactSixteenAdapter extends EnzymeAdapter {
     this.options = {
       ...this.options,
       enableComponentDidUpdateOnSetState: true, // TODO: remove, semver-major
+      legacyContextMode: 'parent',
       lifecycles: {
         ...lifecycles,
         componentDidUpdate: {
@@ -266,6 +267,9 @@ class ReactSixteenAdapter extends EnzymeAdapter {
         getSnapshotBeforeUpdate: true,
         setState: {
           skipsComponentDidUpdateOnNullish: true,
+        },
+        getChildContext: {
+          calledByRenderer: false,
         },
       },
     };

--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -8,6 +8,7 @@ import ReactDOMServer from 'react-dom/server';
 import ShallowRenderer from 'react-test-renderer/shallow';
 // eslint-disable-next-line import/no-unresolved
 import TestUtils from 'react-dom/test-utils';
+import checkPropTypes from 'prop-types/checkPropTypes';
 import {
   isElement,
   isPortal,
@@ -40,6 +41,7 @@ import {
   simulateError,
   wrap,
   getMaskedContext,
+  getComponentStack,
 } from 'enzyme-adapter-utils';
 import findCurrentFiberUsingSlowPath from './findCurrentFiberUsingSlowPath';
 import detectFiberTags from './detectFiberTags';
@@ -442,6 +444,15 @@ class ReactSixteenAdapter extends EnzymeAdapter {
       batchedUpdates(fn) {
         return fn();
         // return ReactDOM.unstable_batchedUpdates(fn);
+      },
+      checkPropTypes(typeSpecs, values, location, hierarchy) {
+        return checkPropTypes(
+          typeSpecs,
+          values,
+          location,
+          displayNameOfNode(cachedNode),
+          () => getComponentStack(hierarchy.concat([cachedNode])),
+        );
       },
     };
   }

--- a/packages/enzyme-adapter-utils/src/Utils.js
+++ b/packages/enzyme-adapter-utils/src/Utils.js
@@ -240,7 +240,7 @@ export function propsWithKeysAndRef(node) {
   return node.props;
 }
 
-function getComponentStack(
+export function getComponentStack(
   hierarchy,
   getNodeType = nodeTypeFromType,
   getDisplayName = displayNameOfNode,


### PR DESCRIPTION
Fixes #664

This PR adds support for `getChildContext()` when shallow-rendering. I've decided to only implement parent-based context, not owner-based context (as I'm not exactly sure what that behavior is, tbh) which means I've excluded `react@0.13` from this implementation. (Hope that's okay!)

In `react@<=15`, the react shallow renderer actually calls `getChildContext()` for us! This means, as is the case with `shouldComponentUpdate()`, we just spy on that method's return value.

In `react@>=16`, `getChildContext()` is _not_ called (understandable—it's a deprecated API), so we have to call it ourselves.

P.S. Sorry the diff is a little ugly. I ended up messing with the nesting of some conditionals to avoid duplicated checks.