### PR TITLE
Upgrade eslint-plugin-react in packages

### DIFF
--- a/packages/enzyme-adapter-react-13/package.json
+++ b/packages/enzyme-adapter-react-13/package.json
@@ -52,7 +52,7 @@
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
-    "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react": "^7.12.3",
     "in-publish": "^2.0.0",
     "rimraf": "^2.6.2",
     "safe-publish-latest": "^1.1.2"

--- a/packages/enzyme-adapter-react-14/package.json
+++ b/packages/enzyme-adapter-react-14/package.json
@@ -55,7 +55,7 @@
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
-    "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react": "^7.12.3",
     "in-publish": "^2.0.0",
     "rimraf": "^2.6.2",
     "safe-publish-latest": "^1.1.2"

--- a/packages/enzyme-adapter-react-15.4/package.json
+++ b/packages/enzyme-adapter-react-15.4/package.json
@@ -56,7 +56,7 @@
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
-    "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react": "^7.12.3",
     "in-publish": "^2.0.0",
     "rimraf": "^2.6.2",
     "safe-publish-latest": "^1.1.2"

--- a/packages/enzyme-adapter-react-15/package.json
+++ b/packages/enzyme-adapter-react-15/package.json
@@ -55,7 +55,7 @@
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
-    "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react": "^7.12.3",
     "in-publish": "^2.0.0",
     "rimraf": "^2.6.2",
     "safe-publish-latest": "^1.1.2"

--- a/packages/enzyme-adapter-react-16.1/package.json
+++ b/packages/enzyme-adapter-react-16.1/package.json
@@ -55,7 +55,7 @@
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
-    "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react": "^7.12.3",
     "in-publish": "^2.0.0",
     "rimraf": "^2.6.2",
     "safe-publish-latest": "^1.1.2"

--- a/packages/enzyme-adapter-react-16.2/package.json
+++ b/packages/enzyme-adapter-react-16.2/package.json
@@ -56,7 +56,7 @@
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
-    "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react": "^7.12.3",
     "in-publish": "^2.0.0",
     "rimraf": "^2.6.2",
     "safe-publish-latest": "^1.1.2"

--- a/packages/enzyme-adapter-react-16.3/package.json
+++ b/packages/enzyme-adapter-react-16.3/package.json
@@ -57,7 +57,7 @@
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
-    "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react": "^7.12.3",
     "in-publish": "^2.0.0",
     "rimraf": "^2.6.2",
     "safe-publish-latest": "^1.1.2"

--- a/packages/enzyme-adapter-react-16/package.json
+++ b/packages/enzyme-adapter-react-16/package.json
@@ -56,7 +56,7 @@
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
-    "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react": "^7.12.3",
     "in-publish": "^2.0.0",
     "rimraf": "^2.6.2",
     "safe-publish-latest": "^1.1.2"

--- a/packages/enzyme-adapter-react-helper/package.json
+++ b/packages/enzyme-adapter-react-helper/package.json
@@ -46,7 +46,7 @@
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
-    "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react": "^7.12.3",
     "in-publish": "^2.0.0",
     "react": "0.13.x || 0.14.x || ^15.0.0-0 || ^16.0.0-0 || ^16.3.0-0 || ^16.4.0-0",
     "safe-publish-latest": "^1.1.2"

--- a/packages/enzyme-adapter-utils/package.json
+++ b/packages/enzyme-adapter-utils/package.json
@@ -50,7 +50,7 @@
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
-    "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react": "^7.12.3",
     "in-publish": "^2.0.0",
     "rimraf": "^2.6.2",
     "safe-publish-latest": "^1.1.2"

--- a/packages/enzyme-example-mocha/package.json
+++ b/packages/enzyme-example-mocha/package.json
@@ -25,7 +25,7 @@
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
-    "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react": "^7.12.3",
     "espree": "^4.1.0",
     "in-publish": "^2.0.0",
     "jsdom": "^11.5.1",

--- a/packages/enzyme-test-suite/package.json
+++ b/packages/enzyme-test-suite/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-mocha": "^5.2.0",
-    "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react": "^7.12.3",
     "react-is": "^16.7.0"
   }
 }

--- a/packages/enzyme/package.json
+++ b/packages/enzyme/package.json
@@ -62,7 +62,7 @@
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
-    "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react": "^7.12.3",
     "in-publish": "^2.0.0",
     "jsdom": "^6.5.1",
     "rimraf": "^2.6.2",


### PR DESCRIPTION
I started getting tired of seeing the red x next to my builds so I decided to figure out why the linter was failing. Lo and behold, @ljharb fixed the issue in `eslint-plugin-react` a few days ago!

It looks like you upgraded the dependency in the top-level `package.json`, but not in the child packages, so I figured I'd help you out with that chore.

P.S. I believe it is also a common monorepo pattern to only declare `devDependencies` in the top-level `package.json`. We could also move to that pattern to avoid chores like this in the future.