### PR TITLE
Support React.lazy and React.Suspense

### DIFF
--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -50,8 +50,9 @@ describe('<MyComponent />', () => {
   - `options.disableLifecycleMethods`: (`Boolean` [optional]): If set to true, `componentDidMount`
 is not called on the component, and `componentDidUpdate` is not called after
 [`setProps`](ShallowWrapper/setProps.md) and [`setContext`](ShallowWrapper/setContext.md). Default to `false`.
-- `options.wrappingComponent`: (`ComponentType` [optional]): A component that will render as a parent of the `node`. It can be used to provide context to the `node`, among other things. See the [`getWrappingComponent()` docs](ShallowWrapper/getWrappingComponent.md) for an example. **Note**: `wrappingComponent` _must_ render its children.
-- `options.wrappingComponentProps`: (`Object` [optional]): Initial props to pass to the `wrappingComponent` if it is specified.
+  - `options.wrappingComponent`: (`ComponentType` [optional]): A component that will render as a parent of the `node`. It can be used to provide context to the `node`, among other things. See the [`getWrappingComponent()` docs](ShallowWrapper/getWrappingComponent.md) for an example. **Note**: `wrappingComponent` _must_ render its children.
+  - `options.wrappingComponentProps`: (`Object` [optional]): Initial props to pass to the `wrappingComponent` if it is specified.
+  - `options.suspenseFallback`: (`Boolean` [optional]): If set to true, when rendering `Suspense` enzyme will replace all the lazy components in children with `fallback` element prop. Otherwise it won't handle fallback of lazy component. Default to `true`. Note: not supported in React < 16.6.
 
 #### Returns
 

--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -754,11 +754,7 @@ class ReactSixteenAdapter extends EnzymeAdapter {
         return name ? `ForwardRef(${name})` : 'ForwardRef';
       }
       case Lazy || NaN: {
-        if (type.displayName) {
-          return type.displayName;
-        }
-        const name = displayNameOfNode({ type: type._result });
-        return name ? `lazy(${name})` : 'lazy';
+        return 'lazy';
       }
       default: return displayNameOfNode(node);
     }

--- a/packages/enzyme-adapter-react-16/src/detectFiberTags.js
+++ b/packages/enzyme-adapter-react-16/src/detectFiberTags.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { fakeDynamicImport } from 'enzyme-adapter-utils';
 
 function getFiber(element) {
   const container = global.document.createElement('div');
@@ -14,12 +15,38 @@ function getFiber(element) {
   return inst._reactInternalFiber.child;
 }
 
+function getLazyFiber(LazyComponent) {
+  const container = global.document.createElement('div');
+  let inst = null;
+  // eslint-disable-next-line react/prefer-stateless-function
+  class Tester extends React.Component {
+    render() {
+      inst = this;
+      return React.createElement(LazyComponent);
+    }
+  }
+  // eslint-disable-next-line react/prefer-stateless-function
+  class SuspenseWrapper extends React.Component {
+    render() {
+      return React.createElement(
+        React.Suspense,
+        { fallback: false },
+        React.createElement(Tester),
+      );
+    }
+  }
+  ReactDOM.render(React.createElement(SuspenseWrapper), container);
+  return inst._reactInternalFiber.child;
+}
+
 module.exports = function detectFiberTags() {
   const supportsMode = typeof React.StrictMode !== 'undefined';
   const supportsContext = typeof React.createContext !== 'undefined';
   const supportsForwardRef = typeof React.forwardRef !== 'undefined';
   const supportsMemo = typeof React.memo !== 'undefined';
   const supportsProfiler = typeof React.unstable_Profiler !== 'undefined';
+  const supportsSuspense = typeof React.Suspense !== 'undefined';
+  const supportsLazy = typeof React.lazy !== 'undefined';
 
   function Fn() {
     return null;
@@ -32,6 +59,7 @@ module.exports = function detectFiberTags() {
   }
   let Ctx = null;
   let FwdRef = null;
+  let LazyComponent = null;
   if (supportsContext) {
     Ctx = React.createContext();
   }
@@ -39,6 +67,9 @@ module.exports = function detectFiberTags() {
     // React will warn if we don't have both arguments.
     // eslint-disable-next-line no-unused-vars
     FwdRef = React.forwardRef((props, ref) => null);
+  }
+  if (supportsLazy) {
+    LazyComponent = React.lazy(() => fakeDynamicImport(() => null));
   }
 
   return {
@@ -69,6 +100,12 @@ module.exports = function detectFiberTags() {
       : -1,
     Profiler: supportsProfiler
       ? getFiber(React.createElement(React.unstable_Profiler, { id: 'mock', onRender() {} })).tag
+      : -1,
+    Suspense: supportsSuspense
+      ? getFiber(React.createElement(React.Suspense, { fallback: false })).tag
+      : -1,
+    Lazy: supportsLazy
+      ? getLazyFiber(LazyComponent).tag
       : -1,
   };
 };

--- a/packages/enzyme-adapter-utils/src/Utils.js
+++ b/packages/enzyme-adapter-utils/src/Utils.js
@@ -363,3 +363,7 @@ export function getWrappingComponentMountRenderer({ toTree, getMountWrapperInsta
     },
   };
 }
+
+export function fakeDynamicImport(moduleToImport) {
+  return Promise.resolve({ default: moduleToImport });
+}

--- a/packages/enzyme-test-suite/test/Adapter-spec.jsx
+++ b/packages/enzyme-test-suite/test/Adapter-spec.jsx
@@ -1079,42 +1079,6 @@ describe('Adapter', () => {
       const LazyComponent = lazy(() => fakeDynamicImport(DynamicComponent));
       expect(getDisplayName(<LazyComponent />)).to.equal('lazy');
     });
-
-    itIf(is('>= 16.6'), 'show explicitly defined display name of lazy component', () => {
-      class DynamicComponent extends React.Component {
-        render() {
-          return <div>DynamicComponent</div>;
-        }
-      }
-      const theDisplayName = 'SOMETHING';
-      const LazyComponent = Object.assign(lazy(() => fakeDynamicImport(DynamicComponent)), { displayName: theDisplayName });
-      expect(getDisplayName(<LazyComponent />)).to.equal(theDisplayName);
-    });
-
-    itIf(is('>= 16.6'), 'show display name of wrapped component of lazy', () => {
-      class ComponentWithDisplayName extends React.Component {
-        render() {
-          return <div>DynamicComponent</div>;
-        }
-      }
-      ComponentWithDisplayName.displayName = 'Something';
-      const LazyComponent = lazy(() => fakeDynamicImport(ComponentWithDisplayName));
-      /* eslint-disable no-underscore-dangle */
-      LazyComponent._result = ComponentWithDisplayName;
-      expect(getDisplayName(<LazyComponent />)).to.equal(`lazy(${ComponentWithDisplayName.displayName})`);
-    });
-
-    itIf(is('>= 16.6'), 'show name of wrapped component of lazy if its displayName is empty', () => {
-      class ComponentWithoutDisplayName extends React.Component {
-        render() {
-          return <div>DynamicComponent</div>;
-        }
-      }
-      const LazyComponent = lazy(() => fakeDynamicImport(ComponentWithoutDisplayName));
-      /* eslint-disable no-underscore-dangle */
-      LazyComponent._result = ComponentWithoutDisplayName;
-      expect(getDisplayName(<LazyComponent />)).to.equal('lazy(ComponentWithoutDisplayName)');
-    });
   });
 
   describeIf(is('>= 16.2'), 'determines if node isFragment', () => {

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -1688,20 +1688,6 @@ describe('shallow', () => {
       expect(wrapper.debug()).to.equal('<lazy />');
     });
 
-    it('returns lazy component string including wrapped component when debug() is called and lazy component is loaded', () => {
-      const LazyComponent = lazy(fakeDynamicImport(DynamicComponent));
-      /* eslint-disable no-underscore-dangle */
-      LazyComponent._result = DynamicComponent;
-
-      const wrapper = shallow((
-        <Suspense fallback={<Fallback />}>
-          <LazyComponent />
-        </Suspense>
-      ));
-
-      expect(wrapper.debug()).to.equal('<lazy(DynamicComponent) />');
-    });
-
     it('replaces LazyComponent with Fallback when render Suspense if options.suspenseFallback=true', () => {
       const LazyComponent = lazy(fakeDynamicImport(DynamicComponent));
 

--- a/packages/enzyme-test-suite/test/_helpers/getLoadedLazyComponent.js
+++ b/packages/enzyme-test-suite/test/_helpers/getLoadedLazyComponent.js
@@ -1,0 +1,31 @@
+import { fakeDynamicImport } from 'enzyme-adapter-utils';
+import { lazy } from './react-compat';
+import { is, VERSION } from './version';
+
+function fakeSyncThenable(result) {
+  return {
+    then(resolve) {
+      return resolve({ default: result });
+    },
+  };
+}
+
+export default function getLoadedLazyComponent(wrappedComponent) {
+  if (is('>= 16.8')) {
+    return lazy(() => fakeSyncThenable(wrappedComponent));
+  }
+  if (is('>= 16.6')) {
+    const LazyComponent = lazy(() => fakeDynamicImport(wrappedComponent));
+    /**
+     * Before React v16.8 there's no public api to synchronously / await
+     * loaded lazy component.
+     * So we have to hack this by setting `_result` and `_status` implementation.
+     */
+    /* eslint-disable no-underscore-dangle */
+    LazyComponent._result = wrappedComponent;
+    /* eslint-disable no-underscore-dangle */
+    LazyComponent._status = 1;
+    return LazyComponent;
+  }
+  throw Error(`Current React version ${VERSION} doesn't support \`lazy()\` api.`);
+}

--- a/packages/enzyme-test-suite/test/adapter-utils-spec.jsx
+++ b/packages/enzyme-test-suite/test/adapter-utils-spec.jsx
@@ -12,6 +12,7 @@ import {
   getNodeFromRootFinder,
   wrapWithWrappingComponent,
   getWrappingComponentMountRenderer,
+  fakeDynamicImport,
 } from 'enzyme-adapter-utils';
 
 import './_helpers/setupAdapters';
@@ -375,6 +376,24 @@ describe('enzyme-adapter-utils', () => {
       it('throws an error if there is no instance', () => {
         instance = undefined;
         expect(() => renderer.render(<div />, null, () => {})).to.throw('The wrapping component may not be updated if the root is unmounted.');
+      });
+    });
+  });
+
+  describe('fakeDynamicImport', () => {
+    it('is a function', () => {
+      expect(fakeDynamicImport).to.be.a('function');
+    });
+
+    it('returns a promise', () => {
+      const promise = fakeDynamicImport();
+      expect(Promise.resolve(promise)).to.equal(promise);
+    });
+
+    it('returns a promise for an object containing the provided argument', () => {
+      const signal = {};
+      return fakeDynamicImport(signal).then((actual) => {
+        expect(actual).to.have.property('default', signal);
       });
     });
   });

--- a/packages/enzyme-test-suite/test/staticRender-spec.jsx
+++ b/packages/enzyme-test-suite/test/staticRender-spec.jsx
@@ -3,11 +3,12 @@ import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { render } from 'enzyme';
 import renderEntry from 'enzyme/render';
+import { fakeDynamicImport } from 'enzyme-adapter-utils';
 
 import './_helpers/setupAdapters';
 import { describeWithDOM, describeIf } from './_helpers';
 import { is } from './_helpers/version';
-import { createClass } from './_helpers/react-compat';
+import { createClass, lazy } from './_helpers/react-compat';
 
 describeWithDOM('render', () => {
   describe('top level entry points', () => {
@@ -78,6 +79,20 @@ describeWithDOM('render', () => {
 
       const context = { name: 'foo' };
       expect(() => render(<SimpleComponent />, { context })).to.not.throw(Error);
+    });
+  });
+
+  describeIf(is('> 16.6'), 'suspense fallback option', () => {
+    it('throws if options.suspenseFallback is specified', () => {
+      class DynamicComponent extends React.Component {
+        render() {
+          return (
+            <div>Dynamic Component</div>
+          );
+        }
+      }
+      const LazyComponent = lazy(fakeDynamicImport(DynamicComponent));
+      expect(() => render(<LazyComponent />, { suspenseFallback: false })).to.throw();
     });
   });
 });


### PR DESCRIPTION
Fixes #1917 .

Given a component wrapped by `React.lazy` in `<Suspense />`
It'll plainly render a `<Lazy />` in `shallow` and render fallback component in mount.

There are something I'm not sure / still working on:

1. What should `displayName` of the component returned by `React.lazy` be? Currently I directly named it as `Lazy`. Not sure if it's something we could define by ourselves.

2. I'm trying to add an `waitUntilLazyLoaded()` on `ReactWrapper`, which will return a promise resolving when the dynamic import loaded and React trigger the re-render, so we can write some tests like:

```jsx

const LazyComponent = lazy(() => import('/path/to/dynamic/component'));
const Fallback = () => <div />;
const SuspenseComponent = () => (
    <Suspense fallback={<Fallback />}>
      <LazyComponent />
    </Suspense>
);

const wrapper = mount(<SuspenseComponent />)
await wrapper.waitUntilLazyLoaded()

expect(wrapper.find('DynamicComponent').to.have.lengthOf(1)

```

But I don't know how to detect if all the lazy loaded component inside `<Suspense />` has completeted loading. It looks like that we have to hack around react fiber. @ljharb Would you know any way to detect this?

Also note that this PR add `babel-plugin-dynamic-import-node` and `babel-plugin-syntax-dynamic-import` for using `import()`, `babel-eslint` in `enzyme-adapter-react-16` and `enzyme-test-suite` for dynamic import support of eslint.