### PR TITLE
[Fix] `shallow`: ensure SCU is called after GDSFP returns null

### DIFF
--- a/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
+++ b/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
@@ -251,7 +251,9 @@ class ReactSixteenThreeAdapter extends EnzymeAdapter {
         componentDidUpdate: {
           onSetState: true,
         },
-        getDerivedStateFromProps: true,
+        getDerivedStateFromProps: {
+          hasShouldComponentUpdateBug: true,
+        },
         getSnapshotBeforeUpdate: true,
         setState: {
           skipsComponentDidUpdateOnNullish: true,

--- a/packages/enzyme-adapter-react-16/package.json
+++ b/packages/enzyme-adapter-react-16/package.json
@@ -40,7 +40,8 @@
     "object.values": "^1.1.0",
     "prop-types": "^15.7.2",
     "react-is": "^16.7.0",
-    "react-test-renderer": "^16.0.0-0"
+    "react-test-renderer": "^16.0.0-0",
+    "semver": "^5.6.0"
   },
   "peerDependencies": {
     "enzyme": "^3.0.0",

--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -5,8 +5,10 @@ import ReactDOM from 'react-dom';
 import ReactDOMServer from 'react-dom/server';
 // eslint-disable-next-line import/no-unresolved
 import ShallowRenderer from 'react-test-renderer/shallow';
+import { version as testRendererVersion } from 'react-test-renderer/package';
 // eslint-disable-next-line import/no-unresolved
 import TestUtils from 'react-dom/test-utils';
+import semver from 'semver';
 import checkPropTypes from 'prop-types/checkPropTypes';
 import {
   isElement,
@@ -51,6 +53,8 @@ const is164 = !!TestUtils.Simulate.touchStart; // 16.4+
 const is165 = !!TestUtils.Simulate.auxClick; // 16.5+
 const is166 = is165 && !React.unstable_AsyncMode; // 16.6+
 const is168 = is166 && typeof TestUtils.act === 'function';
+
+const hasShouldComponentUpdateBug = semver.satisfies(testRendererVersion, '< 16.8');
 
 // Lazily populated if DOM is available.
 let FiberTags = null;
@@ -303,7 +307,7 @@ class ReactSixteenAdapter extends EnzymeAdapter {
           onSetState: true,
         },
         getDerivedStateFromProps: {
-          hasShouldComponentUpdateBug: !is168,
+          hasShouldComponentUpdateBug,
         },
         getSnapshotBeforeUpdate: true,
         setState: {

--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -50,6 +50,7 @@ import detectFiberTags from './detectFiberTags';
 const is164 = !!TestUtils.Simulate.touchStart; // 16.4+
 const is165 = !!TestUtils.Simulate.auxClick; // 16.5+
 const is166 = is165 && !React.unstable_AsyncMode; // 16.6+
+const is168 = is166 && typeof TestUtils.act === 'function';
 
 // Lazily populated if DOM is available.
 let FiberTags = null;
@@ -280,7 +281,7 @@ function getEmptyStateValue() {
 }
 
 function wrapAct(fn) {
-  if (typeof TestUtils.act !== 'function') {
+  if (!is168) {
     return fn();
   }
   let returnVal;
@@ -301,7 +302,9 @@ class ReactSixteenAdapter extends EnzymeAdapter {
         componentDidUpdate: {
           onSetState: true,
         },
-        getDerivedStateFromProps: true,
+        getDerivedStateFromProps: {
+          hasShouldComponentUpdateBug: !is168,
+        },
         getSnapshotBeforeUpdate: true,
         setState: {
           skipsComponentDidUpdateOnNullish: true,

--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -5774,7 +5774,7 @@ describeWithDOM('mount', () => {
         ]);
       });
 
-      it('calls GDSFP when expected', () => {
+      it('calls gDSFP when expected', () => {
         const prevProps = { a: 1 };
         const state = { state: true };
         const wrapper = mount(<GDSFP {...prevProps} />);
@@ -5820,6 +5820,35 @@ describeWithDOM('mount', () => {
             prevContext: is('>= 16') ? undefined : prevContext,
           }],
         ]);
+      });
+
+      it('cDU’s nextState differs from `this.state` when gDSFP returns new state', () => {
+        class SimpleComponent extends React.Component {
+          constructor(props) {
+            super(props);
+            this.state = { value: props.value };
+          }
+
+          static getDerivedStateFromProps(props, state) {
+            return props.value === state.value ? null : { value: props.value };
+          }
+
+          shouldComponentUpdate(nextProps, nextState) {
+            return nextState.value !== this.state.value;
+          }
+
+          render() {
+            const { value } = this.state;
+            return (<input value={value} />);
+          }
+        }
+        const wrapper = mount(<SimpleComponent value="initial" />);
+
+        expect(wrapper.find('input').prop('value')).to.equal('initial');
+
+        wrapper.setProps({ value: 'updated' });
+
+        expect(wrapper.find('input').prop('value')).to.equal('updated');
       });
     });
 

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -6114,7 +6114,7 @@ describe('shallow', () => {
         ]);
       });
 
-      it('calls GDSFP when expected', () => {
+      it('calls gDSFP when expected', () => {
         const prevProps = { a: 1 };
         const state = { state: true };
         const wrapper = shallow(<GDSFP {...prevProps} />);
@@ -6160,6 +6160,35 @@ describe('shallow', () => {
             prevContext: is('>= 16') ? undefined : prevContext,
           }],
         ]);
+      });
+
+      it('cDU’s nextState differs from `this.state` when gDSFP returns new state', () => {
+        class SimpleComponent extends React.Component {
+          constructor(props) {
+            super(props);
+            this.state = { value: props.value };
+          }
+
+          static getDerivedStateFromProps(props, state) {
+            return props.value === state.value ? null : { value: props.value };
+          }
+
+          shouldComponentUpdate(nextProps, nextState) {
+            return nextState.value !== this.state.value;
+          }
+
+          render() {
+            const { value } = this.state;
+            return (<input value={value} />);
+          }
+        }
+        const wrapper = shallow(<SimpleComponent value="initial" />);
+
+        expect(wrapper.find('input').prop('value')).to.equal('initial');
+
+        wrapper.setProps({ value: 'updated' });
+
+        expect(wrapper.find('input').prop('value')).to.equal('updated');
       });
     });
 

--- a/packages/enzyme-test-suite/test/Utils-spec.jsx
+++ b/packages/enzyme-test-suite/test/Utils-spec.jsx
@@ -787,6 +787,27 @@ describe('Utils', () => {
       spy.restore();
       expect(Object.getOwnPropertyDescriptor(obj, 'method')).to.deep.equal(descriptor);
     });
+
+    it('accepts an optional `getStub` argument', () => {
+      const obj = {};
+      const descriptor = {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: () => {},
+      };
+      Object.defineProperty(obj, 'method', descriptor);
+      let stub;
+      let original;
+      spyMethod(obj, 'method', (originalMethod) => {
+        original = originalMethod;
+        stub = () => { throw new EvalError('stubbed'); };
+        return stub;
+      });
+      expect(original).to.equal(descriptor.value);
+      expect(obj).to.have.property('method', stub);
+      expect(() => obj.method()).to.throw(EvalError);
+    });
   });
 
   describe('isCustomComponentElement()', () => {

--- a/packages/enzyme/src/Utils.js
+++ b/packages/enzyme/src/Utils.js
@@ -282,7 +282,7 @@ export function cloneElement(adapter, el, props) {
   );
 }
 
-export function spyMethod(instance, methodName) {
+export function spyMethod(instance, methodName, getStub = () => {}) {
   let lastReturnValue;
   const originalMethod = instance[methodName];
   const hasOwn = has(instance, methodName);
@@ -293,7 +293,7 @@ export function spyMethod(instance, methodName) {
   Object.defineProperty(instance, methodName, {
     configurable: true,
     enumerable: !descriptor || !!descriptor.enumerable,
-    value(...args) {
+    value: getStub(originalMethod) || function spied(...args) {
       const result = originalMethod.apply(this, args);
       lastReturnValue = result;
       return result;


### PR DESCRIPTION
Prevent forgetting PR for #1970 😓  . I've added test case in this PR(should fail now).
Wait for release of facebook/react#14613 and we can update react-test-renderer in dependency.

Fixes #1970.