### PR TITLE
Make sure findWhere doesn't get stuck on empty string

### DIFF
--- a/packages/enzyme-test-suite/test/RSTTraversal-spec.jsx
+++ b/packages/enzyme-test-suite/test/RSTTraversal-spec.jsx
@@ -350,10 +350,11 @@ describe('RSTTraversal', () => {
       const node = $((
         <div>
           <p>{''}</p>
+          <p>Test</p>
         </div>
       ));
       treeForEach(node, spy);
-      expect(spy).to.have.property('callCount', 3);
+      expect(spy).to.have.property('callCount', 4); // div, p, p, 'Test'
     });
 
     it('passes in the node', () => {

--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -1721,6 +1721,39 @@ describeWithDOM('mount', () => {
       expect(foundNotSpan).to.have.lengthOf(0);
     });
 
+    it('does not get trapped when conditionally rendering using an empty string variable as the condition', () => {
+      const emptyString = '';
+
+      class Foo extends React.Component {
+        render() {
+          return (
+            <div>
+              <header>
+                <span />
+                {emptyString && <i />}
+              </header>
+              <div>
+                <span data-foo={this.props.selector}>Test</span>
+              </div>
+            </div>
+          );
+        }
+      }
+
+      const selector = 'blah';
+      const wrapper = mount(<Foo selector={selector} />);
+      const foundSpan = wrapper.findWhere(n => (
+        n.type() === 'span'
+        && n.props()['data-foo'] === selector
+      ));
+
+      expect(foundSpan.debug()).to.equal((
+        `<span data-foo="${selector}">
+  Test
+</span>`
+      ));
+    });
+
     it('returns props object when props() is called', () => {
       class Foo extends React.Component {
         render() {

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -1584,7 +1584,7 @@ describe('shallow', () => {
       const stub = sinon.stub();
       wrapper.findWhere(stub);
       const passedNodeLengths = stub.getCalls().map(({ args: [firstArg] }) => firstArg.length);
-      expect(passedNodeLengths).to.eql([1, 1]);
+      expect(passedNodeLengths).to.eql([1]);
     });
 
     it('calls the predicate with the wrapped node as the first argument', () => {
@@ -1695,6 +1695,39 @@ describe('shallow', () => {
         n.type() !== 'span' && n.props()['data-foo'] === selector
       ));
       expect(foundNotSpan).to.have.lengthOf(0);
+    });
+
+    it('does not get trapped when conditionally rendering using an empty string variable as the condition', () => {
+      const emptyString = '';
+
+      class Foo extends React.Component {
+        render() {
+          return (
+            <div>
+              <header>
+                <span />
+                {emptyString && <i />}
+              </header>
+              <div>
+                <span data-foo={this.props.selector}>Test</span>
+              </div>
+            </div>
+          );
+        }
+      }
+
+      const selector = 'blah';
+      const wrapper = shallow(<Foo selector={selector} />);
+      const foundSpan = wrapper.findWhere(n => (
+        n.type() === 'span'
+        && n.props()['data-foo'] === selector
+      ));
+
+      expect(foundSpan.debug()).to.equal((
+        `<span data-foo="${selector}">
+  Test
+</span>`
+      ));
     });
 
     it('returns props object when props() is called', () => {

--- a/packages/enzyme/src/RSTTraversal.js
+++ b/packages/enzyme/src/RSTTraversal.js
@@ -40,7 +40,7 @@ export function hasClassName(node, className) {
 }
 
 export function treeForEach(tree, fn) {
-  if (tree !== null && tree !== false && typeof tree !== 'undefined') {
+  if (tree) {
     fn(tree);
   }
   childrenOfNode(tree).forEach(node => treeForEach(node, fn));


### PR DESCRIPTION
# What
- Add a `findWhere` test case that replicates the use case I ran into
- Update `RSTTraversal.treeForEach` to not call `fn` on empty strings
- Update `treeForEach` test case that references empty strings

# Why
In the event that the DOM has an empty string, make sure `findWhere` can iterate past it and still find elements that are further down the tree.

## Links
- Fixes #1994
- [Codesandbox](https://codesandbox.io/s/jp4vnqy2n3?expanddevtools=1&module=%2Fsrc%2FHello.js&previewwindow=tests) that replicates the initial issue I had