### PR TITLE
Make nodeToHostNode handle arrays

### DIFF
--- a/packages/enzyme-adapter-react-16.1/src/ReactSixteenOneAdapter.js
+++ b/packages/enzyme-adapter-react-16.1/src/ReactSixteenOneAdapter.js
@@ -201,13 +201,15 @@ function nodeToHostNode(_node) {
   while (node && !Array.isArray(node) && node.instance === null) {
     node = node.rendered;
   }
-  if (Array.isArray(node)) {
-    // TODO(lmr): throw warning regarding not being able to get a host node here
-    throw new Error('Trying to get host node of an array');
-  }
   // if the SFC returned null effectively, there is no host node.
   if (!node) {
     return null;
+  }
+  if (Array.isArray(node)) {
+    return node.map(item => ReactDOM.findDOMNode(item.instance));
+  }
+  if (Array.isArray(node.rendered) && node.nodeType === 'class') {
+    return node.rendered.map(item => ReactDOM.findDOMNode(item.instance));
   }
   return ReactDOM.findDOMNode(node.instance);
 }

--- a/packages/enzyme-adapter-react-16.1/src/ReactSixteenOneAdapter.js
+++ b/packages/enzyme-adapter-react-16.1/src/ReactSixteenOneAdapter.js
@@ -205,13 +205,18 @@ function nodeToHostNode(_node) {
   if (!node) {
     return null;
   }
+
+  const mapper = (item) => {
+    if (item && item.instance) return ReactDOM.findDOMNode(item.instance);
+    return null;
+  };
   if (Array.isArray(node)) {
-    return node.map(item => ReactDOM.findDOMNode(item.instance));
+    return node.map(mapper);
   }
   if (Array.isArray(node.rendered) && node.nodeType === 'class') {
-    return node.rendered.map(item => ReactDOM.findDOMNode(item.instance));
+    return node.rendered.map(mapper);
   }
-  return ReactDOM.findDOMNode(node.instance);
+  return mapper(node);
 }
 
 const eventOptions = { animation: true };

--- a/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
+++ b/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
@@ -206,13 +206,18 @@ function nodeToHostNode(_node) {
   if (!node) {
     return null;
   }
+
+  const mapper = (item) => {
+    if (item && item.instance) return ReactDOM.findDOMNode(item.instance);
+    return null;
+  };
   if (Array.isArray(node)) {
-    return node.map(item => ReactDOM.findDOMNode(item.instance));
+    return node.map(mapper);
   }
   if (Array.isArray(node.rendered) && node.nodeType === 'class') {
-    return node.rendered.map(item => ReactDOM.findDOMNode(item.instance));
+    return node.rendered.map(mapper);
   }
-  return ReactDOM.findDOMNode(node.instance);
+  return mapper(node);
 }
 
 const eventOptions = { animation: true };

--- a/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
+++ b/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
@@ -202,13 +202,15 @@ function nodeToHostNode(_node) {
   while (node && !Array.isArray(node) && node.instance === null) {
     node = node.rendered;
   }
-  if (Array.isArray(node)) {
-    // TODO(lmr): throw warning regarding not being able to get a host node here
-    throw new Error('Trying to get host node of an array');
-  }
   // if the SFC returned null effectively, there is no host node.
   if (!node) {
     return null;
+  }
+  if (Array.isArray(node)) {
+    return node.map(item => ReactDOM.findDOMNode(item.instance));
+  }
+  if (Array.isArray(node.rendered) && node.nodeType === 'class') {
+    return node.rendered.map(item => ReactDOM.findDOMNode(item.instance));
   }
   return ReactDOM.findDOMNode(node.instance);
 }

--- a/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
+++ b/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
@@ -219,13 +219,15 @@ function nodeToHostNode(_node) {
   while (node && !Array.isArray(node) && node.instance === null) {
     node = node.rendered;
   }
-  if (Array.isArray(node)) {
-    // TODO(lmr): throw warning regarding not being able to get a host node here
-    throw new Error('Trying to get host node of an array');
-  }
   // if the SFC returned null effectively, there is no host node.
   if (!node) {
     return null;
+  }
+  if (Array.isArray(node)) {
+    return node.map(item => ReactDOM.findDOMNode(item.instance));
+  }
+  if (Array.isArray(node.rendered) && node.nodeType === 'class') {
+    return node.rendered.map(item => ReactDOM.findDOMNode(item.instance));
   }
   return ReactDOM.findDOMNode(node.instance);
 }

--- a/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
+++ b/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
@@ -223,13 +223,18 @@ function nodeToHostNode(_node) {
   if (!node) {
     return null;
   }
+
+  const mapper = (item) => {
+    if (item && item.instance) return ReactDOM.findDOMNode(item.instance);
+    return null;
+  };
   if (Array.isArray(node)) {
-    return node.map(item => ReactDOM.findDOMNode(item.instance));
+    return node.map(mapper);
   }
   if (Array.isArray(node.rendered) && node.nodeType === 'class') {
-    return node.rendered.map(item => ReactDOM.findDOMNode(item.instance));
+    return node.rendered.map(mapper);
   }
-  return ReactDOM.findDOMNode(node.instance);
+  return mapper(node);
 }
 
 const eventOptions = { animation: true };

--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -219,13 +219,15 @@ function nodeToHostNode(_node) {
   while (node && !Array.isArray(node) && node.instance === null) {
     node = node.rendered;
   }
-  if (Array.isArray(node)) {
-    // TODO(lmr): throw warning regarding not being able to get a host node here
-    throw new Error('Trying to get host node of an array');
-  }
   // if the SFC returned null effectively, there is no host node.
   if (!node) {
     return null;
+  }
+  if (Array.isArray(node)) {
+    return node.map(item => ReactDOM.findDOMNode(item.instance));
+  }
+  if (Array.isArray(node.rendered) && node.nodeType === 'class') {
+    return node.rendered.map(item => ReactDOM.findDOMNode(item.instance));
   }
   return ReactDOM.findDOMNode(node.instance);
 }

--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -223,13 +223,18 @@ function nodeToHostNode(_node) {
   if (!node) {
     return null;
   }
+
+  const mapper = (item) => {
+    if (item && item.instance) return ReactDOM.findDOMNode(item.instance);
+    return null;
+  };
   if (Array.isArray(node)) {
-    return node.map(item => ReactDOM.findDOMNode(item.instance));
+    return node.map(mapper);
   }
   if (Array.isArray(node.rendered) && node.nodeType === 'class') {
-    return node.rendered.map(item => ReactDOM.findDOMNode(item.instance));
+    return node.rendered.map(mapper);
   }
-  return ReactDOM.findDOMNode(node.instance);
+  return mapper(node);
 }
 
 const eventOptions = {

--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -3702,6 +3702,38 @@ describeWithDOM('mount', () => {
         expect(wrapper.text()).to.equal('{ some text }');
       });
     });
+
+    describeIf(is('> 16.2'), 'fragments', () => {
+      class FragmentClassExample extends React.Component {
+        render() {
+          return (
+            <Fragment>
+              <div>Foo</div>
+              <div>Bar</div>
+            </Fragment>
+          );
+        }
+      }
+
+      const FragmentConstExample = () => (
+        <Fragment>
+          <div><span>Foo</span></div>
+          <div><span>Bar</span></div>
+        </Fragment>
+      );
+
+      it('correctly gets text for both children for class', () => {
+        const classWrapper = mount(<FragmentClassExample />);
+        expect(classWrapper.text()).to.include('Foo');
+        expect(classWrapper.text()).to.include('Bar');
+      });
+
+      it('correctly gets text for both children for const', () => {
+        const constWrapper = mount(<FragmentConstExample />);
+        expect(constWrapper.text()).to.include('Foo');
+        expect(constWrapper.text()).to.include('Bar');
+      });
+    });
   });
 
   describe('.props()', () => {
@@ -5133,6 +5165,36 @@ describeWithDOM('mount', () => {
         const wrapper = mount(<Bar />);
         expect(wrapper.html()).to.equal('<div class="in-bar"><div class="in-foo"></div></div>');
         expect(wrapper.find(Foo).html()).to.equal('<div class="in-foo"></div>');
+      });
+    });
+
+    describeIf(is('>16.2'), 'fragments', () => {
+      class FragmentClassExample extends React.Component {
+        render() {
+          return (
+            <Fragment>
+              <div><span>Foo</span></div>
+              <div><span>Bar</span></div>
+            </Fragment>
+          );
+        }
+      }
+
+      const FragmentConstExample = () => (
+        <Fragment>
+          <div><span>Foo</span></div>
+          <div><span>Bar</span></div>
+        </Fragment>
+      );
+
+      it('correctly renders html for both children for class', () => {
+        const classWrapper = mount(<FragmentClassExample />);
+        expect(classWrapper.html()).to.equal('<div><span>Foo</span></div><div><span>Bar</span></div>');
+      });
+
+      it('correctly renders html for both children for const', () => {
+        const constWrapper = mount(<FragmentConstExample />);
+        expect(constWrapper.html()).to.equal('<div><span>Foo</span></div><div><span>Bar</span></div>');
       });
     });
   });

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -3653,6 +3653,38 @@ describe('shallow', () => {
         expect(wrapper.text()).to.equal('{ some text }');
       });
     });
+
+    describeIf(is('> 16.2'), 'fragments', () => {
+      class FragmentClassExample extends React.Component {
+        render() {
+          return (
+            <Fragment>
+              <div>Foo</div>
+              <div>Bar</div>
+            </Fragment>
+          );
+        }
+      }
+
+      const FragmentConstExample = () => (
+        <Fragment>
+          <div><span>Foo</span></div>
+          <div><span>Bar</span></div>
+        </Fragment>
+      );
+
+      it('correctly gets text for both children for class', () => {
+        const classWrapper = shallow(<FragmentClassExample />);
+        expect(classWrapper.text()).to.include('Foo');
+        expect(classWrapper.text()).to.include('Bar');
+      });
+
+      it('correctly gets text for both children for const', () => {
+        const constWrapper = shallow(<FragmentConstExample />);
+        expect(constWrapper.text()).to.include('Foo');
+        expect(constWrapper.text()).to.include('Bar');
+      });
+    });
   });
 
   describe('.props()', () => {
@@ -5205,6 +5237,36 @@ describe('shallow', () => {
         expect(wrapper.find(Foo).html()).to.equal((
           '<div class="in-foo"></div>'
         ));
+      });
+    });
+
+    describeIf(is('>16.2'), 'fragments', () => {
+      class FragmentClassExample extends React.Component {
+        render() {
+          return (
+            <Fragment>
+              <div><span>Foo</span></div>
+              <div><span>Bar</span></div>
+            </Fragment>
+          );
+        }
+      }
+
+      const FragmentConstExample = () => (
+        <Fragment>
+          <div><span>Foo</span></div>
+          <div><span>Bar</span></div>
+        </Fragment>
+      );
+
+      it('correctly renders html for both children for class', () => {
+        const classWrapper = shallow(<FragmentClassExample />);
+        expect(classWrapper.html()).to.equal('<div><span>Foo</span></div><div><span>Bar</span></div>');
+      });
+
+      it('correctly renders html for both children for const', () => {
+        const constWrapper = shallow(<FragmentConstExample />);
+        expect(constWrapper.html()).to.equal('<div><span>Foo</span></div><div><span>Bar</span></div>');
       });
     });
   });

--- a/packages/enzyme/src/RSTTraversal.js
+++ b/packages/enzyme/src/RSTTraversal.js
@@ -141,6 +141,5 @@ export function getTextFromNode(node) {
     return `<${node.type.displayName || functionName(node.type)} />`;
   }
 
-  return childrenOfNode(node).map(getTextFromNode)
-    .join('');
+  return childrenOfNode(node).map(getTextFromNode).join('');
 }

--- a/packages/enzyme/src/ReactWrapper.js
+++ b/packages/enzyme/src/ReactWrapper.js
@@ -579,7 +579,16 @@ class ReactWrapper {
       if (!node) {
         return typeof n === 'string' ? n : node;
       }
-      return node.textContent;
+
+      const nodeArray = Array.isArray(node) ? node : [node];
+      const textContent = nodeArray.map((item) => {
+        if (!item) {
+          return '';
+        }
+        return item.textContent || '';
+      });
+
+      return textContent.join('');
     });
   }
 
@@ -594,10 +603,17 @@ class ReactWrapper {
     return this.single('html', (n) => {
       if (n === null) return null;
       const adapter = getAdapter(this[OPTIONS]);
-      const node = adapter.nodeToHostNode(n);
-      return node === null
+      const node = adapter.nodeToHostNode(n, true);
+
+      if (node === null) return null;
+
+      const nodeArray = Array.isArray(node) ? node : [node];
+      const nodesHTML = nodeArray.map(item => (item === null
         ? null
-        : node.outerHTML.replace(/\sdata-(reactid|reactroot)+="([^"]*)+"/g, '');
+        : item.outerHTML.replace(/\sdata-(reactid|reactroot)+="([^"]*)+"/g, '')
+      ));
+
+      return nodesHTML.join('');
     });
   }
 


### PR DESCRIPTION
In order to resolve Issue #1799 and return expected .text() and .html() results for non-wrapped Fragments, nodeToHostNode in the react adapters needed to be able to handle arrays. This PR does that, changing `.text()` and `.html()` to deal with an array of nodes while maintaining backwards compatibility for adapters returning single nodes.

Fixes #1799.