### PR TITLE
[Tests] add hooks tests

### DIFF
--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -1050,6 +1050,8 @@ describeWithDOM('mount', () => {
     'useEffect',
     'useLayoutEffect',
     'useMemo',
+    'useState',
+    'custom',
   );
 
   describeIf(is('>= 16.6'), 'Suspense & lazy', () => {

--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -1050,6 +1050,7 @@ describeWithDOM('mount', () => {
     'useEffect',
     'useLayoutEffect',
     'useMemo',
+    'useReducer',
     'useState',
     'custom',
   );

--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -1047,6 +1047,7 @@ describeWithDOM('mount', () => {
   describeHooks(
     { Wrap, Wrapper },
     'useCallback',
+    'useContext',
     'useEffect',
     'useLayoutEffect',
     'useMemo',

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -1228,6 +1228,7 @@ describe('shallow', () => {
   describeHooks(
     { Wrap, Wrapper },
     'useCallback',
+    'useContext',
     'useEffect',
     'useLayoutEffect',
     'useMemo',

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -1231,6 +1231,7 @@ describe('shallow', () => {
     'useEffect',
     'useLayoutEffect',
     'useMemo',
+    'useReducer',
     'useState',
     'custom',
   );

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -1231,6 +1231,8 @@ describe('shallow', () => {
     'useEffect',
     'useLayoutEffect',
     'useMemo',
+    'useState',
+    'custom',
   );
 
   describe('.shallow()', () => {

--- a/packages/enzyme-test-suite/test/shared/hooks/_hook.template
+++ b/packages/enzyme-test-suite/test/shared/hooks/_hook.template
@@ -19,6 +19,7 @@ import {
 
 import {
   useCallback,
+  useContext,
   useEffect,
   useLayoutEffect,
   useMemo,

--- a/packages/enzyme-test-suite/test/shared/hooks/custom.jsx
+++ b/packages/enzyme-test-suite/test/shared/hooks/custom.jsx
@@ -76,7 +76,7 @@ export default function describeCustomHooks({
     });
 
     // todo: enable shallow when useEffect works in the shallow renderer. see https://github.com/facebook/react/issues/15275
-    describeIf(!isShallow, 'custom hook: formInput simulate', () => {
+    describeIf(!isShallow, 'custom hook: formInput invoke props', () => {
       function useFormInput(initialValue = '') {
         const [value, setValue] = useState(initialValue);
 
@@ -122,24 +122,27 @@ export default function describeCustomHooks({
         return <input {...search} />;
       }
 
-      it('does not succeed without act', () => {
+      it('work with native input', () => {
         const spy = sinon.spy();
         const wrapper = Wrap(<ControlledInputWithNativeInput searchSomething={spy} />);
-        // Works with Act
-        // act(() => {
-        wrapper.simulate('change', { target: { value: 'foo' } });
-        // });
+        wrapper.find('input').invoke('onChange')({ target: { value: 'foo' } });
 
         expect(spy.withArgs('foo')).to.have.property('callCount', 1);
       });
 
-      // TODO: Need to evaluate as per issue raised
-      it.skip('does not succeed with/without act', () => {
+      it('work with custom wrapped Input', () => {
         const spy = sinon.spy();
         const wrapper = Wrap(<ControlledInputWithEnhancedInput searchSomething={spy} />);
-        // act(() => {
-        wrapper.simulate('change', { target: { value: 'foo' } });
-        // });
+        const input = wrapper.find('Input');
+        input.invoke('onChange')({ target: { value: 'foo' } });
+        expect(spy.withArgs('foo')).to.have.property('callCount', 1);
+      });
+
+      it('work with custom wrapped input', () => {
+        const spy = sinon.spy();
+        const wrapper = Wrap(<ControlledInputWithEnhancedInput searchSomething={spy} />);
+        const input = wrapper.find('input');
+        input.invoke('onChange')({ target: { value: 'foo' } });
         expect(spy.withArgs('foo')).to.have.property('callCount', 1);
       });
     });

--- a/packages/enzyme-test-suite/test/shared/hooks/custom.jsx
+++ b/packages/enzyme-test-suite/test/shared/hooks/custom.jsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon-sandbox';
+
+import {
+  describeIf,
+} from '../../_helpers';
+
+import {
+  useEffect,
+  useState,
+} from '../../_helpers/react-compat';
+
+export default function describeCustomHooks({
+  hasHooks,
+  Wrap,
+  isShallow,
+}) {
+  describeIf(hasHooks, 'hooks: custom', () => {
+    describe('custom hook : useCounter', () => {
+      function useCounter({ initialCount = 0, step = 1 } = {}) {
+        const [count, setCount] = useState(initialCount);
+        const increment = () => setCount(c => c + step);
+        const decrement = () => setCount(c => c - step);
+        return { count, increment, decrement };
+      }
+      // testing custom hooks with renderProps
+      // may be we can think of adding in utils
+      // will be repeated
+      const Counter = ({ children, ...rest }) => children(useCounter(rest));
+
+      function setup(props) {
+        const returnVal = {};
+        Wrap(
+          <Counter {...props}>
+            {(val) => {
+              Object.assign(returnVal, val);
+              return null;
+            }}
+          </Counter>,
+        );
+        return returnVal;
+      }
+
+      it('useCounter', () => {
+        const counterData = setup();
+        counterData.increment();
+        expect(counterData).to.have.property('count', 1);
+        counterData.decrement();
+        expect(counterData).to.have.property('count', 0);
+      });
+
+      it('useCounter with initialCount', () => {
+        const counterData = setup({ initialCount: 2 });
+        counterData.increment();
+        expect(counterData).to.have.property('count', 3);
+        counterData.decrement();
+        expect(counterData).to.have.property('count', 2);
+      });
+
+      it('useCounter with step', () => {
+        const counterData = setup({ step: 2 });
+        counterData.increment();
+        expect(counterData).to.have.property('count', 2);
+        counterData.decrement();
+        expect(counterData).to.have.property('count', 0);
+      });
+
+      it('useCounter with step and initialCount', () => {
+        const counterData = setup({ step: 2, initialCount: 5 });
+        counterData.increment();
+        expect(counterData).to.have.property('count', 7);
+        counterData.decrement();
+        expect(counterData).to.have.property('count', 5);
+      });
+    });
+
+    // todo: enable shallow when useEffect works in the shallow renderer. see https://github.com/facebook/react/issues/15275
+    describeIf(!isShallow, 'custom hook: formInput simulate', () => {
+      function useFormInput(initialValue = '') {
+        const [value, setValue] = useState(initialValue);
+
+        return {
+          value,
+          onChange(e) {
+            setValue(e.target.value);
+          },
+        };
+      }
+
+      function Input(props) {
+        return (
+          <div>
+            <input {...props} />
+          </div>
+        );
+      }
+
+      function ControlledInputWithEnhancedInput({ searchSomething }) {
+        const search = useFormInput();
+
+        useEffect(
+          () => {
+            searchSomething(search.value);
+          },
+          [search.value],
+        );
+
+        return <Input {...search} />;
+      }
+
+      function ControlledInputWithNativeInput({ searchSomething }) {
+        const search = useFormInput();
+
+        useEffect(
+          () => {
+            searchSomething(search.value);
+          },
+          [search.value],
+        );
+
+        return <input {...search} />;
+      }
+
+      it('does not succeed without act', () => {
+        const spy = sinon.spy();
+        const wrapper = Wrap(<ControlledInputWithNativeInput searchSomething={spy} />);
+        // Works with Act
+        // act(() => {
+        wrapper.simulate('change', { target: { value: 'foo' } });
+        // });
+
+        expect(spy.withArgs('foo')).to.have.property('callCount', 1);
+      });
+
+      // TODO: Need to evaluate as per issue raised
+      it.skip('does not succeed with/without act', () => {
+        const spy = sinon.spy();
+        const wrapper = Wrap(<ControlledInputWithEnhancedInput searchSomething={spy} />);
+        // act(() => {
+        wrapper.simulate('change', { target: { value: 'foo' } });
+        // });
+        expect(spy.withArgs('foo')).to.have.property('callCount', 1);
+      });
+    });
+  });
+}

--- a/packages/enzyme-test-suite/test/shared/hooks/useContext.jsx
+++ b/packages/enzyme-test-suite/test/shared/hooks/useContext.jsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { expect } from 'chai';
+
+import {
+  describeIf,
+  itIf,
+} from '../../_helpers';
+
+import {
+  useContext,
+  useState,
+  createContext,
+} from '../../_helpers/react-compat';
+
+export default function describeUseContext({
+  hasHooks,
+  Wrap,
+  isShallow,
+}) {
+  describeIf(hasHooks, 'hooks: useContext', () => {
+    describe('simple example', () => {
+      const initialTitle = 'initialTitle';
+      const TitleContext = createContext && createContext(initialTitle);
+
+      function UiComponent() {
+        const title = useContext(TitleContext);
+        return (
+          <div>
+            {title}
+          </div>
+        );
+      }
+
+      const customTitle = 'CustomTitle';
+
+      function App() {
+        return (
+          <TitleContext.Provider value={customTitle}>
+            <UiComponent />
+          </TitleContext.Provider>
+        );
+      }
+
+      it('render ui component with initial context value', () => {
+        const wrapper = Wrap(<UiComponent />);
+        expect(wrapper.text()).to.equal(initialTitle);
+      });
+
+      // TODO: useContext: enable when shallow dive supports createContext
+      itIf(!isShallow, 'render ui component with value from outer provider', () => {
+        const wrapper = Wrap(<App />);
+        const subWrapper = isShallow ? wrapper.dive().dive() : wrapper;
+        expect(subWrapper.text()).to.equal(customTitle);
+      });
+    });
+
+    // TODO: useContext: enable when shallow dive supports createContext
+    describeIf(!isShallow, 'useContext: with Setting', () => {
+      const initialState = 10;
+      const context = createContext && createContext(null);
+
+      function MyGrandChild() {
+        const myContextVal = useContext(context);
+
+        const increment = () => {
+          myContextVal.setState(myContextVal.state + 1);
+        };
+
+        return (
+          <div>
+            <button type="button" onClick={increment}>increment</button>
+            <span className="grandChildState">
+              {myContextVal.state}
+            </span>
+          </div>
+        );
+      }
+
+      function MyChild() {
+        return (
+          <div>
+            <MyGrandChild />
+          </div>
+        );
+      }
+
+      function App() {
+        const [state, setState] = useState(initialState);
+
+        return (
+          <context.Provider value={{ state, setState }}>
+            <div>
+              <MyChild />
+            </div>
+          </context.Provider>
+        );
+      }
+
+      it('test render, get and set context value ', () => {
+        const wrapper = Wrap(<App />);
+
+        function getChild() {
+          const child = wrapper.find(MyChild);
+          return isShallow ? child.dive() : child;
+        }
+        function getGrandChild() {
+          const grandchild = getChild().find(MyGrandChild);
+          return isShallow ? grandchild.dive() : grandchild;
+        }
+        expect(getGrandChild().find('.grandChildState').debug()).to.equal(`<span className="grandChildState">
+  ${String(initialState)}
+</span>`);
+
+        getGrandChild().find('button').props().onClick();
+        wrapper.update();
+        expect(getGrandChild().find('.grandChildState').debug()).to.equal(`<span className="grandChildState">
+  ${String(initialState + 1)}
+</span>`);
+      });
+    });
+  });
+}

--- a/packages/enzyme-test-suite/test/shared/hooks/useEffect.jsx
+++ b/packages/enzyme-test-suite/test/shared/hooks/useEffect.jsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import { expect } from 'chai';
+import sinon from 'sinon-sandbox';
 
 import {
   describeIf,
-  itIf,
 } from '../../_helpers';
 
 import {
   useEffect,
   useState,
+  Fragment,
 } from '../../_helpers/react-compat';
 
 export default function describeUseEffect({
@@ -16,7 +17,8 @@ export default function describeUseEffect({
   Wrap,
   isShallow,
 }) {
-  describeIf(hasHooks, 'hooks: useEffect', () => {
+  // TODO: enable when the shallow renderer fixes its bug, see https://github.com/facebook/react/issues/15275.
+  describeIf(hasHooks && !isShallow, 'hooks: useEffect', () => {
     const timeout = 100;
     function ComponentUsingEffectHook() {
       const [ctr, setCtr] = useState(0);
@@ -33,8 +35,7 @@ export default function describeUseEffect({
       );
     }
 
-    // TODO: enable when the shallow renderer fixes its bug
-    itIf(!isShallow, 'works with `useEffect`', (done) => {
+    it('works', (done) => {
       const wrapper = Wrap(<ComponentUsingEffectHook />);
 
       expect(wrapper.debug()).to.equal(
@@ -64,6 +65,183 @@ export default function describeUseEffect({
         );
         done();
       }, timeout + 1);
+    });
+
+    describe('with mount effect', () => {
+      const didMountCount = 9;
+
+      function FooCounterWithMountEffect({ initialCount = 0 }) {
+        const [count, setCount] = useState(+initialCount);
+
+        useEffect(() => {
+          setCount(didMountCount);
+        }, []);
+        return (
+          <Fragment>
+            <span className="counter">
+              {count}
+            </span>
+          </Fragment>
+        );
+      }
+
+      it('initial render after did mount effect', () => {
+        const wrapper = Wrap(<FooCounterWithMountEffect />);
+        expect(wrapper.find('.counter').text()).to.equal(String(didMountCount));
+      });
+    });
+
+    describe('with async effect', () => {
+      it('works with `useEffect`', (done) => {
+        const wrapper = Wrap(<ComponentUsingEffectHook />);
+
+        expect(wrapper.debug()).to.equal(
+          isShallow
+            ? `<div>
+  1
+</div>`
+            : `<ComponentUsingEffectHook>
+  <div>
+    1
+  </div>
+</ComponentUsingEffectHook>`,
+        );
+
+        setTimeout(() => {
+          wrapper.update();
+          expect(wrapper.debug()).to.equal(
+            isShallow
+              ? `<div>
+  2
+</div>`
+              : `<ComponentUsingEffectHook>
+  <div>
+    2
+  </div>
+</ComponentUsingEffectHook>`,
+          );
+          done();
+        }, timeout + 1);
+      });
+    });
+
+    describe('on componentDidUpdate & componentDidMount', () => {
+      const expectedCountString = x => `You clicked ${x} times`;
+
+      let setDocumentTitle;
+      function ClickCounterPage() {
+        const [count, setCount] = useState(0);
+
+        useEffect(() => {
+          setDocumentTitle(expectedCountString(count));
+        }, [count]);
+
+        return (
+          <div>
+            <p>You clicked {count} times</p>
+            <button onClick={() => setCount(count + 1)}>
+              Click me
+            </button>
+          </div>
+        );
+      }
+
+      beforeEach(() => {
+        setDocumentTitle = sinon.stub();
+      });
+
+      it('on mount initial render', () => {
+        const wrapper = Wrap(<ClickCounterPage />);
+
+        expect(wrapper.find('p').text()).to.eq(expectedCountString(0));
+        expect(setDocumentTitle).to.have.property('callCount', 1);
+        expect(setDocumentTitle.args).to.deep.equal([[expectedCountString(0)]]);
+      });
+
+      // TODO: useEffect fixme
+      it.skip('on didupdate', () => {
+        const wrapper = Wrap(<ClickCounterPage />);
+
+        expect(setDocumentTitle).to.have.property('callCount', 1);
+        expect(setDocumentTitle.args).to.deep.equal([[expectedCountString(0)]]);
+        expect(wrapper.find('p').text()).to.equal(expectedCountString(0));
+
+        const { onClick } = wrapper.find('button').props();
+        onClick();
+
+        expect(setDocumentTitle).to.have.property('callCount', 2);
+        expect(setDocumentTitle.args).to.deep.equal([[expectedCountString(1)]]);
+        expect(wrapper.find('p').text()).to.equal(expectedCountString(1));
+
+        onClick();
+        onClick();
+
+        expect(setDocumentTitle).to.have.property('callCount', 4);
+        expect(setDocumentTitle.args).to.deep.equal([[expectedCountString(3)]]);
+        expect(wrapper.find('p').text()).to.equal(expectedCountString(3));
+      });
+    });
+
+    describe('with cleanup Effect', () => {
+      let ChatAPI;
+
+      beforeEach(() => {
+        ChatAPI = {
+          subscribeToFriendStatus: sinon.stub(),
+          unsubscribeFromFriendStatus: sinon.stub(),
+        };
+      });
+
+      function FriendStatus({ friend = {} }) {
+        const [isOnline, setIsOnline] = useState(null);
+
+        function handleStatusChange(status) {
+          setIsOnline(status.isOnline);
+        }
+
+        useEffect(() => {
+          ChatAPI.subscribeToFriendStatus(friend.id, handleStatusChange);
+          return function cleanup() {
+            ChatAPI.unsubscribeFromFriendStatus(friend.id, handleStatusChange);
+          };
+        }, [isOnline]);
+
+        if (isOnline === null) {
+          return 'Loading...';
+        }
+        return isOnline ? 'Online' : 'Offline';
+      }
+
+      const friend = { id: 'enzyme' };
+
+      it('on initial mount', () => {
+        const wrapper = Wrap(<FriendStatus friend={friend} />);
+        expect(wrapper.debug()).to.equal(
+          `<FriendStatus friend={{...}}>
+  Loading...
+</FriendStatus>`,
+        );
+        expect(wrapper.html()).to.eql('Loading...');
+        expect(ChatAPI.subscribeToFriendStatus.calledOnceWith(friend.id)).to.equal(true);
+      });
+
+      it('simulate status Change', () => {
+        const wrapper = Wrap(<FriendStatus friend={friend} />);
+        const [[, simulateChange]] = ChatAPI.subscribeToFriendStatus.args;
+
+        simulateChange({ isOnline: true });
+
+        wrapper.update();
+        expect(wrapper.html()).to.eql('Online');
+      });
+
+      it('cleanup on unmount', () => {
+        const wrapper = Wrap(<FriendStatus friend={friend} />);
+
+        wrapper.unmount();
+
+        expect(ChatAPI.unsubscribeFromFriendStatus.calledOnceWith(friend.id)).to.equal(true);
+      });
     });
   });
 }

--- a/packages/enzyme-test-suite/test/shared/hooks/useEffect.jsx
+++ b/packages/enzyme-test-suite/test/shared/hooks/useEffect.jsx
@@ -4,8 +4,11 @@ import sinon from 'sinon-sandbox';
 
 import {
   describeIf,
+  itIf,
 } from '../../_helpers';
-
+import {
+  is,
+} from '../../_helpers/version';
 import {
   useEffect,
   useState,
@@ -158,26 +161,27 @@ export default function describeUseEffect({
         expect(setDocumentTitle.args).to.deep.equal([[expectedCountString(0)]]);
       });
 
-      // TODO: useEffect fixme
-      it.skip('on didupdate', () => {
+      it('on didupdate', () => {
         const wrapper = Wrap(<ClickCounterPage />);
 
         expect(setDocumentTitle).to.have.property('callCount', 1);
-        expect(setDocumentTitle.args).to.deep.equal([[expectedCountString(0)]]);
+        const [firstCall] = setDocumentTitle.args;
+        expect(firstCall).to.deep.equal([expectedCountString(0)]);
         expect(wrapper.find('p').text()).to.equal(expectedCountString(0));
 
-        const { onClick } = wrapper.find('button').props();
-        onClick();
+        wrapper.find('button').invoke('onClick')();
 
         expect(setDocumentTitle).to.have.property('callCount', 2);
-        expect(setDocumentTitle.args).to.deep.equal([[expectedCountString(1)]]);
+        const [, secondCall] = setDocumentTitle.args;
+        expect(secondCall).to.deep.equal([expectedCountString(1)]);
         expect(wrapper.find('p').text()).to.equal(expectedCountString(1));
 
-        onClick();
-        onClick();
+        wrapper.find('button').invoke('onClick')();
+        wrapper.find('button').invoke('onClick')();
 
         expect(setDocumentTitle).to.have.property('callCount', 4);
-        expect(setDocumentTitle.args).to.deep.equal([[expectedCountString(3)]]);
+        const [,,, fourthCall] = setDocumentTitle.args;
+        expect(fourthCall).to.deep.equal([expectedCountString(3)]);
         expect(wrapper.find('p').text()).to.equal(expectedCountString(3));
       });
     });
@@ -235,12 +239,14 @@ export default function describeUseEffect({
         expect(wrapper.html()).to.eql('Online');
       });
 
-      it('cleanup on unmount', () => {
+      itIf(is('> 16.8.3'), 'cleanup on unmount', () => {
         const wrapper = Wrap(<FriendStatus friend={friend} />);
 
         wrapper.unmount();
 
-        expect(ChatAPI.unsubscribeFromFriendStatus.calledOnceWith(friend.id)).to.equal(true);
+        expect(ChatAPI.unsubscribeFromFriendStatus).to.have.property('callCount', 1);
+        const [[firstArg]] = ChatAPI.unsubscribeFromFriendStatus.args;
+        expect(firstArg).to.equal(friend.id);
       });
     });
   });

--- a/packages/enzyme-test-suite/test/shared/hooks/useReducer.jsx
+++ b/packages/enzyme-test-suite/test/shared/hooks/useReducer.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { expect } from 'chai';
+
+import { describeIf } from '../../_helpers';
+
+import { useReducer } from '../../_helpers/react-compat';
+
+export default function describeUseReducer({
+  hasHooks,
+  Wrap,
+}) {
+  describeIf(hasHooks, 'hooks: useReducer', () => {
+    describe('with custom dispatch', () => {
+      const initialState = [];
+
+      function Child({ dispatch, text }) {
+        function fire() {
+          dispatch({
+            type: 'ADD_TEXT',
+            payload: text,
+          });
+        }
+
+        return <button type="button" onClick={fire}>Add {text}</button>;
+      }
+
+      function reducer(state, action) {
+        switch (action.type) {
+          case 'ADD_TEXT':
+            return [...state, action.payload];
+          default:
+            throw new Error();
+        }
+      }
+
+      function FooBarTextList() {
+        const [state, dispatch] = useReducer(reducer, initialState);
+
+        return (
+          <div className="FooBarTextList">
+            <Child text="foo" dispatch={dispatch} />
+            <Child text="bar" dispatch={dispatch} />
+            {state.map(text => (
+              <p key={text}>{text}</p>
+            ))}
+          </div>
+        );
+      }
+
+      it('render with initial state from useReducer', () => {
+        const wrapper = Wrap(<FooBarTextList />);
+        expect(wrapper.find('p')).to.have.lengthOf(0);
+      });
+
+      it('Test with Add Foo & Bar tex', () => {
+        const wrapper = Wrap(<FooBarTextList />);
+        expect(wrapper.find('p')).to.have.lengthOf(0);
+        wrapper.find('Child').at(0).props().dispatch({
+          type: 'ADD_TEXT',
+          payload: 'foo',
+        });
+        wrapper.update();
+
+        expect(wrapper.find('p')).to.have.lengthOf(1);
+        expect(wrapper.find('p').at(0).text()).to.equal('foo');
+
+        wrapper.find('Child').at(1).props().dispatch({
+          type: 'ADD_TEXT',
+          payload: 'bar',
+        });
+        wrapper.update();
+        expect(wrapper.find('p')).to.have.length(2);
+        expect(wrapper.find('p').at(0).text()).to.equal('foo');
+        expect(wrapper.find('p').at(1).text()).to.equal('bar');
+      });
+    });
+  });
+}

--- a/packages/enzyme-test-suite/test/shared/hooks/useState.jsx
+++ b/packages/enzyme-test-suite/test/shared/hooks/useState.jsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { expect } from 'chai';
+
+import {
+  describeIf,
+  itIf,
+} from '../../_helpers';
+
+import {
+  useState,
+  useEffect,
+  Fragment,
+} from '../../_helpers/react-compat';
+
+export default function describeUseState({
+  hasHooks,
+  Wrap,
+  isShallow,
+}) {
+  describeIf(hasHooks, 'hooks: useState', () => {
+    function FooCounter({ initialCount: initial = 0 }) {
+      const [count, setCount] = useState(+initial);
+
+      return (
+        <Fragment>
+          <button className="increment" type="button" onClick={() => setCount(count + 1)}>-</button>
+          <span className="counter">
+            {count}
+          </span>
+          <button className="decrement" type="button" onClick={() => setCount(count - 1)}>+</button>
+        </Fragment>
+      );
+    }
+
+    const initialCount = 5;
+
+    it('initial render', () => {
+      const wrapper = Wrap(<FooCounter initialCount={initialCount} />);
+      expect(wrapper.find('.counter').text()).to.equal(String(initialCount));
+    });
+
+    it('lets increment', () => {
+      const wrapper = Wrap(<FooCounter initialCount={initialCount} />);
+
+      wrapper.find('.increment').props().onClick();
+
+      expect(wrapper.find('.counter').text()).to.equal(String(initialCount + 1));
+    });
+
+    it('now decrement', () => {
+      const wrapper = Wrap(<FooCounter initialCount={initialCount} />);
+
+      wrapper.find('.decrement').props().onClick();
+
+      expect(wrapper.find('.counter').text()).to.equal(String(initialCount - 1));
+    });
+
+    describe('useState with willReceive prop effect / simulate getDerivedStateFromProp', () => {
+      const newPropCount = 10;
+
+      function FooCounterWithEffect({ initialCount: initial = 0 }) {
+        const [count, setCount] = useState(+initial);
+
+        useEffect(() => {
+          setCount(initial);
+        }, [initial]);
+
+        return (
+          <Fragment>
+            <span className="counter">
+              {count}
+            </span>
+          </Fragment>
+        );
+      }
+
+      // TODO: fixme when useEffect works in the shallow renderer, see https://github.com/facebook/react/issues/15275
+      itIf(!isShallow, 'initial render & new Props', () => {
+        const wrapper = Wrap(<FooCounterWithEffect initialCount={initialCount} />);
+        expect(wrapper.find('.counter').text()).to.equal(String(initialCount));
+
+        wrapper.setProps({ initialCount: newPropCount });
+        expect(wrapper.find('.counter').text()).to.equal(String(newPropCount));
+      });
+    });
+  });
+}

--- a/packages/enzyme-test-suite/test/shared/hooks/useState.jsx
+++ b/packages/enzyme-test-suite/test/shared/hooks/useState.jsx
@@ -55,6 +55,33 @@ export default function describeUseState({
       expect(wrapper.find('.counter').text()).to.equal(String(initialCount - 1));
     });
 
+    it('handles useState', () => {
+      function ComponentUsingStateHook() {
+        const [count] = useState(0);
+        return <div>{count}</div>;
+      }
+
+      const wrapper = Wrap(<ComponentUsingStateHook />);
+
+      expect(wrapper.find('div').length).to.equal(1);
+      expect(wrapper.find('div').text()).to.equal('0');
+    });
+
+    it('handles setState returned from useState', () => {
+      function ComponentUsingStateHook() {
+        const [count, setCount] = useState(0);
+        return <div onClick={() => setCount(count + 1)}>{count}</div>;
+      }
+
+      const wrapper = Wrap(<ComponentUsingStateHook />);
+      const div = wrapper.find('div');
+      const setCount = div.prop('onClick');
+      setCount();
+      wrapper.update();
+
+      expect(wrapper.find('div').text()).to.equal('1');
+    });
+
     describe('useState with willReceive prop effect / simulate getDerivedStateFromProp', () => {
       const newPropCount = 10;
 


### PR DESCRIPTION
This PR adds support for [basic hooks API] (https://reactjs.org/docs/hooks-reference.html#basic-hooks) (`useState`, `useEffect`, `useContext`, related issue #1938 #1996). Currently I'm not sure what hooks API is already working in enzyme shallow / mount and what isn't, so I'll start from adding test cases to confirm the current supports. I'll try to finish the following checklist in the next few days. Also tell me if it's better to have single PR for each api :-)

- [ ] useState
  - [x] mount
    - [x] get value from hooks
    - [x] set value from hooks and rendered element should be updated
  - [ ] shallow
    - [x] get value from hooks
    - [x] set value from hooks and rendered element should be updated (that's a bug in react shallow renderer, fixed in react after react@16.8.5, see https://github.com/facebook/react/pull/15120)

I've added some test cases for `useState` and found it doesn't work in `shallow` to setState.

(Updated: Created a checklist in #2011 to try to track any issue / PR in hooks, and concentrate on support `useState` in this PR)