### PR TITLE
Update deprecated key in documentation

### DIFF
--- a/docs/guides/jest.md
+++ b/docs/guides/jest.md
@@ -7,7 +7,7 @@ To run the setup file to configure Enzyme and the Adapter (as shown in the [Inst
 ```json
 {
   "jest": {
-    "setupTestFrameworkScriptFile": "<rootDir>src/setupTests.js"
+    "setupFilesAfterEnv": ["<rootDir>src/setupTests.js"]
   }
 }
 ```


### PR DESCRIPTION
Change deprecated `setupTestFrameworkScriptFile` to `setupFilesAfterEnv`.

see: https://jestjs.io/docs/en/configuration#setupfilesafterenv-array