### PR TITLE
Don't wrap functional components in react >=16.5 to shallow render

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ matrix:
     - node_js: "6"
       env: REACT=16
     - node_js: "lts/*"
+      env: REACT=16.8.5 RENDERER=16.8.5
+    - node_js: "lts/*"
       env: REACT=16.8.3
     - node_js: "lts/*"
       env: REACT=16.8 RENDERER=16.7

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -643,7 +643,7 @@ describe('shallow', () => {
     });
   });
 
-  describeIf(is('>= 16.8'), 'hooks', () => {
+  describeIf(is('>= 16.8.5'), 'hooks', () => {
     // TODO: enable when the shallow renderer fixes its bug
     it.skip('works with `useEffect`', (done) => {
       function ComponentUsingEffectHook() {


### PR DESCRIPTION
This is necessary because ReactShallowRender checks for equality in function components to decide if it should keep hooks state between renders.

This along with https://github.com/facebook/react/pull/14802 / https://github.com/facebook/react/issues/14840 should help in test components with some of the core hooks.
link #2011 , #2008 and #1996