### PR TITLE
Wrap mount renderer render with reactTestUtils.act()

### DIFF
--- a/packages/enzyme-adapter-react-13/.eslintrc
+++ b/packages/enzyme-adapter-react-13/.eslintrc
@@ -2,6 +2,7 @@
   "extends": "airbnb",
   "root": true,
   "rules": {
+    "max-len": 0,
     "react/no-find-dom-node": 0,
     "react/no-multi-comp": 0,
     "no-underscore-dangle": 0,

--- a/packages/enzyme-adapter-react-14/.eslintrc
+++ b/packages/enzyme-adapter-react-14/.eslintrc
@@ -2,6 +2,7 @@
   "extends": "airbnb",
   "root": true,
   "rules": {
+    "max-len": 0,
     "react/no-find-dom-node": 0,
     "react/no-multi-comp": 0,
     "no-underscore-dangle": 0,

--- a/packages/enzyme-adapter-react-15.4/.eslintrc
+++ b/packages/enzyme-adapter-react-15.4/.eslintrc
@@ -2,6 +2,7 @@
   "extends": "airbnb",
   "root": true,
   "rules": {
+    "max-len": 0,
     "react/no-find-dom-node": 0,
     "react/no-multi-comp": 0,
     "no-underscore-dangle": 0,

--- a/packages/enzyme-adapter-react-15/.eslintrc
+++ b/packages/enzyme-adapter-react-15/.eslintrc
@@ -2,6 +2,7 @@
   "extends": "airbnb",
   "root": true,
   "rules": {
+    "max-len": 0,
     "react/no-find-dom-node": 0,
     "react/no-multi-comp": 0,
     "no-underscore-dangle": 0,

--- a/packages/enzyme-adapter-react-16.1/.eslintrc
+++ b/packages/enzyme-adapter-react-16.1/.eslintrc
@@ -2,6 +2,7 @@
   "extends": "airbnb",
   "root": true,
   "rules": {
+    "max-len": 0,
     "import/no-extraneous-dependencies": 0,
     "import/no-unresolved": 0,
     "import/extensions": 0,

--- a/packages/enzyme-adapter-react-16.2/.eslintrc
+++ b/packages/enzyme-adapter-react-16.2/.eslintrc
@@ -2,6 +2,7 @@
   "extends": "airbnb",
   "root": true,
   "rules": {
+    "max-len": 0,
     "import/no-extraneous-dependencies": 0,
     "import/no-unresolved": 0,
     "import/extensions": 0,

--- a/packages/enzyme-adapter-react-16.3/.eslintrc
+++ b/packages/enzyme-adapter-react-16.3/.eslintrc
@@ -2,6 +2,7 @@
   "extends": "airbnb",
   "root": true,
   "rules": {
+    "max-len": 0,
     "import/no-extraneous-dependencies": 0,
     "import/no-unresolved": 0,
     "import/extensions": 0,

--- a/packages/enzyme-adapter-react-16/.eslintrc
+++ b/packages/enzyme-adapter-react-16/.eslintrc
@@ -2,6 +2,7 @@
   "extends": "airbnb",
   "root": true,
   "rules": {
+    "max-len": 0,
     "import/no-extraneous-dependencies": 0,
     "import/no-unresolved": 0,
     "import/extensions": 0,
@@ -13,7 +14,7 @@
   },
   "settings": {
     "react": {
-      "version": "16.4.0",
+      "version": "16",
     },
   },
 }

--- a/packages/enzyme-adapter-react-helper/.eslintrc
+++ b/packages/enzyme-adapter-react-helper/.eslintrc
@@ -4,4 +4,9 @@
   "rules": {
     "max-len": 0,
   },
+  "settings": {
+    "react": {
+      "version": "detect",
+    },
+  },
 }

--- a/packages/enzyme-adapter-utils/.eslintrc
+++ b/packages/enzyme-adapter-utils/.eslintrc
@@ -9,4 +9,12 @@
       },
     },
   ],
+  "rules": {
+    "max-len": 0,
+  },
+  "settings": {
+    "react": {
+      "version": "detect",
+    },
+  },
 }

--- a/packages/enzyme-test-suite/.eslintrc
+++ b/packages/enzyme-test-suite/.eslintrc
@@ -7,6 +7,9 @@
   "plugins": ["mocha"],
   "settings": {
     "mocha/additionalTestFunctions": ["itIf", "describeIf"],
+    "react": {
+      "version": "detect",
+    },
   },
   "rules": {
     "max-len": 0,

--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -31,6 +31,8 @@ import {
   forwardRef,
   memo,
   PureComponent,
+  useEffect,
+  useState,
 } from './_helpers/react-compat';
 import {
   describeWithDOM,
@@ -645,6 +647,42 @@ describeWithDOM('mount', () => {
     </div>
   </Portal>
 </Foo>`);
+    });
+  });
+
+  describeIf(is('>= 16.8'), 'hooks', () => {
+    it('works with `useEffect`', (done) => {
+      function ComponentUsingEffectHook() {
+        const [ctr, setCtr] = useState(0);
+        useEffect(() => {
+          setCtr(1);
+          setTimeout(() => {
+            setCtr(2);
+          }, 1e3);
+        }, []);
+        return (
+          <div>
+            {ctr}
+          </div>
+        );
+      }
+      const wrapper = mount(<ComponentUsingEffectHook />);
+
+      expect(wrapper.debug()).to.equal(`<ComponentUsingEffectHook>
+  <div>
+    1
+  </div>
+</ComponentUsingEffectHook>`);
+
+      setTimeout(() => {
+        wrapper.update();
+        expect(wrapper.debug()).to.equal(`<ComponentUsingEffectHook>
+  <div>
+    2
+  </div>
+</ComponentUsingEffectHook>`);
+        done();
+      }, 1e3);
     });
   });
 

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -31,6 +31,8 @@ import {
   forwardRef,
   memo,
   PureComponent,
+  useEffect,
+  useState,
 } from './_helpers/react-compat';
 import {
   describeIf,
@@ -650,6 +652,39 @@ describe('shallow', () => {
     InPortal
   </div>
 </Portal>`);
+    });
+  });
+
+  describeIf(is('>= 16.8'), 'hooks', () => {
+    // TODO: enable when the shallow renderer fixes its bug
+    it.skip('works with `useEffect`', (done) => {
+      function ComponentUsingEffectHook() {
+        const [ctr, setCtr] = useState(0);
+        useEffect(() => {
+          setCtr(1);
+          setTimeout(() => {
+            setCtr(2);
+          }, 1e3);
+        }, []);
+        return (
+          <div>
+            {ctr}
+          </div>
+        );
+      }
+      const wrapper = shallow(<ComponentUsingEffectHook />);
+
+      expect(wrapper.debug()).to.equal(`<div>
+  1
+</div>`);
+
+      setTimeout(() => {
+        wrapper.update();
+        expect(wrapper.debug()).to.equal(`<div>
+  2
+</div>`);
+        done();
+      }, 1e3);
     });
   });
 


### PR DESCRIPTION
This PR wrap the render function of mount renderer with `act()` so that use cases with `useEffect` would work. The test is the test case in https://github.com/threepointone/react-act-examples/blob/master/README.md#effects .