### PR TITLE
feat: Add support for unstable_Profiler to mount API

### DIFF
--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -216,6 +216,7 @@ function toTree(vnode) {
     case FiberTags.ContextProvider:
     case FiberTags.ContextConsumer:
       return childrenToTree(node.child);
+    case FiberTags.Profiler:
     case FiberTags.ForwardRef: {
       return {
         nodeType: 'function',

--- a/packages/enzyme-adapter-react-16/src/detectFiberTags.js
+++ b/packages/enzyme-adapter-react-16/src/detectFiberTags.js
@@ -19,6 +19,7 @@ module.exports = function detectFiberTags() {
   const supportsContext = typeof React.createContext !== 'undefined';
   const supportsForwardRef = typeof React.forwardRef !== 'undefined';
   const supportsMemo = typeof React.memo !== 'undefined';
+  const supportsProfiler = typeof React.unstable_Profiler !== 'undefined';
 
   function Fn() {
     return null;
@@ -65,6 +66,9 @@ module.exports = function detectFiberTags() {
       : -1,
     ForwardRef: supportsForwardRef
       ? getFiber(React.createElement(FwdRef)).tag
+      : -1,
+    Profiler: supportsProfiler
+      ? getFiber(React.createElement(React.unstable_Profiler, { id: 'mock', onRender: () => {} })).tag
       : -1,
   };
 };

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -25,6 +25,7 @@ import {
   PureComponent,
   useEffect,
   useState,
+  Profiler,
 } from './_helpers/react-compat';
 import {
   describeIf,
@@ -1004,6 +1005,122 @@ describe('shallow', () => {
     InPortal
   </div>
 </Portal>`);
+    });
+  });
+
+  describeIf(is('>= 16.4'), 'Profiler', () => {
+    function SomeComponent() {
+      return (
+        <Profiler id="SomeComponent" onRender={() => {}}>
+          <main>
+            <div className="child" />
+          </main>
+        </Profiler>
+      );
+    }
+
+    wrap()
+      .withConsoleThrows()
+      .it('mounts without complaint', () => {
+        expect(() => shallow(<SomeComponent />)).not.to.throw();
+      });
+
+    it('renders', () => {
+      const wrapper = shallow(<SomeComponent />);
+      expect(wrapper.debug()).to.equal(`<Profiler id="SomeComponent" onRender={[Function: onRender]}>
+  <main>
+    <div className="child" />
+  </main>
+</Profiler>`);
+    });
+
+    it('finds elements through Profiler elements', () => {
+      const wrapper = shallow(<SomeComponent />);
+
+      expect(wrapper.find('.child')).to.have.lengthOf(1);
+    });
+
+    it('finds Profiler element', () => {
+      const Parent = () => <span><SomeComponent foo="hello" /></span>;
+
+      const wrapper = shallow(<Parent foo="hello" />);
+      const results = wrapper.find(SomeComponent);
+
+      expect(results).to.have.lengthOf(1);
+      expect(results.type()).to.equal(SomeComponent);
+      expect(results.props()).to.eql({ foo: 'hello' });
+    });
+
+    it('can find Profiler by id', () => {
+      const wrapper = shallow(<SomeComponent />);
+      expect(wrapper.find('[id="SomeComponent"]').exists()).to.equal(true);
+    });
+
+    it('can find Profiler by display name', () => {
+      const wrapper = shallow(<SomeComponent />);
+      const profiler = wrapper.find('Profiler');
+      expect(profiler).to.have.lengthOf(1);
+      expect(profiler.type()).to.equal(Profiler);
+    });
+
+    // TODO: enable when Profiler is no longer unstable
+    it.skip('recognizes render phases', () => {
+      const handleRender = sinon.spy();
+      function AnotherComponent() {
+        return (
+          <Profiler id="AnotherComponent" onRender={handleRender}>
+            <div />
+          </Profiler>
+        );
+      }
+
+      const wrapper = shallow(<AnotherComponent />);
+      expect(handleRender).to.have.property('callCount', 1);
+      expect(handleRender.args[0][1]).to.equal('mount');
+
+      wrapper.setProps({ unusedProp: true });
+      expect(handleRender).to.have.property('callCount', 2);
+      expect(handleRender.args[1][1]).to.equal('update');
+    });
+
+    // TODO: enable when Profiler is no longer unstable
+    it.skip('measures timings', () => {
+      /**
+       * test environment has no access to the performance API at which point
+       * the profiling API has to fallback to Date.now() which isn't precise enough
+       * which results in 0 duration for these simple examples most of the time.
+       * With performance API it should test for greaterThan(0) instead of least(0)
+       */
+      const handleRender = sinon.spy();
+      function AnotherComponent() {
+        return (
+          <Profiler id="AnotherComponent" onRender={handleRender}>
+            <div />
+          </Profiler>
+        );
+      }
+
+      const wrapper = shallow(<AnotherComponent />);
+      expect(handleRender).to.have.property('callCount', 1);
+      const [firstArgs] = handleRender.args;
+      if (typeof performance === 'undefined') {
+        expect(firstArgs[2]).to.be.least(0);
+        expect(firstArgs[3]).to.be.least(0);
+      } else {
+        expect(firstArgs[2]).to.be.greaterThan(0);
+        expect(firstArgs[3]).to.be.greaterThan(0);
+      }
+
+      wrapper.setProps({ unusedProp: true });
+      expect(handleRender).to.have.property('callCount', 2);
+      const [, secondArgs] = handleRender.args;
+      if (typeof performance === 'undefined') {
+        expect(secondArgs[2]).to.be.least(0);
+        expect(secondArgs[3]).to.be.least(0);
+      } else {
+        expect(secondArgs[2]).to.be.greaterThan(0);
+        expect(secondArgs[3]).to.be.greaterThan(0);
+      }
     });
   });
 


### PR DESCRIPTION
Part of #2054

Opening this with failing tests. Will need to establish if we accept those for now or fix before merge. I'm also missing some context what work in `mount` is done by React and what is re-implemented in this package. 

## TODO
1. [x] revert `pretest` removal
2. [x] add find by display name support
3. [x] add find by `id` support
4. [x] investigate missing timings
5. [x] prop warnings for Profiler

## notes

### about find by *

~I guess this is related to `Profiler` not appearing in `wrapper.debug()` output. Might be caused by `Profiler` being one of those "mode-components" (e.g. StrictMode or ConcurrentMode)~ Solved and explained in https://github.com/airbnb/enzyme/pull/2055#discussion_r272426306

### missing timings

These are implented in the fiber related code (ReactFiberCommitWork):
- https://github.com/facebook/react/blob/0c03a474362c27aa9222ae27088782a01402067c/packages/react-reconciler/src/ReactFiberCommitWork.js#L564

`onRender` isn't even called with `ReactTestRenderer.create`. Maybe this is the actual blocker here?
Update: Timings weren't missing. The test environment didn't have a `performance` API available at which point React uses `Date.now` which isn't precise enough to display any duration.

### prop warnings
There is currently a test case that included a bare `<Profiler />` (existed before this PR). Those should trigger warnings about missing `id` and `onRender` props. Probably never triggered since this is not actual prop types validation but happens when creating the fiber: https://github.com/facebook/react/blob/4186952a6f3558eb4fae9f6c5f669bd898dc1d97/packages/react-reconciler/src/ReactFiber.js#L597
Update: Warnings are logged perfectly fine with `mount`. I don't think we need to shim those in `getDisplayName`.