### PR TITLE
[Fix] `shallow`: `x.find()` should not change state of `x`

### DIFF
--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -933,6 +933,18 @@ class ReactSixteenAdapter extends EnzymeAdapter {
     return isElement(element);
   }
 
+  shouldComponentUpdate(prevProps, root) {
+    const instance = root.instance();
+    if (instance !== null) {
+      const { updater, props } = instance;
+      return (
+        updater._renderer._newState !== null || !shallowEqual(prevProps, props)
+      );
+    }
+
+    return true;
+  }
+
   isValidElementType(object) {
     return !!object && isValidElementType(object);
   }

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -2237,9 +2237,12 @@ describe('shallow', () => {
           }
         }
         const wrapper = shallow(<MyComponent />, { disableLifecycleMethods: true });
-        expect(wrapper.find(Table).length).to.equal(0);
+        expect(wrapper.find(Table)).to.have.lengthOf(0);
+
         wrapper.instance().componentDidMount();
-        expect(wrapper.find(Table).length).to.equal(1);
+        // wrapper.update(); // TODO: uncomment or delete
+
+        expect(wrapper.find(Table)).to.have.lengthOf(1);
       });
 
       it('calls shouldComponentUpdate when disableLifecycleMethods flag is true', () => {

--- a/packages/enzyme-test-suite/test/shared/methods/find.jsx
+++ b/packages/enzyme-test-suite/test/shared/methods/find.jsx
@@ -308,6 +308,50 @@ export default function describeFind({
       expect(wrapper.find('.b').find('.c')).to.have.lengthOf(6);
     });
 
+    it('can call find on the same wrapper more than once', () => {
+      class TestComponent extends React.Component {
+        render() {
+          return (
+            <div>
+              <h1>Title</h1>
+              <span key="1">1</span>
+              <span key="2">2</span>
+            </div>
+          );
+        }
+      }
+      const component = Wrap(<TestComponent />);
+
+      const cards = component.find('span');
+
+      const title = component.find('h1'); // for side effects
+      expect(title.is('h1')).to.equal(true);
+
+      expect(cards.at(0).parent().is('div')).to.equal(true);
+    });
+
+    describeIf(is('> 0.13'), 'stateless function components (SFCs)', () => {
+      it('can call find on the same wrapper more than once', () => {
+        function TestComponentSFC() {
+          return (
+            <div>
+              <h1>Title</h1>
+              <span key="1">1</span>
+              <span key="2">2</span>
+            </div>
+          );
+        }
+        const component = Wrap(<TestComponentSFC />);
+
+        const cards = component.find('span');
+
+        const title = component.find('h1'); // for side effects
+        expect(title.is('h1')).to.equal(true);
+
+        expect(cards.at(0).parent().debug()).to.equal('<div />');
+      });
+    });
+
     it('works with an adjacent sibling selector', () => {
       const a = 'some';
       const b = 'text';

--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -473,8 +473,13 @@ class ShallowWrapper {
    */
   getNodesInternal() {
     if (this[ROOT] === this && this.length === 1) {
-      this.update();
+      const adapter = getAdapter(this[OPTIONS]);
+      const prevProps = (this[UNRENDERED] && this[UNRENDERED].props) || {};
+      if (!adapter.shouldComponentUpdate || adapter.shouldComponentUpdate(prevProps, this[ROOT])) {
+        this.update();
+      }
     }
+
     return this[NODES];
   }
 
@@ -569,8 +574,10 @@ class ShallowWrapper {
    */
   unmount() {
     this[RENDERER].unmount();
+    this.update();
     if (this[ROOT][WRAPPING_COMPONENT]) {
       this[ROOT][WRAPPING_COMPONENT].unmount();
+      this[ROOT][WRAPPING_COMPONENT].update();
     }
     return this;
   }


### PR DESCRIPTION
Fixes #1916.