### PR TITLE
[Fix] `shallow`/`mount`: `renderProp`: avoid warning when renderProp function returns null

### DIFF
--- a/packages/enzyme-adapter-utils/package.json
+++ b/packages/enzyme-adapter-utils/package.json
@@ -35,6 +35,7 @@
   "author": "Leland Richardson <leland.richardson@airbnb.com>",
   "license": "MIT",
   "dependencies": {
+    "airbnb-prop-types": "^2.12.0",
     "function.prototype.name": "^1.1.0",
     "object.assign": "^4.1.0",
     "object.fromentries": "^2.0.0",

--- a/packages/enzyme-adapter-utils/src/wrapWithSimpleWrapper.jsx
+++ b/packages/enzyme-adapter-utils/src/wrapWithSimpleWrapper.jsx
@@ -1,16 +1,21 @@
 import React from 'react';
 import { intersects } from 'semver';
+import { or, explicitNull } from 'airbnb-prop-types';
 import PropTypes from 'prop-types';
 
 const propTypes = {
-  children: PropTypes.node.isRequired,
+  children: or([explicitNull().isRequired, PropTypes.node.isRequired]),
+};
+
+const defaultProps = {
+  children: undefined,
 };
 
 const Wrapper = (intersects('>= 0.14', React.version)
   // eslint-disable-next-line prefer-arrow-callback
   ? () => Object.assign(function SimpleSFCWrapper({ children }) {
     return children;
-  }, { propTypes })
+  }, { propTypes, defaultProps })
   : () => {
     class SimpleClassWrapper extends React.Component {
       render() {
@@ -19,6 +24,7 @@ const Wrapper = (intersects('>= 0.14', React.version)
       }
     }
     SimpleClassWrapper.propTypes = propTypes;
+    SimpleClassWrapper.defaultProps = defaultProps;
     return SimpleClassWrapper;
   }
 )();

--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -5611,6 +5611,19 @@ describeWithDOM('mount', () => {
           wrapper.find(ComponentWithRenderProp).renderProp('r')(NaN);
         });
 
+        it('works with null', () => {
+          const wrapper = mount(<MyComponent val={null} />);
+
+          wrapper.find(ComponentWithRenderProp).renderProp('r')(null);
+        });
+
+        // FIXME: figure out how to test this reliably
+        it.skip('throws with undefined', () => {
+          const wrapper = mount(<MyComponent val="" />);
+
+          expect(() => wrapper.find(ComponentWithRenderProp).renderProp('r')(undefined)).to.throw();
+        });
+
         it('works with arrays', () => {
           const wrapper = mount(<MyComponent val={[]} />);
 

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -5792,6 +5792,18 @@ describe('shallow', () => {
           wrapper.find(ComponentWithRenderProp).renderProp('r')(NaN);
         });
 
+        it('works with null', () => {
+          const wrapper = shallow(<MyComponent val={null} />);
+
+          wrapper.find(ComponentWithRenderProp).renderProp('r')(null);
+        });
+
+        it('throws with undefined', () => {
+          const wrapper = shallow(<MyComponent val="" />);
+
+          expect(() => wrapper.find(ComponentWithRenderProp).renderProp('r')(undefined).shallow()).to.throw();
+        });
+
         it('works with arrays', () => {
           const wrapper = shallow(<MyComponent val={[]} />);
 


### PR DESCRIPTION
Fixes #2059