### PR TITLE
[enzyme-adapter-react-16] [fix] Find memo components by constructor

### DIFF
--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -184,7 +184,7 @@ function toTree(vnode) {
       }
       return {
         nodeType: 'function',
-        type: node.elementType.type,
+        type: node.elementType,
         props: { ...node.memoizedProps },
         key: ensureKeyOrUndefined(node.key),
         ref: node.ref,
@@ -648,7 +648,7 @@ class ReactSixteenAdapter extends EnzymeAdapter {
     switch ($$typeofType) {
       case ContextConsumer || NaN: return 'ContextConsumer';
       case ContextProvider || NaN: return 'ContextProvider';
-      case Memo || NaN: return displayNameOfNode(type.type);
+      case Memo || NaN: return displayNameOfNode(type);
       case ForwardRef || NaN: {
         if (type.displayName) {
           return type.displayName;

--- a/packages/enzyme-test-suite/test/shared/methods/find.jsx
+++ b/packages/enzyme-test-suite/test/shared/methods/find.jsx
@@ -858,10 +858,14 @@ export default function describeFind({
 
     describeIf(is('>= 16.6'), 'React.memo', () => {
       it('works with an SFC', () => {
-        const InnerComp = () => <div><span>Hello</span></div>;
+        function InnerComp({ message }) {
+          return <div><span>{message}</span></div>;
+        }
+        const InnerMemo = React.memo(InnerComp);
         const InnerFoo = ({ foo }) => (
           <div>
-            <InnerComp />
+            <InnerComp message="Hello" />
+            <InnerMemo message="find me?" />
             <div className="bar">bar</div>
             <div className="qoo">{foo}</div>
           </div>
@@ -871,7 +875,8 @@ export default function describeFind({
         const wrapper = Wrap(<Foo foo="qux" />);
         const expectedDebug = isShallow
           ? `<div>
-  <InnerComp />
+  <InnerComp message="Hello" />
+  <InnerComp message="find me?" />
   <div className="bar">
     bar
   </div>
@@ -881,10 +886,17 @@ export default function describeFind({
 </div>`
           : `<InnerFoo foo="qux">
   <div>
-    <InnerComp>
+    <InnerComp message="Hello">
       <div>
         <span>
           Hello
+        </span>
+      </div>
+    </InnerComp>
+    <InnerComp message="find me?">
+      <div>
+        <span>
+          find me?
         </span>
       </div>
     </InnerComp>
@@ -897,9 +909,10 @@ export default function describeFind({
   </div>
 </InnerFoo>`;
         expect(wrapper.debug()).to.equal(expectedDebug);
-        expect(wrapper.find('InnerComp')).to.have.lengthOf(1);
+        expect(wrapper.find('InnerComp')).to.have.lengthOf(2);
         expect(wrapper.find('.bar')).to.have.lengthOf(1);
         expect(wrapper.find('.qoo').text()).to.equal('qux');
+        expect(wrapper.find(InnerMemo)).to.have.lengthOf(1);
       });
 
       it('works with a class component', () => {


### PR DESCRIPTION
Follow up on 4149a21983fa0bdad8e5c60059add34016756d0c which attempted to fix #2038. The fix was not working for the scenario described in https://github.com/airbnb/enzyme/issues/2038#issuecomment-475204325.

This PR adds a test for the scenario above and fixes that issue.