### PR TITLE
fix invariant violation in provider

### DIFF
--- a/packages/enzyme-adapter-react-16/src/detectFiberTags.js
+++ b/packages/enzyme-adapter-react-16/src/detectFiberTags.js
@@ -62,13 +62,13 @@ module.exports = function detectFiberTags() {
       ? getFiber(React.createElement(Ctx.Consumer, null, () => null)).tag
       : -1,
     ContextProvider: supportsContext
-      ? getFiber(React.createElement(Ctx.Provider, { value: null })).tag
+      ? getFiber(React.createElement(Ctx.Provider, { value: null }, null)).tag
       : -1,
     ForwardRef: supportsForwardRef
       ? getFiber(React.createElement(FwdRef)).tag
       : -1,
     Profiler: supportsProfiler
-      ? getFiber(React.createElement(React.unstable_Profiler, { id: 'mock', onRender: () => {} })).tag
+      ? getFiber(React.createElement(React.unstable_Profiler, { id: 'mock', onRender() {} })).tag
       : -1,
   };
 };


### PR DESCRIPTION
Hello!

I'm running into an issue when using the latest version of react. 

```
Invariant Violation: Provider(...): Nothing was returned from render. This usually means a return statement is missing. Or, to render nothing, return null.
```

Turns out the context provider in `deterctFiberTags` needs to return a value.