### PR TITLE
Add link to new Preact adapter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ to make a PR to this README and add a link to it! The known 3rd party adapters a
 
 | Adapter Package | For Library | Status |
 | --- | --- | --- |
-| [`preact-enzyme-adapter`](https://github.com/aweary/preact-enzyme-adapater) | [`preact`](https://github.com/developit/preact) | (work in progress) |
+| [`enzyme-adapter-preact-pure`](https://github.com/preactjs/enzyme-adapter-preact-pure) | [`preact`](https://github.com/developit/preact) | (stable) |
 |[`enzyme-adapter-inferno`](https://github.com/bbc/enzyme-adapter-inferno)|[`inferno`](https://github.com/infernojs/inferno)|(work in progress)|
 
 Running Enzyme Tests


### PR DESCRIPTION
A new Preact adapter for Enzyme is available under the [Preact](https://github.com/preactjs) org on GitHub. This PR replaces the link in the README with a reference to the newer one.

This adapter supports all three Enzyme rendering modes as well as the upcoming
Preact v10 release (which is a rewrite of the internals). It also avoids an indirect dependency on React and the need to install the React-compatibility layer in order to use it.

As an aside, as part of this project some work was done to create [type definitions](https://github.com/preactjs/enzyme-adapter-preact-pure/blob/master/types/enzyme/index.d.ts) for Enzyme adapter authors to use. Would there be interest in moving those upstream into enzyme itself at some point?