### PR TITLE
Fix simulate being a no-op for memo components

### DIFF
--- a/packages/enzyme-adapter-react-16.1/src/ReactSixteenOneAdapter.js
+++ b/packages/enzyme-adapter-react-16.1/src/ReactSixteenOneAdapter.js
@@ -326,7 +326,7 @@ class ReactSixteenOneAdapter extends EnzymeAdapter {
           throw new TypeError(`ReactWrapper::simulate() event '${event}' does not exist`);
         }
         // eslint-disable-next-line react/no-find-dom-node
-        eventFn(nodeToHostNode(node), mock);
+        eventFn(adapter.nodeToHostNode(node), mock);
       },
       batchedUpdates(fn) {
         return fn();

--- a/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
+++ b/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
@@ -328,7 +328,7 @@ class ReactSixteenTwoAdapter extends EnzymeAdapter {
           throw new TypeError(`ReactWrapper::simulate() event '${event}' does not exist`);
         }
         // eslint-disable-next-line react/no-find-dom-node
-        eventFn(nodeToHostNode(node), mock);
+        eventFn(adapter.nodeToHostNode(node), mock);
       },
       batchedUpdates(fn) {
         return fn();

--- a/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
+++ b/packages/enzyme-adapter-react-16.3/src/ReactSixteenThreeAdapter.js
@@ -347,7 +347,7 @@ class ReactSixteenThreeAdapter extends EnzymeAdapter {
           throw new TypeError(`ReactWrapper::simulate() event '${event}' does not exist`);
         }
         // eslint-disable-next-line react/no-find-dom-node
-        eventFn(nodeToHostNode(node), mock);
+        eventFn(adapter.nodeToHostNode(node), mock);
       },
       batchedUpdates(fn) {
         return fn();

--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -427,7 +427,7 @@ class ReactSixteenAdapter extends EnzymeAdapter {
         if (!eventFn) {
           throw new TypeError(`ReactWrapper::simulate() event '${event}' does not exist`);
         }
-        eventFn(nodeToHostNode(node), mock);
+        eventFn(adapter.nodeToHostNode(node), mock);
       },
       batchedUpdates(fn) {
         return fn();

--- a/packages/enzyme-test-suite/test/shared/methods/simulate.jsx
+++ b/packages/enzyme-test-suite/test/shared/methods/simulate.jsx
@@ -287,5 +287,30 @@ export default function describeSimulate({
         expect(onClick).to.have.property('callCount', 1);
       });
     });
+
+    describeIf(is('>= 16.6'), 'React.memo', () => {
+      itIf(isMount, 'can simulate events', () => {
+        function Child({ onClick }) {
+          return <button onClick={onClick} type="button" />;
+        }
+        const MemoizedChild = React.memo(Child);
+
+        function Parent(props) {
+          const { onClick } = props;
+
+          return <MemoizedChild onClick={onClick} />;
+        }
+
+        const handleClick = sinon.spy();
+        const wrapper = Wrap(<Parent onClick={handleClick} />);
+
+        wrapper.find(MemoizedChild).props().onClick();
+        expect(handleClick).to.have.property('callCount', 1);
+        wrapper.find(MemoizedChild).simulate('click');
+        expect(handleClick).to.have.property('callCount', 2);
+        wrapper.find(MemoizedChild).props().onClick();
+        expect(handleClick).to.have.property('callCount', 3);
+      });
+    });
   });
 }


### PR DESCRIPTION
Fixes `mount(<MemoizedButton />).simulate('click')` not calling the `onClick` handler.

I strongly suspect this fixes issues with `simulate` not necessarily related to `React.memo` as well.

Alternate implementation without arrow functions and outer `this`: 9ef0776bc3fee3d539558c1ba486feb99273b223