### PR TITLE
Ensure the right versions of React / adapters are installed

### DIFF
--- a/packages/enzyme-adapter-react-helper/src/enzyme-adapter-react-install.js
+++ b/packages/enzyme-adapter-react-helper/src/enzyme-adapter-react-install.js
@@ -5,6 +5,7 @@ import 'airbnb-js-shims';
 
 import semver from 'semver';
 import npmRun from 'npm-run';
+import getAdapterForReactVersion from './getAdapterForReactVersion';
 
 const reactEnv = process.env.REACT;
 const reactArg = process.argv[2];
@@ -41,68 +42,12 @@ try {
 }
 
 console.log(`Installing React@${reactVersion} and related packages...`);
-if (semver.intersects(reactVersion, '^16.4.0-0')) {
-  try {
-    npmRun.execSync('install-peerdeps -S enzyme-adapter-react-16', { stdio: 'inherit' });
-  } catch (e) {
-    console.error('An installation failed');
-    console.log(e);
-    process.exit(16);
-  }
-} else if (semver.intersects(reactVersion, '~16.3.0-0')) {
-  try {
-    npmRun.execSync('install-peerdeps -S enzyme-adapter-react-16.3', { stdio: 'inherit' });
-  } catch (e) {
-    console.error('An installation failed');
-    console.log(e);
-    process.exit(162);
-  }
-} else if (semver.intersects(reactVersion, '~16.2')) {
-  try {
-    npmRun.execSync('install-peerdeps -S enzyme-adapter-react-16.2', { stdio: 'inherit' });
-  } catch (e) {
-    console.error('An installation failed');
-    console.log(e);
-    process.exit(162);
-  }
-} else if (semver.intersects(reactVersion, '~16.0.0-0 || ~16.1')) {
-  try {
-    npmRun.execSync('install-peerdeps -S enzyme-adapter-react-16.1', { stdio: 'inherit' });
-  } catch (e) {
-    console.error('An installation failed');
-    console.log(e);
-    process.exit(161);
-  }
-} else if (semver.intersects(reactVersion, '^15.5.0')) {
-  try {
-    npmRun.execSync('install-peerdeps -S enzyme-adapter-react-15', { stdio: 'inherit' });
-  } catch (e) {
-    console.error('An installation failed');
-    console.log(e);
-    process.exit(155);
-  }
-} else if (semver.intersects(reactVersion, '15.0.0 - 15.4.x')) {
-  try {
-    npmRun.execSync('install-peerdeps -S enzyme-adapter-react-15.4', { stdio: 'inherit' });
-  } catch (e) {
-    console.error('An installation failed');
-    console.log(e);
-    process.exit(15);
-  }
-} else if (semver.intersects(reactVersion, '^0.14.0')) {
-  try {
-    npmRun.execSync('install-peerdeps -S enzyme-adapter-react-14', { stdio: 'inherit' });
-  } catch (e) {
-    console.error('An installation failed');
-    console.log(e);
-    process.exit(14);
-  }
-} else if (semver.intersects(reactVersion, '^0.13.0')) {
-  try {
-    npmRun.execSync('install-peerdeps -S enzyme-adapter-react-13', { stdio: 'inherit' });
-  } catch (e) {
-    console.error('An installation failed');
-    console.log(e);
-    process.exit(13);
-  }
+const adapterName = getAdapterForReactVersion(reactVersion);
+
+try {
+  npmRun.execSync(`install-peerdeps -S ${adapterName}`, { stdio: 'inherit' });
+} catch (e) {
+  console.error('An installation failed');
+  console.log(e);
+  process.exit(666);
 }

--- a/packages/enzyme-adapter-react-helper/src/getAdapterForReactVersion.js
+++ b/packages/enzyme-adapter-react-helper/src/getAdapterForReactVersion.js
@@ -1,0 +1,32 @@
+import semver from 'semver';
+
+export default function getAdapterForReactVersion(reactVersion) {
+  const normalizedVersion = semver.coerce(reactVersion);
+
+  if (semver.satisfies(normalizedVersion, '^16.4.0-0')) {
+    return 'enzyme-adapter-react-16';
+  }
+  if (semver.satisfies(normalizedVersion, '~16.3.0-0')) {
+    return 'enzyme-adapter-react-16.3';
+  }
+  if (semver.satisfies(normalizedVersion, '~16.2')) {
+    return 'enzyme-adapter-react-16.2';
+  }
+  if (semver.satisfies(normalizedVersion, '~16.0.0-0 || ~16.1')) {
+    return 'enzyme-adapter-react-16.1';
+  }
+  if (semver.satisfies(normalizedVersion, '^15.5.0')) {
+    return 'enzyme-adapter-react-15';
+  }
+  if (semver.satisfies(normalizedVersion, '15.0.0 - 15.4.x')) {
+    return 'enzyme-adapter-react-15.4';
+  }
+  if (semver.satisfies(normalizedVersion, '^0.14.0')) {
+    return 'enzyme-adapter-react-14';
+  }
+  if (semver.satisfies(normalizedVersion, '^0.13.0')) {
+    return 'enzyme-adapter-react-13';
+  }
+
+  throw new RangeError(`No Enzyme adapter could be found for React version “${reactVersion}”`);
+}

--- a/packages/enzyme-test-suite/package.json
+++ b/packages/enzyme-test-suite/package.json
@@ -33,6 +33,7 @@
     "chai": "^4.2.0",
     "create-react-class": "^15.6.3",
     "enzyme": "^3.9.0",
+    "enzyme-adapter-react-helper": "^1.3.3",
     "enzyme-adapter-utils": "^1.10.1",
     "html-element-map": "^1.0.1",
     "jsdom": "^6.5.1",

--- a/packages/enzyme-test-suite/test/enzyme-adapter-react-install-spec.js
+++ b/packages/enzyme-test-suite/test/enzyme-adapter-react-install-spec.js
@@ -1,0 +1,94 @@
+import { expect } from 'chai';
+import getAdapterForReactVersion from 'enzyme-adapter-react-helper/src/getAdapterForReactVersion';
+
+describe('enzyme-adapter-react-helper', () => {
+  describe('getAdapterForReactVersion', () => {
+    it('returns "enzyme-adapter-react-16" for 16.4 and up', () => {
+      expect(getAdapterForReactVersion('16.8')).to.equal('enzyme-adapter-react-16');
+      expect(getAdapterForReactVersion('16.8.0')).to.equal('enzyme-adapter-react-16');
+      expect(getAdapterForReactVersion('16.8.6')).to.equal('enzyme-adapter-react-16');
+
+      expect(getAdapterForReactVersion('16.7')).to.equal('enzyme-adapter-react-16');
+      expect(getAdapterForReactVersion('16.7.0')).to.equal('enzyme-adapter-react-16');
+
+      expect(getAdapterForReactVersion('16.6')).to.equal('enzyme-adapter-react-16');
+      expect(getAdapterForReactVersion('16.6.0')).to.equal('enzyme-adapter-react-16');
+      expect(getAdapterForReactVersion('16.6.3')).to.equal('enzyme-adapter-react-16');
+
+      expect(getAdapterForReactVersion('16.5')).to.equal('enzyme-adapter-react-16');
+      expect(getAdapterForReactVersion('16.5.0')).to.equal('enzyme-adapter-react-16');
+      expect(getAdapterForReactVersion('16.5.2')).to.equal('enzyme-adapter-react-16');
+
+      expect(getAdapterForReactVersion('16.4')).to.equal('enzyme-adapter-react-16');
+      expect(getAdapterForReactVersion('16.4.0')).to.equal('enzyme-adapter-react-16');
+      expect(getAdapterForReactVersion('16.4.2')).to.equal('enzyme-adapter-react-16');
+    });
+
+    it('returns "enzyme-adapter-react-16.3" for 16.3', () => {
+      expect(getAdapterForReactVersion('16.3')).to.equal('enzyme-adapter-react-16.3');
+      expect(getAdapterForReactVersion('16.3.0')).to.equal('enzyme-adapter-react-16.3');
+      expect(getAdapterForReactVersion('16.3.2')).to.equal('enzyme-adapter-react-16.3');
+    });
+
+    it('returns "enzyme-adapter-react-16.2" for 16.2', () => {
+      expect(getAdapterForReactVersion('16.2')).to.equal('enzyme-adapter-react-16.2');
+      expect(getAdapterForReactVersion('16.2.0')).to.equal('enzyme-adapter-react-16.2');
+    });
+
+    it('returns "enzyme-adapter-react-16.1" for 16.0 and 16.1', () => {
+      expect(getAdapterForReactVersion('16.1')).to.equal('enzyme-adapter-react-16.1');
+      expect(getAdapterForReactVersion('16.1.0')).to.equal('enzyme-adapter-react-16.1');
+      expect(getAdapterForReactVersion('16.1.1')).to.equal('enzyme-adapter-react-16.1');
+
+      expect(getAdapterForReactVersion('16.0')).to.equal('enzyme-adapter-react-16.1');
+      expect(getAdapterForReactVersion('16.0.0')).to.equal('enzyme-adapter-react-16.1');
+    });
+
+    it('returns "enzyme-adapter-react-15" for 15.5', () => {
+      expect(getAdapterForReactVersion('15.5')).to.equal('enzyme-adapter-react-15');
+      expect(getAdapterForReactVersion('15.5.0')).to.equal('enzyme-adapter-react-15');
+      expect(getAdapterForReactVersion('15.5.4')).to.equal('enzyme-adapter-react-15');
+    });
+
+    it('returns "enzyme-adapter-react-15.4" for 15.0, 15.1, 15.2, 15.3, and 15.4', () => {
+      expect(getAdapterForReactVersion('15.4')).to.equal('enzyme-adapter-react-15.4');
+      expect(getAdapterForReactVersion('15.4.0')).to.equal('enzyme-adapter-react-15.4');
+      expect(getAdapterForReactVersion('15.4.2')).to.equal('enzyme-adapter-react-15.4');
+
+      expect(getAdapterForReactVersion('15.3')).to.equal('enzyme-adapter-react-15.4');
+      expect(getAdapterForReactVersion('15.3.0')).to.equal('enzyme-adapter-react-15.4');
+      expect(getAdapterForReactVersion('15.3.2')).to.equal('enzyme-adapter-react-15.4');
+
+      expect(getAdapterForReactVersion('15.2')).to.equal('enzyme-adapter-react-15.4');
+      expect(getAdapterForReactVersion('15.2.0')).to.equal('enzyme-adapter-react-15.4');
+      expect(getAdapterForReactVersion('15.2.1')).to.equal('enzyme-adapter-react-15.4');
+
+      expect(getAdapterForReactVersion('15.1')).to.equal('enzyme-adapter-react-15.4');
+      expect(getAdapterForReactVersion('15.1.0')).to.equal('enzyme-adapter-react-15.4');
+
+      expect(getAdapterForReactVersion('15.0')).to.equal('enzyme-adapter-react-15.4');
+      expect(getAdapterForReactVersion('15.0.0')).to.equal('enzyme-adapter-react-15.4');
+      expect(getAdapterForReactVersion('15.0.2')).to.equal('enzyme-adapter-react-15.4');
+    });
+
+    it('returns "enzyme-adapter-react-14" for 0.14', () => {
+      expect(getAdapterForReactVersion('0.14')).to.equal('enzyme-adapter-react-14');
+      expect(getAdapterForReactVersion('0.14.0')).to.equal('enzyme-adapter-react-14');
+      expect(getAdapterForReactVersion('0.14.8')).to.equal('enzyme-adapter-react-14');
+    });
+
+    it('returns "enzyme-adapter-react-13" for 0.13', () => {
+      expect(getAdapterForReactVersion('0.13')).to.equal('enzyme-adapter-react-13');
+      expect(getAdapterForReactVersion('0.13.0')).to.equal('enzyme-adapter-react-13');
+      expect(getAdapterForReactVersion('0.13.3')).to.equal('enzyme-adapter-react-13');
+    });
+
+    it('throws an error for unrecognized versions', () => {
+      const version = '1337';
+      expect(() => getAdapterForReactVersion(version)).to.throw(
+        RangeError,
+        `No Enzyme adapter could be found for React version “${version}”`,
+      );
+    });
+  });
+});


### PR DESCRIPTION
There's a weird issue where partial React versions can result in the wrong versions of React being installed. This happens because `semver.intersects` is returning something weird when both are true:

- A partial version of React is used - for example, 16.3
- And it's compared against a version with prerelease specifiers in it

See [this truth table](https://stackblitz.com/edit/semver-intersection-truth-table) which highlights the issue.

In this PR we:
- Separate out a function for determining the right adapter to install (which makes testing it easier)
- Convert to using `semver.satisfies` from `semver.intersects`

@ljharb , what do you think?