### PR TITLE
Add 'has' to dependencies for enzyme-adapter-react-16

### DIFF
--- a/packages/enzyme-adapter-react-16.1/.eslintrc
+++ b/packages/enzyme-adapter-react-16.1/.eslintrc
@@ -3,9 +3,6 @@
   "root": true,
   "rules": {
     "max-len": 0,
-    "import/no-extraneous-dependencies": 0,
-    "import/no-unresolved": 0,
-    "import/extensions": 0,
     "react/no-deprecated": 0,
     "react/no-find-dom-node": 0,
     "react/no-multi-comp": 0,

--- a/packages/enzyme-adapter-react-16.2/.eslintrc
+++ b/packages/enzyme-adapter-react-16.2/.eslintrc
@@ -3,9 +3,6 @@
   "root": true,
   "rules": {
     "max-len": 0,
-    "import/no-extraneous-dependencies": 0,
-    "import/no-unresolved": 0,
-    "import/extensions": 0,
     "react/no-deprecated": 0,
     "react/no-find-dom-node": 0,
     "react/no-multi-comp": 0,

--- a/packages/enzyme-adapter-react-16.3/.eslintrc
+++ b/packages/enzyme-adapter-react-16.3/.eslintrc
@@ -3,9 +3,6 @@
   "root": true,
   "rules": {
     "max-len": 0,
-    "import/no-extraneous-dependencies": 0,
-    "import/no-unresolved": 0,
-    "import/extensions": 0,
     "react/no-deprecated": 0,
     "react/no-find-dom-node": 0,
     "react/no-multi-comp": 0,

--- a/packages/enzyme-adapter-react-16/.eslintrc
+++ b/packages/enzyme-adapter-react-16/.eslintrc
@@ -3,9 +3,9 @@
   "root": true,
   "rules": {
     "max-len": 0,
-    "import/no-extraneous-dependencies": 0,
-    "import/no-unresolved": 0,
-    "import/extensions": 0,
+    "import/no-extraneous-dependencies": 2,
+    "import/no-unresolved": 2,
+    "import/extensions": 2,
     "react/no-deprecated": 0,
     "react/no-find-dom-node": 0,
     "react/no-multi-comp": 0,

--- a/packages/enzyme-adapter-react-16/package.json
+++ b/packages/enzyme-adapter-react-16/package.json
@@ -36,6 +36,7 @@
   "license": "MIT",
   "dependencies": {
     "enzyme-adapter-utils": "^1.12.0",
+    "has": "^1.0.3",
     "object.assign": "^4.1.0",
     "object.values": "^1.1.0",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
Adds missing dependency to enzyme-adapter-react-16 – see #2124 for details.