### PR TITLE
Fix adapter helper regression

### DIFF
--- a/packages/enzyme-adapter-react-helper/src/getAdapterForReactVersion.js
+++ b/packages/enzyme-adapter-react-helper/src/getAdapterForReactVersion.js
@@ -1,30 +1,36 @@
 import semver from 'semver';
 
-export default function getAdapterForReactVersion(reactVersion) {
-  const normalizedVersion = semver.coerce(reactVersion);
+function removePreRelease(version) {
+  return semver.inc(version, 'patch');
+}
 
-  if (semver.satisfies(normalizedVersion, '^16.4.0-0')) {
+export default function getAdapterForReactVersion(reactVersion) {
+  const versionRange = semver.prerelease(reactVersion)
+    ? removePreRelease(reactVersion)
+    : semver.validRange(reactVersion);
+
+  if (semver.intersects(versionRange, '^16.4.0')) {
     return 'enzyme-adapter-react-16';
   }
-  if (semver.satisfies(normalizedVersion, '~16.3.0-0')) {
+  if (semver.intersects(versionRange, '~16.3.0')) {
     return 'enzyme-adapter-react-16.3';
   }
-  if (semver.satisfies(normalizedVersion, '~16.2')) {
+  if (semver.intersects(versionRange, '~16.2')) {
     return 'enzyme-adapter-react-16.2';
   }
-  if (semver.satisfies(normalizedVersion, '~16.0.0-0 || ~16.1')) {
+  if (semver.intersects(versionRange, '~16.0.0 || ~16.1')) {
     return 'enzyme-adapter-react-16.1';
   }
-  if (semver.satisfies(normalizedVersion, '^15.5.0')) {
+  if (semver.intersects(versionRange, '^15.5.0')) {
     return 'enzyme-adapter-react-15';
   }
-  if (semver.satisfies(normalizedVersion, '15.0.0 - 15.4.x')) {
+  if (semver.intersects(versionRange, '15.0.0 - 15.4.x')) {
     return 'enzyme-adapter-react-15.4';
   }
-  if (semver.satisfies(normalizedVersion, '^0.14.0')) {
+  if (semver.intersects(versionRange, '^0.14.0')) {
     return 'enzyme-adapter-react-14';
   }
-  if (semver.satisfies(normalizedVersion, '^0.13.0')) {
+  if (semver.intersects(versionRange, '^0.13.0')) {
     return 'enzyme-adapter-react-13';
   }
 

--- a/packages/enzyme-test-suite/test/enzyme-adapter-react-install-spec.js
+++ b/packages/enzyme-test-suite/test/enzyme-adapter-react-install-spec.js
@@ -3,15 +3,20 @@ import getAdapterForReactVersion from 'enzyme-adapter-react-helper/src/getAdapte
 
 describe('enzyme-adapter-react-helper', () => {
   describe('getAdapterForReactVersion', () => {
-    it('returns "enzyme-adapter-react-16" for 16.4 and up', () => {
+    it('returns "enzyme-adapter-react-16" when intended', () => {
+      expect(getAdapterForReactVersion('16')).to.equal('enzyme-adapter-react-16');
+
       expect(getAdapterForReactVersion('16.8')).to.equal('enzyme-adapter-react-16');
+      expect(getAdapterForReactVersion('16.8.0-alpha.1')).to.equal('enzyme-adapter-react-16');
       expect(getAdapterForReactVersion('16.8.0')).to.equal('enzyme-adapter-react-16');
       expect(getAdapterForReactVersion('16.8.6')).to.equal('enzyme-adapter-react-16');
 
       expect(getAdapterForReactVersion('16.7')).to.equal('enzyme-adapter-react-16');
+      expect(getAdapterForReactVersion('16.7.0-alpha.2')).to.equal('enzyme-adapter-react-16');
       expect(getAdapterForReactVersion('16.7.0')).to.equal('enzyme-adapter-react-16');
 
       expect(getAdapterForReactVersion('16.6')).to.equal('enzyme-adapter-react-16');
+      expect(getAdapterForReactVersion('16.6.0-alpha.8af6728')).to.equal('enzyme-adapter-react-16');
       expect(getAdapterForReactVersion('16.6.0')).to.equal('enzyme-adapter-react-16');
       expect(getAdapterForReactVersion('16.6.3')).to.equal('enzyme-adapter-react-16');
 
@@ -20,65 +25,95 @@ describe('enzyme-adapter-react-helper', () => {
       expect(getAdapterForReactVersion('16.5.2')).to.equal('enzyme-adapter-react-16');
 
       expect(getAdapterForReactVersion('16.4')).to.equal('enzyme-adapter-react-16');
+      expect(getAdapterForReactVersion('16.4.0-alpha.0911da3')).to.equal('enzyme-adapter-react-16');
       expect(getAdapterForReactVersion('16.4.0')).to.equal('enzyme-adapter-react-16');
       expect(getAdapterForReactVersion('16.4.2')).to.equal('enzyme-adapter-react-16');
     });
 
-    it('returns "enzyme-adapter-react-16.3" for 16.3', () => {
+    it('returns "enzyme-adapter-react-16.3" when intended', () => {
       expect(getAdapterForReactVersion('16.3')).to.equal('enzyme-adapter-react-16.3');
+      expect(getAdapterForReactVersion('16.3.0-alpha.3')).to.equal('enzyme-adapter-react-16.3');
+      expect(getAdapterForReactVersion('16.3.0-rc.0')).to.equal('enzyme-adapter-react-16.3');
       expect(getAdapterForReactVersion('16.3.0')).to.equal('enzyme-adapter-react-16.3');
       expect(getAdapterForReactVersion('16.3.2')).to.equal('enzyme-adapter-react-16.3');
     });
 
-    it('returns "enzyme-adapter-react-16.2" for 16.2', () => {
+    it('returns "enzyme-adapter-react-16.2" when intended', () => {
       expect(getAdapterForReactVersion('16.2')).to.equal('enzyme-adapter-react-16.2');
       expect(getAdapterForReactVersion('16.2.0')).to.equal('enzyme-adapter-react-16.2');
     });
 
-    it('returns "enzyme-adapter-react-16.1" for 16.0 and 16.1', () => {
+    it('returns "enzyme-adapter-react-16.1" when intended', () => {
       expect(getAdapterForReactVersion('16.1')).to.equal('enzyme-adapter-react-16.1');
+      expect(getAdapterForReactVersion('16.1.0-beta.1')).to.equal('enzyme-adapter-react-16.1');
+      expect(getAdapterForReactVersion('16.1.0-rc')).to.equal('enzyme-adapter-react-16.1');
       expect(getAdapterForReactVersion('16.1.0')).to.equal('enzyme-adapter-react-16.1');
       expect(getAdapterForReactVersion('16.1.1')).to.equal('enzyme-adapter-react-16.1');
 
       expect(getAdapterForReactVersion('16.0')).to.equal('enzyme-adapter-react-16.1');
+      expect(getAdapterForReactVersion('16.0.0-alpha.13')).to.equal('enzyme-adapter-react-16.1');
+      expect(getAdapterForReactVersion('16.0.0-beta.5')).to.equal('enzyme-adapter-react-16.1');
+      expect(getAdapterForReactVersion('16.0.0-rc.3')).to.equal('enzyme-adapter-react-16.1');
       expect(getAdapterForReactVersion('16.0.0')).to.equal('enzyme-adapter-react-16.1');
     });
 
-    it('returns "enzyme-adapter-react-15" for 15.5', () => {
+    it('returns "enzyme-adapter-react-15" when intended', () => {
+      expect(getAdapterForReactVersion('15')).to.equal('enzyme-adapter-react-15');
+
+      expect(getAdapterForReactVersion('15.6')).to.equal('enzyme-adapter-react-15');
+      expect(getAdapterForReactVersion('15.6.0-rc.1')).to.equal('enzyme-adapter-react-15');
+      expect(getAdapterForReactVersion('15.6.0')).to.equal('enzyme-adapter-react-15');
+      expect(getAdapterForReactVersion('15.6.1')).to.equal('enzyme-adapter-react-15');
+
       expect(getAdapterForReactVersion('15.5')).to.equal('enzyme-adapter-react-15');
+      expect(getAdapterForReactVersion('15.5.0-rc.2')).to.equal('enzyme-adapter-react-15');
       expect(getAdapterForReactVersion('15.5.0')).to.equal('enzyme-adapter-react-15');
       expect(getAdapterForReactVersion('15.5.4')).to.equal('enzyme-adapter-react-15');
     });
 
-    it('returns "enzyme-adapter-react-15.4" for 15.0, 15.1, 15.2, 15.3, and 15.4', () => {
+    it('returns "enzyme-adapter-react-15.4" when intended', () => {
       expect(getAdapterForReactVersion('15.4')).to.equal('enzyme-adapter-react-15.4');
+      expect(getAdapterForReactVersion('15.4.0-rc.4')).to.equal('enzyme-adapter-react-15.4');
       expect(getAdapterForReactVersion('15.4.0')).to.equal('enzyme-adapter-react-15.4');
       expect(getAdapterForReactVersion('15.4.2')).to.equal('enzyme-adapter-react-15.4');
 
       expect(getAdapterForReactVersion('15.3')).to.equal('enzyme-adapter-react-15.4');
+      expect(getAdapterForReactVersion('15.3.0-rc.3')).to.equal('enzyme-adapter-react-15.4');
       expect(getAdapterForReactVersion('15.3.0')).to.equal('enzyme-adapter-react-15.4');
+      expect(getAdapterForReactVersion('15.3.1-rc.2')).to.equal('enzyme-adapter-react-15.4');
+      expect(getAdapterForReactVersion('15.3.1')).to.equal('enzyme-adapter-react-15.4');
+      expect(getAdapterForReactVersion('15.3.2-rc.1')).to.equal('enzyme-adapter-react-15.4');
       expect(getAdapterForReactVersion('15.3.2')).to.equal('enzyme-adapter-react-15.4');
 
       expect(getAdapterForReactVersion('15.2')).to.equal('enzyme-adapter-react-15.4');
+      expect(getAdapterForReactVersion('15.2.0-rc.2')).to.equal('enzyme-adapter-react-15.4');
       expect(getAdapterForReactVersion('15.2.0')).to.equal('enzyme-adapter-react-15.4');
       expect(getAdapterForReactVersion('15.2.1')).to.equal('enzyme-adapter-react-15.4');
 
       expect(getAdapterForReactVersion('15.1')).to.equal('enzyme-adapter-react-15.4');
+      expect(getAdapterForReactVersion('15.1.0-alpha.1')).to.equal('enzyme-adapter-react-15.4');
       expect(getAdapterForReactVersion('15.1.0')).to.equal('enzyme-adapter-react-15.4');
 
       expect(getAdapterForReactVersion('15.0')).to.equal('enzyme-adapter-react-15.4');
       expect(getAdapterForReactVersion('15.0.0')).to.equal('enzyme-adapter-react-15.4');
       expect(getAdapterForReactVersion('15.0.2')).to.equal('enzyme-adapter-react-15.4');
+      expect(getAdapterForReactVersion('15.0.3-alpha.2')).to.equal('enzyme-adapter-react-15.4');
     });
 
-    it('returns "enzyme-adapter-react-14" for 0.14', () => {
+    it('returns "enzyme-adapter-react-14" when intended', () => {
       expect(getAdapterForReactVersion('0.14')).to.equal('enzyme-adapter-react-14');
+      expect(getAdapterForReactVersion('0.14.0-alpha3')).to.equal('enzyme-adapter-react-14');
+      expect(getAdapterForReactVersion('0.14.0-beta3')).to.equal('enzyme-adapter-react-14');
+      expect(getAdapterForReactVersion('0.14.0-rc1')).to.equal('enzyme-adapter-react-14');
       expect(getAdapterForReactVersion('0.14.0')).to.equal('enzyme-adapter-react-14');
       expect(getAdapterForReactVersion('0.14.8')).to.equal('enzyme-adapter-react-14');
     });
 
-    it('returns "enzyme-adapter-react-13" for 0.13', () => {
+    it('returns "enzyme-adapter-react-13" when intended', () => {
       expect(getAdapterForReactVersion('0.13')).to.equal('enzyme-adapter-react-13');
+      expect(getAdapterForReactVersion('0.13.0-alpha.2')).to.equal('enzyme-adapter-react-13');
+      expect(getAdapterForReactVersion('0.13.0-beta.2')).to.equal('enzyme-adapter-react-13');
+      expect(getAdapterForReactVersion('0.13.0-rc2')).to.equal('enzyme-adapter-react-13');
       expect(getAdapterForReactVersion('0.13.0')).to.equal('enzyme-adapter-react-13');
       expect(getAdapterForReactVersion('0.13.3')).to.equal('enzyme-adapter-react-13');
     });


### PR DESCRIPTION
Fixes a regression caused by #2116.

If we specify `enzyme-adapter-react-install 16`, we want the latest version of the adapter supporting React 16 to be installed.

After #2116, however, we ended up getting the earliest version supporting React 16. The fix is to treat the provided version as a range (so 16 is basically `>= 16 < 17`) instead of a version (16 is `16.0.0`).

Unfortunately, pre-release versions complicates this, and this solution right now drops special handling for pre-release versions.