### PR TITLE
Update childAt.md

### DIFF
--- a/docs/api/ShallowWrapper/childAt.md
+++ b/docs/api/ShallowWrapper/childAt.md
@@ -25,4 +25,4 @@ expect(wrapper.find('ul').childAt(0).type()).to.equal('li');
 - [`.parents() => ShallowWrapper`](parents.md)
 - [`.parent() => ShallowWrapper`](parent.md)
 - [`.closest(selector) => ShallowWrapper`](closest.md)
-- [`.children() => ReactWrapper`](children.md)
+- [`.children() => ShallowWrapper`](children.md)


### PR DESCRIPTION
The section [Related Methods](https://airbnb.io/enzyme/docs/api/ShallowWrapper/childAt.html#) method says that method `.children()` must return a new wrapper with the type `ReactWrapper`, but if we follow the link, we'll see that method `.children()` returns a new wrapper with the type `ShallowWrapper`.