### PR TITLE
Wrap mounts simulate() in ReactTestUtils.act()

### DIFF
--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -474,7 +474,9 @@ class ReactSixteenAdapter extends EnzymeAdapter {
         if (!eventFn) {
           throw new TypeError(`ReactWrapper::simulate() event '${event}' does not exist`);
         }
-        eventFn(adapter.nodeToHostNode(node), mock);
+        wrapAct(() => {
+          eventFn(adapter.nodeToHostNode(node), mock);
+        });
       },
       batchedUpdates(fn) {
         return fn();

--- a/packages/enzyme-test-suite/test/shared/methods/simulate.jsx
+++ b/packages/enzyme-test-suite/test/shared/methods/simulate.jsx
@@ -13,6 +13,8 @@ import {
 
 import {
   memo,
+  useEffect,
+  useState,
 } from '../../_helpers/react-compat';
 
 export default function describeSimulate({
@@ -314,6 +316,31 @@ export default function describeSimulate({
         expect(handleClick).to.have.property('callCount', 2);
         wrapper.find(MemoizedChild).props().onClick();
         expect(handleClick).to.have.property('callCount', 3);
+      });
+    });
+
+    describeIf(is('>= 16.8'), 'hooks', () => {
+      // TODO: fix for shallow when useEffect works for shallow
+      itIf(!isShallow, 'works with `useEffect` simulated events', () => {
+        const effectSpy = sinon.spy();
+        function ComponentUsingEffectHook() {
+          useEffect(effectSpy);
+          const [counter, setCounter] = useState(0);
+
+          return (
+            <button type="button" onClick={() => setCounter(counter + 1)}>{counter}</button>
+          );
+        }
+        const wrapper = Wrap(<ComponentUsingEffectHook />);
+
+        const button = wrapper.find('button');
+        expect(button.text()).to.equal('0');
+        expect(effectSpy).to.have.property('callCount', 1);
+
+        button.simulate('click');
+
+        expect(button.text()).to.equal('1');
+        expect(effectSpy).to.have.property('callCount', 2);
       });
     });
   });


### PR DESCRIPTION
Wraps the mount simulate method in ReactTestUtils.act() to correctly
allow component interactions to be tested in a synchronous way

Fixes #2084