### PR TITLE
Support for an optional `last` argument, to count backward

### DIFF
--- a/docs/api/ShallowWrapper/last.md
+++ b/docs/api/ShallowWrapper/last.md
@@ -2,6 +2,10 @@
 
 Reduce the set of matched nodes to the last in the set, just like `.at(length - 1)`.
 
+#### Arguments
+
+1. fromIndex (Number [optional]): The index at which item you wan't moving backwards.
+
 
 #### Returns
 
@@ -13,6 +17,11 @@ Reduce the set of matched nodes to the last in the set, just like `.at(length - 
 ```jsx
 const wrapper = shallow(<MyComponent />);
 expect(wrapper.find(Foo).last().props().foo).to.equal('bar');
+```
+
+```jsx
+const wrapper = shallow(<MyComponent />);
+expect(wrapper.find(Foo).last(-1).props().foo).to.equal('baz');
 ```
 
 

--- a/packages/enzyme-test-suite/test/shared/methods/last.jsx
+++ b/packages/enzyme-test-suite/test/shared/methods/last.jsx
@@ -16,5 +16,16 @@ export default function describeLast({
       ));
       expect(wrapper.find('.bar').last().hasClass('baz')).to.equal(true);
     });
+    it('should return the second last node in the current set', () => {
+      const wrapper = Wrap((
+        <div>
+          <div className="bar" />
+          <div className="bar" />
+          <div className="bar baz" />
+          <div className="bar" />
+        </div>
+      ));
+      expect(wrapper.find('.bar').last(-1).hasClass('baz')).to.equal(true); 
+    });
   });
 }

--- a/packages/enzyme/src/ReactWrapper.js
+++ b/packages/enzyme/src/ReactWrapper.js
@@ -1123,10 +1123,14 @@ class ReactWrapper {
   /**
    * Returns a wrapper around the last node of the current wrapper.
    *
+   * @param {Number} fromIndex (optional)
    * @returns {ReactWrapper}
    */
-  last() {
-    return this.at(this.length - 1);
+  last(fromIndex = 0) {
+    const lengthToReturn = fromIndex >= 0
+      ? -1
+      : fromIndex - 1;
+    return this.at(this.length + lengthToReturn);
   }
 
   /**


### PR DESCRIPTION
With this PR I aim to add an optional argument to the `last` _filter_, so address the scenario where you might not wan't the last, but the second last. But without having to keep a count of children, to then use the `.at(index)`.

I see it work like this:

```jsx
const wrapper = shallow(<ul>
	<li>a</li>
	<li>b</li>
	<li>c</li>
	<li>d</li>
</ul>);

expect(wrapper.find('li').last().text()).toEqual('d');
expect(wrapper.find('li').last(-1).text()).toEqual('c');
// or
const children = wrapper.find('li')
expect(children.at(children.length - 2).text()).toEqual('c');
```