### PR TITLE
React hooks test case part 2 -- useMemo

### DIFF
--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -31,6 +31,7 @@ import {
   Suspense,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useState,
 } from './_helpers/react-compat';
 import {
@@ -1033,6 +1034,42 @@ describeWithDOM('mount', () => {
 </ComponentUsingLayoutEffectHook>`);
         done();
       }, 100);
+    });
+
+    it('get same value when using `useMemo` and rerender with same prop in dependencies', () => {
+      function Child() {
+        return false;
+      }
+      function ComponentUsingMemoHook(props) {
+        const { count } = props;
+        const memoized = useMemo(() => ({ result: count * 2 }), [count]);
+        return (
+          <Child memoized={memoized} />
+        );
+      }
+      const wrapper = mount(<ComponentUsingMemoHook count={1} />);
+      const initialValue = wrapper.find(Child).prop('memoized');
+      wrapper.setProps({ unRelatedProp: '123' });
+      const nextValue = wrapper.find(Child).prop('memoized');
+      expect(initialValue).to.equal(nextValue);
+    });
+
+    it('get different value when using `useMemo` and rerender with different prop in dependencies', () => {
+      function Child() {
+        return false;
+      }
+      function ComponentUsingMemoHook(props) {
+        const { count, relatedProp } = props;
+        const memoized = useMemo(() => ({ result: count * 2 }), [count, relatedProp]);
+        return (
+          <Child memoized={memoized} relatedProp={relatedProp} />
+        );
+      }
+      const wrapper = mount(<ComponentUsingMemoHook relatedProp="456" count={1} />);
+      const initialValue = wrapper.find(Child).prop('memoized');
+      wrapper.setProps({ relatedProp: '123' });
+      const nextValue = wrapper.find(Child).prop('memoized');
+      expect(initialValue).to.not.equal(nextValue);
     });
   });
 

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -27,6 +27,7 @@ import {
   PureComponent,
   Suspense,
   useEffect,
+  useMemo,
   useLayoutEffect,
   useState,
   Profiler,
@@ -1209,6 +1210,42 @@ describe('shallow', () => {
 </div>`);
         done();
       }, 100);
+    });
+
+    it('get same value when using `useMemo` and rerender with same prop in dependencies', () => {
+      function Child() {
+        return false;
+      }
+      function ComponentUsingMemoHook(props) {
+        const { count } = props;
+        const memoized = useMemo(() => ({ result: count * 2 }), [count]);
+        return (
+          <Child memoized={memoized} />
+        );
+      }
+      const wrapper = shallow(<ComponentUsingMemoHook count={1} />);
+      const initialValue = wrapper.find(Child).prop('memoized');
+      wrapper.setProps({ unRelatedProp: '123' });
+      const nextValue = wrapper.find(Child).prop('memoized');
+      expect(initialValue).to.equal(nextValue);
+    });
+
+    it('get different value when using `useMemo` and rerender with different prop in dependencies', () => {
+      function Child() {
+        return false;
+      }
+      function ComponentUsingMemoHook(props) {
+        const { count, relatedProp } = props;
+        const memoized = useMemo(() => ({ result: count * 2 }), [count, relatedProp]);
+        return (
+          <Child memoized={memoized} relatedProp={relatedProp} />
+        );
+      }
+      const wrapper = shallow(<ComponentUsingMemoHook relatedProp="456" count={1} />);
+      const initialValue = wrapper.find(Child).prop('memoized');
+      wrapper.setProps({ relatedProp: '123' });
+      const nextValue = wrapper.find(Child).prop('memoized');
+      expect(initialValue).to.not.equal(nextValue);
     });
   });
 


### PR DESCRIPTION
Related to #2011 .

Add `useMemo` test cases in both shallow and mount test suites to make sure it works with enzyme. There are 2 tests for each:
1. In component get memoized value from `useMemo` and pass it down to child. Then rerender the component by changing a prop which is not in the dependencies of `useMemo` call. So we can assert that the prop passed down will be the same (`===`) between two rendering. Note that the memoized value is an object in the test so we can make sure they are shallow equal.
2. Like (1), but we change a prop which is in dependencies of `useMemo`, so now the prop passed down will be different between two rendering.
Any advice on additional tests is welcome :-)