### PR TITLE
Wrap `.Invoke()` with act to make trigger rerender by handler less error prone

### DIFF
--- a/docs/api/ReactWrapper/invoke.md
+++ b/docs/api/ReactWrapper/invoke.md
@@ -1,6 +1,7 @@
 # `.invoke(propName)(...args) => Any`
 
 Invokes a function prop.
+Note that in React 16.8+, `.invoke` will wrap your handler with [`ReactTestUtils.act`](https://reactjs.org/docs/test-utils.html#act) and call `.update()` automatically.
 
 #### Arguments
 

--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -495,6 +495,7 @@ class ReactSixteenAdapter extends EnzymeAdapter {
           }),
         };
       },
+      ...(is168 && { wrapInvoke: wrapAct }),
     };
   }
 

--- a/packages/enzyme-test-suite/test/shared/methods/invoke.jsx
+++ b/packages/enzyme-test-suite/test/shared/methods/invoke.jsx
@@ -1,10 +1,22 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon-sandbox';
+import {
+  itIf,
+} from '../../_helpers';
+import {
+  is,
+} from '../../_helpers/version';
+
+import {
+  useEffect,
+  useState,
+} from '../../_helpers/react-compat';
 
 export default function describeInvoke({
   Wrap,
   WrapperName,
+  isShallow,
 }) {
   describe('.invoke(propName)(..args)', () => {
     class CounterButton extends React.Component {
@@ -83,6 +95,33 @@ export default function describeInvoke({
       const [[arg1, arg2]] = spy.args;
       expect(arg1).to.equal(a);
       expect(arg2).to.equal(b);
+    });
+
+    // TODO: enable when the shallow renderer fixes its bug
+    itIf(!isShallow && is('>= 16.8'), 'works without explicit `act` wrapper', () => {
+      function App() {
+        const [counter, setCounter] = useState(0);
+        const [result, setResult] = useState(0);
+        useEffect(
+          () => setResult(counter * 2),
+          [counter],
+        );
+        return (
+          <button type="button" onClick={() => setCounter(input => input + 1)}>{result}</button>
+        );
+      }
+      const wrapper = Wrap(<App />);
+
+      const expected = ['0', '2', '4', '6'];
+
+      const actual = [wrapper.find('button').text()]
+        .concat(Array.from({ length: 3 }, () => {
+          wrapper.find('button').invoke('onClick')();
+          wrapper.update();
+
+          return wrapper.find('button').text();
+        }));
+      expect(actual).to.eql(expected);
     });
   });
 }

--- a/packages/enzyme/src/ReactWrapper.js
+++ b/packages/enzyme/src/ReactWrapper.js
@@ -841,7 +841,9 @@ class ReactWrapper {
         throw new TypeError('ReactWrapper::invoke() requires the name of a prop whose value is a function');
       }
       return (...args) => {
-        const response = handler(...args);
+        const response = typeof this[RENDERER].wrapInvoke === 'function'
+          ? this[RENDERER].wrapInvoke(() => handler(...args))
+          : handler(...args);
         this[ROOT].update();
         return response;
       };


### PR DESCRIPTION
This PR expose `act` call out of `enzyme-adapter-react-16` and make the `invoke` api call handler with `act`. This will make the added test case passed without explicitly call `act()`. Before this change, we have to call `act()` outside of the `onClick` handler manually, which is easy to forget to do that.

Also update the doc of `invoke` to encourage people to trigger handler with it (so we don't need to explictly call `act()` and `update()`).