### PR TITLE
Add missing backticks to end of invoke example

### DIFF
--- a/docs/api/ShallowWrapper/invoke.md
+++ b/docs/api/ShallowWrapper/invoke.md
@@ -38,3 +38,4 @@ const wrapper = shallow(<Foo />);
 wrapper.find('a').invoke('onClick')().then(() => {
   // expect()
 });
+```


### PR DESCRIPTION
The example for invoke is missing a closing set of backticks for the example which is leading to it not rendering correctly on the docs site (https://airbnb.io/enzyme/docs/api/ShallowWrapper/invoke.html).

<img width="1080" alt="Screenshot 2019-06-10 at 14 38 50" src="https://user-images.githubusercontent.com/2521383/59199503-0494fa80-8b8e-11e9-8ccd-6d70dbf8c9d3.png">

This commit updates the code example in  `invoke.md` to include the missing backticks.