### PR TITLE
[Docs] Mark inline code snippet in a warning in docs/api/shallow.md

### DIFF
--- a/docs/api/ReactWrapper/html.md
+++ b/docs/api/ReactWrapper/html.md
@@ -1,6 +1,6 @@
 # `.html() => String`
 
-Returns a string of the rendered HTML markup of the current render tree. See also [.debug()](debug.md)
+Returns a string of the rendered HTML markup of the current render tree. See also [`.debug()`](debug.md)
 
 Note: can only be called on a wrapper of a single node.
 

--- a/docs/api/ReactWrapper/isEmpty.md
+++ b/docs/api/ReactWrapper/isEmpty.md
@@ -1,5 +1,5 @@
 # `.isEmpty() => Boolean`
-**Deprecated**: Use [.exists()](exists.md) instead.
+**Deprecated**: Use [`.exists()`](exists.md) instead.
 
 Returns whether or not the wrapper is empty.
 

--- a/docs/api/ShallowWrapper/dive.md
+++ b/docs/api/ShallowWrapper/dive.md
@@ -4,7 +4,7 @@ Shallow render the one non-DOM child of the current wrapper, and return a wrappe
 
 There is no corresponding `dive` method for ReactWrappers.
 
-NOTE: can only be called on a wrapper of a single non-DOM component element node, otherwise it will throw an error. If you have to shallow-wrap a wrapper with multiple child nodes, use [.shallow()](shallow.md).
+NOTE: can only be called on a wrapper of a single non-DOM component element node, otherwise it will throw an error. If you have to shallow-wrap a wrapper with multiple child nodes, use [`.shallow()`](shallow.md).
 
 
 #### Arguments

--- a/docs/api/ShallowWrapper/isEmpty.md
+++ b/docs/api/ShallowWrapper/isEmpty.md
@@ -1,5 +1,5 @@
 # `.isEmpty() => Boolean`
-**Deprecated**: Use [.exists()](exists.md) instead.
+**Deprecated**: Use [`.exists()`](exists.md) instead.
 
 Returns whether or not the wrapper is empty.
 

--- a/docs/api/mount.md
+++ b/docs/api/mount.md
@@ -99,7 +99,7 @@ Returns whether or not the current node matches a provided selector.
 Returns whether or not the current node exists, or, if given a selector, whether that selector has any matching results.
 
 #### [`.isEmpty() => Boolean`](ReactWrapper/isEmpty.md)
-*Deprecated*: Use [.exists()](ReactWrapper/exists.md) instead.
+*Deprecated*: Use [`.exists()`](ReactWrapper/exists.md) instead.
 
 #### [`.isEmptyRender() => Boolean`](ReactWrapper/isEmptyRender.md)
 Returns whether or not the current component returns a falsy value.

--- a/docs/api/selector.md
+++ b/docs/api/selector.md
@@ -120,4 +120,4 @@ wrapper.find({ foo: 3, bar: undefined });
 // => TypeError: Enzyme::Props can't have 'undefined' values. Try using 'findWhere()' instead.
 ```
 
-If you have to search by `undefined` property value, use [.findWhere()](ShallowWrapper/findWhere.md).
+If you have to search by `undefined` property value, use [`.findWhere()`](ShallowWrapper/findWhere.md).

--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -104,7 +104,7 @@ Returns whether or not the current node matches a provided selector.
 Returns whether or not the current node exists, or, if given a selector, whether that selector has any matching results.
 
 #### [`.isEmpty() => Boolean`](ShallowWrapper/isEmpty.md)
-*Deprecated*: Use [.exists()](ShallowWrapper/exists.md) instead.
+*Deprecated*: Use [`.exists()`](ShallowWrapper/exists.md) instead.
 
 #### [`.isEmptyRender() => Boolean`](ShallowWrapper/isEmptyRender.md)
 Returns whether or not the current component returns a falsy value.


### PR DESCRIPTION
On line 107, added marked `.exists()` as a code block.