### PR TITLE
[Docs] `invoke`: Fix missing white space

### DIFF
--- a/docs/api/ShallowWrapper/invoke.md
+++ b/docs/api/ShallowWrapper/invoke.md
@@ -15,7 +15,7 @@ This essentially calls wrapper.prop(propName)(...args).
 
 #### Example
 
-```jsx
+```jsx 
 class Foo extends React.Component {
   loadData() {
     return fetch();


### PR DESCRIPTION
I noticed the syntax highlighting isn't working in the docs for invoke. Other docs seem to have 
a space after the ```` ```jsx```` 
https://airbnb.io/enzyme/docs/api/ShallowWrapper/invoke.html

![image](https://user-images.githubusercontent.com/2336595/60197781-f7664580-97f4-11e9-8003-9ef1e1ffd8b0.png)

@milesj 