### PR TITLE
update docs to note future deprecation of .simulate

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,5 +1,5 @@
 {
-  "gitbook": "3.2.2",
+  "gitbook": "3.2.3",
   "title": "Enzyme",
   "description": "React Testing",
   "plugins": [

--- a/docs/api/ReactWrapper/simulate.md
+++ b/docs/api/ReactWrapper/simulate.md
@@ -50,4 +50,5 @@ expect(wrapper.find('.clicks-1').length).to.equal(1);
 #### Common Gotchas
 
 - As noted in the function signature above passing a mock event is optional. It is worth noting that `ReactWrapper` will pass a `SyntheticEvent` object to the event handler in your code. Keep in mind that if the code you are testing uses properties that are not included in the `SyntheticEvent`, for instance `event.target.value`, you will need to provide a mock event like so `.simulate("change", { target: { value: "foo" }})` for it to work.
+- One important thing to know is that the simulate function does not faithfully **simulate anything** - all it does is transform the event name to a prop name, and invoke the function provided prop.
 

--- a/docs/api/ShallowWrapper/simulate.md
+++ b/docs/api/ShallowWrapper/simulate.md
@@ -55,3 +55,4 @@ the event handler set.
 target the component's prop based on the event you give it. For example, `.simulate('click')` will
 actually get the `onClick` prop and call it.
 - As noted in the function signature above passing a mock event is optional. Keep in mind that if the code you are testing uses the event for something like, calling `event.preventDefault()` or accessing any of its properties you must provide a mock event object with the properties your code requires.
+- One important thing to know is that the simulate function does not faithfully **simulate anything** - all it does is transform the event name to a prop name, and invoke the function provided prop.

--- a/docs/api/mount.md
+++ b/docs/api/mount.md
@@ -170,6 +170,9 @@ Returns the key of the root component.
 #### [`.simulate(event[, mock]) => ReactWrapper`](ReactWrapper/simulate.md)
 Simulates an event on the current node.
 
+*Deprecated:* Will be removed in later versions of Enzyme. [Click here for more information.](https://github.com/airbnb/enzyme/issues/2173#issuecomment-505551552)
+
+
 #### [`.setState(nextState) => ReactWrapper`](ReactWrapper/setState.md)
 Manually sets state of the root component.
 

--- a/docs/api/shallow.md
+++ b/docs/api/shallow.md
@@ -184,6 +184,8 @@ Invokes a prop function on the current node and returns the function's return va
 #### [`.simulate(event[, data]) => ShallowWrapper`](ShallowWrapper/simulate.md)
 Simulates an event on the current node.
 
+*Deprecated:* Will be removed in later versions of Enzyme. [Click here for more information.](https://github.com/airbnb/enzyme/issues/2173#issuecomment-505551552)
+
 #### [`.setState(nextState) => ShallowWrapper`](ShallowWrapper/setState.md)
 Manually sets state of the root component.
 


### PR DESCRIPTION
This PR updates the doc to explain that simulate doesn't work as intended. I included a link to the original issue that I opened on Friday.