### PR TITLE
[Docs] ReactWrapper debug: add missing option flag

### DIFF
--- a/docs/api/ReactWrapper/debug.md
+++ b/docs/api/ReactWrapper/debug.md
@@ -8,6 +8,7 @@ console when tests are not passing when you expect them to.
 
 `options` (`Object` [optional]):
 - `options.ignoreProps`: (`Boolean` [optional]): Whether props should be omitted in the resulting string. Props are included by default.
+- `options.verbose`: (`Boolean` [optional]): Whether arrays and objects passed as props should be verbosely printed.
 
 #### Returns
 


### PR DESCRIPTION
The `options.verbose` flag was never documented for `ReactWrapper`, but was for `ShallowWrapper`. This PR copies the docs line from `ShallowWrapper` and added it to `ReactWrapper`. ✨ 

It's documented in the source code, and it seems like both wrappers use a common debug function:
https://github.com/airbnb/enzyme/blob/399db46f7eb0ea6f7067ed167493710532aabd87/packages/enzyme/src/ReactWrapper.js#L1190-L1197