### PR TITLE
[Fix] `render`: handle Fiber strings and numbers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 script:
   - 'if [ -n "${LINT-}" ]; then npm run lint; elif [ -n "${KARMA-}" ]; then npm run test:karma -- --single-run; elif [ -n "${REACT-}" ]; then npm run travis; else false ; fi'
 after_script:
-  - 'if [ -n "${REACT-}" ]; then case "${TRAVIS_NODE_VERSION}" in "8" | "6") ;; *) cat ./coverage/lcov.info | ./node_modules/.bin/coveralls ;; esac ; fi'
+  - 'if [ -n "${REACT-}" ] && [ "${TRAVIS_ALLOW_FAILURE}" != true ]; then case "${TRAVIS_NODE_VERSION}" in "8" | "6") ;; *) cat ./coverage/lcov.info | ./node_modules/.bin/coveralls ;; esac ; fi'
 sudo: false
 matrix:
   fast_finish: true
@@ -38,12 +38,6 @@ matrix:
       env: REACT=16.7 RENDERER=16.8
     - node_js: "lts/*"
       env: REACT=16.7 RENDERER=16.7
-    - node_js: "lts/*"
-      env: REACT=16.6
-    - node_js: "lts/*"
-      env: REACT=16.5
-    - node_js: "lts/*"
-      env: REACT=16.4
     - node_js: "lts/*"
       env: REACT=16.3 ADAPTER=16
     - node_js: "6"

--- a/packages/enzyme-adapter-utils/src/createMountWrapper.jsx
+++ b/packages/enzyme-adapter-utils/src/createMountWrapper.jsx
@@ -48,7 +48,6 @@ export default function createMountWrapper(node, options = {}) {
     constructor(...args) {
       super(...args);
       const { props, wrappingComponentProps, context } = this.props;
-      this.rootFinderInstance = null;
       this.state = {
         mount: true,
         props,
@@ -66,28 +65,6 @@ export default function createMountWrapper(node, options = {}) {
 
     setWrappingComponentProps(props, callback = undefined) {
       this.setState({ wrappingComponentProps: props }, callback);
-    }
-
-    getInstance() {
-      const component = this._reactInternalInstance._renderedComponent;
-      const inst = component.getPublicInstance();
-      if (inst === null) {
-        return component._instance;
-      }
-      return inst;
-    }
-
-    getWrappedComponent() {
-      const component = this._reactInternalInstance._renderedComponent;
-      const inst = component.getPublicInstance();
-      if (inst === null) {
-        return component._instance;
-      }
-      return inst;
-    }
-
-    setChildContext(context) {
-      return new Promise((resolve) => this.setState({ context }, resolve));
     }
 
     render() {

--- a/packages/enzyme-test-suite/test/Utils-spec.jsx
+++ b/packages/enzyme-test-suite/test/Utils-spec.jsx
@@ -14,6 +14,7 @@ import {
   isEmptyValue,
   renderedDive,
   isCustomComponent,
+  loadCheerioRoot,
 } from 'enzyme/build/Utils';
 import getAdapter from 'enzyme/build/getAdapter';
 import EnzymeAdapter from 'enzyme/build/EnzymeAdapter';
@@ -1071,6 +1072,19 @@ describe('Utils', () => {
       expect(() => isCustomComponent({}, null)).to.throw(Error);
       expect(() => isCustomComponent({}, false)).to.throw(Error);
       expect(() => isCustomComponent({}, {})).to.throw(Error);
+    });
+  });
+
+  describe('loadCheerioRoot', () => {
+    it('always returns a Cheerio instance', () => {
+      expect(loadCheerioRoot()).to.have.property('cheerio', '[cheerio object]');
+      expect(loadCheerioRoot(null)).to.have.property('cheerio', '[cheerio object]');
+      expect(loadCheerioRoot('')).to.have.property('cheerio', '[cheerio object]');
+      expect(loadCheerioRoot('foo')).to.have.property('cheerio', '[cheerio object]');
+      expect(loadCheerioRoot('123')).to.have.property('cheerio', '[cheerio object]');
+      expect(loadCheerioRoot('<div>bar</div>')).to.have.property('cheerio', '[cheerio object]');
+      expect(loadCheerioRoot('leading <span>text</span>')).to.have.property('cheerio', '[cheerio object]');
+      expect(loadCheerioRoot('<div>malformed</><<html')).to.have.property('cheerio', '[cheerio object]');
     });
   });
 });

--- a/packages/enzyme-test-suite/test/adapter-utils-spec.jsx
+++ b/packages/enzyme-test-suite/test/adapter-utils-spec.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon-sandbox';
+import PropTypes from 'prop-types';
+import { shallow } from 'enzyme';
 import {
   displayNameOfNode,
   ensureKeyOrUndefined,
@@ -14,6 +16,7 @@ import {
   getWrappingComponentMountRenderer,
   fakeDynamicImport,
   assertDomAvailable,
+  createMountWrapper,
 } from 'enzyme-adapter-utils';
 import wrap from 'mocha-wrap';
 
@@ -482,5 +485,29 @@ describe('enzyme-adapter-utils', () => {
         expect(assertDomAvailable).to.throw();
       });
     });
+  });
+
+  describe('createMountWrapper', () => {
+    class Foo extends React.Component {
+      render() { return <div>{this.context.foo}</div>; }
+    }
+    Foo.contextTypes = {
+      foo: PropTypes.string,
+    };
+
+    it('returns a component', () => {
+      const node = <Foo />;
+      const Wrapper = createMountWrapper(node);
+      expect(React.isValidElement(<Wrapper />)).to.equal(true);
+    });
+
+    it('returns the wrapped component’s instance', () => {
+      const node = <Foo />;
+      const Wrapper = createMountWrapper(node);
+      const wrapper = shallow(<Wrapper />);
+      expect(wrapper.instance()).to.be.instanceOf(Wrapper);
+    });
+
+    it('uses the passed `wrappingComponent`', () => {});
   });
 });

--- a/packages/enzyme-test-suite/test/staticRender-spec.jsx
+++ b/packages/enzyme-test-suite/test/staticRender-spec.jsx
@@ -78,7 +78,51 @@ describeWithDOM('render', () => {
       });
 
       const context = { name: 'foo' };
-      expect(() => render(<SimpleComponent />, { context })).to.not.throw(Error);
+      expect(() => render(<SimpleComponent />, { context })).not.to.throw();
+    });
+  });
+
+  describe('rendering non-elements', () => {
+    it('can render strings', () => {
+      const StringComponent = createClass({
+        render() {
+          return 'foo';
+        },
+      });
+
+      const getWrapper = (options) => render(<StringComponent />, options);
+      if (is('>= 16')) {
+        expect(getWrapper).to.not.throw();
+
+        const wrapper = getWrapper();
+        expect(wrapper.text()).to.equal('foo');
+        expect(wrapper.html()).to.equal('foo');
+        expect(String(wrapper)).to.equal('foo');
+        expect(wrapper).to.have.lengthOf(1);
+      } else {
+        expect(getWrapper).to.throw();
+      }
+    });
+
+    it('can render numbers', () => {
+      const NumberComponent = createClass({
+        render() {
+          return 42;
+        },
+      });
+
+      const getWrapper = (options) => render(<NumberComponent />, options);
+      if (is('>= 16')) {
+        expect(getWrapper).to.not.throw();
+
+        const wrapper = getWrapper();
+        expect(wrapper.text()).to.equal('42');
+        expect(wrapper.html()).to.equal('42');
+        expect(String(wrapper)).to.equal('42');
+        expect(wrapper).to.have.lengthOf(1);
+      } else {
+        expect(getWrapper).to.throw();
+      }
     });
   });
 

--- a/packages/enzyme/package.json
+++ b/packages/enzyme/package.json
@@ -36,7 +36,7 @@
   "license": "MIT",
   "dependencies": {
     "array.prototype.flat": "^1.2.1",
-    "cheerio": "^1.0.0-rc.2",
+    "cheerio": "^1.0.0-rc.3",
     "enzyme-shallow-equal": "^1.0.0",
     "function.prototype.name": "^1.1.0",
     "has": "^1.0.3",

--- a/packages/enzyme/src/ReactWrapper.js
+++ b/packages/enzyme/src/ReactWrapper.js
@@ -1,4 +1,3 @@
-import cheerio from 'cheerio';
 import flat from 'array.prototype.flat';
 import has from 'has';
 
@@ -15,6 +14,7 @@ import {
   cloneElement,
   renderedDive,
   isCustomComponent,
+  loadCheerioRoot,
 } from './Utils';
 import getAdapter from './getAdapter';
 import { debugNodes } from './Debug';
@@ -650,7 +650,7 @@ class ReactWrapper {
    */
   render() {
     const html = this.html();
-    return html === null ? cheerio() : cheerio.load('')(html);
+    return loadCheerioRoot(html);
   }
 
   /**

--- a/packages/enzyme/src/ShallowWrapper.js
+++ b/packages/enzyme/src/ShallowWrapper.js
@@ -1,5 +1,4 @@
 import flat from 'array.prototype.flat';
-import cheerio from 'cheerio';
 import has from 'has';
 import shallowEqual from 'enzyme-shallow-equal';
 
@@ -20,6 +19,7 @@ import {
   cloneElement,
   spyMethod,
   isEmptyValue,
+  loadCheerioRoot,
 } from './Utils';
 import getAdapter from './getAdapter';
 import { debugNodes } from './Debug';
@@ -1103,7 +1103,8 @@ class ShallowWrapper {
    * @returns {CheerioWrapper}
    */
   render() {
-    return this.type() === null ? cheerio() : cheerio.load('')(this.html());
+    const html = this.html();
+    return loadCheerioRoot(html);
   }
 
   /**

--- a/packages/enzyme/src/Utils.js
+++ b/packages/enzyme/src/Utils.js
@@ -6,6 +6,8 @@ import functionName from 'function.prototype.name';
 import has from 'has';
 import flat from 'array.prototype.flat';
 import trim from 'string.prototype.trim';
+import cheerio from 'cheerio';
+import { isHtml } from 'cheerio/lib/utils';
 
 import { get } from './configuration';
 import { childrenOfNode } from './RSTTraversal';
@@ -349,4 +351,17 @@ export function renderedDive(nodes) {
 
     return isEmptyValue(n);
   });
+}
+
+export function loadCheerioRoot(html) {
+  if (!html) {
+    return cheerio.root();
+  }
+
+  if (!isHtml(html)) {
+    // use isDocument=false to create fragment
+    return cheerio.load(html, null, false).root();
+  }
+
+  return cheerio.load('')(html);
 }

--- a/packages/enzyme/src/render.js
+++ b/packages/enzyme/src/render.js
@@ -1,5 +1,5 @@
-import cheerio from 'cheerio';
 import getAdapter from './getAdapter';
+import { loadCheerioRoot } from './Utils';
 
 /**
  * Renders a react component into static HTML and provides a cheerio wrapper around it. This is
@@ -19,5 +19,5 @@ export default function render(node, options = {}) {
   const adapter = getAdapter(options);
   const renderer = adapter.createRenderer({ mode: 'string', ...options });
   const html = renderer.render(node, options.context);
-  return cheerio.load('')(html);
+  return loadCheerioRoot(html);
 }


### PR DESCRIPTION
- Fix https://github.com/airbnb/enzyme/issues/2098
- Introduce `loadCheerioRoot` util
- Use util in `render`, `mount` and `shallow`
- Added test cases in `test/staticRender-spec.jsx`