### PR TITLE
[Issue 2219] Update Readme. 

### DIFF
--- a/docs/api/ShallowWrapper/get.md
+++ b/docs/api/ShallowWrapper/get.md
@@ -17,7 +17,7 @@ Returns the node at a given index of the current wrapper.
 
 ```jsx
 const wrapper = shallow(<MyComponent />);
-expect(wrapper.find(Foo).get(0).props.foo).to.equal('bar');
+expect(wrapper.find(Foo).get(0).props().foo).to.equal('bar');
 ```
 
 


### PR DESCRIPTION
Props should be a function as stated in https://airbnb.io/enzyme/docs/api/ShallowWrapper/props.html.