### PR TITLE
[deps] remove prepatch version range from react-test-renderer

### DIFF
--- a/packages/enzyme-adapter-react-16/package.json
+++ b/packages/enzyme-adapter-react-16/package.json
@@ -42,7 +42,7 @@
     "object.values": "^1.1.0",
     "prop-types": "^15.7.2",
     "react-is": "^16.8.6",
-    "react-test-renderer": "^16.0.0-0",
+    "react-test-renderer": "^16.0.0",
     "semver": "^5.7.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Fixes react-test-renderer compatibility detection in lockfiles,
so that multiple entries can be merged