### PR TITLE
turn off linebreak-style

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,7 @@
     "react/no-find-dom-node": 1,
     "import/first": 0,
     "max-len": 0,
+    "linebreak-style": 0
   },
   "overrides": [
     { // things that run in older envs, without babel


### PR DESCRIPTION
Hi, this removes this error that I was seeing when I was running npm run lint in the repo
![enzyme-lint](https://user-images.githubusercontent.com/5825929/66015858-37972d00-e4a2-11e9-8136-c1c6125edabc.PNG)
