### PR TITLE
Update jest.md

### DIFF
--- a/docs/guides/jest.md
+++ b/docs/guides/jest.md
@@ -2,7 +2,7 @@
 
 ## Configure with Jest
 
-To run the setup file to configure Enzyme and the Adapter (as shown in the [Installation docs](https://enzymejs.github.io/enzyme/docs/installation/)) with Jest, set `setupFilesAfterEnv` (previously `setupTestFrameworkScriptFile`) in your config file (check [Jest's documentation](http://jestjs.io/docs/en/configuration) for the possible locations of that config file) to literally the string `<rootDir>` and the path to your setup file.
+To run the setup file to configure Enzyme and the Adapter (as shown in the [Installation docs](https://enzymejs.github.io/enzyme/docs/installation/)) with Jest, set `setupFilesAfterEnv` (previously `setupTestFrameworkScriptFile`) in your config file (check [Jest's documentation](http://jestjs.io/docs/en/configuration) for the possible locations of that config file) to literally the string `<rootDir>` and the path to your setup file. If using [create-react-app](https://create-react-app.dev/), skip this step.
 
 ```json
 {


### PR DESCRIPTION
Add note about skipping setting 'setupFilesAfterEnv' if using create-react-app. If you try to do so when using create-react-app, you get the following error:

```
(base) ➜  component-library git:(setup) ✗ npm run test

> component-library@0.1.0 test
> react-scripts test

We detected setupFilesAfterEnv in your package.json.

Remove it from Jest configuration, and put the initialization code in src/setupTests.js.
This file will be loaded automatically.
```